### PR TITLE
1.0 device caching

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -426,7 +426,7 @@ class DeviceDetector
      * @var \Piwik\CacheFile
      */
     protected $cache = null;
-    private static $browserCache = Array ();
+    protected static $browserCache = array();
 
     public function __construct($userAgent)
     {


### PR DESCRIPTION
Even though it will probably outdate soon, this change trades minimal RAM usage ( there should not be so many different browsers around )  for speed.
Profiler said, about 20% runtime is saved.

time misc/log-analytics/import_logs.py  --token-auth=1a**_c3 --url=http://piwik.local --idsite=2 --hostname=_ --strip-query-string  --recorders=16  --recorder-max-payload-size=2000 --debug /tmp/SSX_T150K  ### 150K Lines

Performance summary 1st run Caching:
     Total time: 44 seconds
     Requests imported per second: 953.63 requests per second

Performance summary 1st run 1.0:
     Total time: 62 seconds
     Requests imported per second: 688.04 requests per second

Performance summary 2nd run 1.0:
     Total time: 61 seconds
     Requests imported per second: 693.58 requests per second

Performance summary 2nd run Caching:
     Total time: 46 seconds
      Requests imported per second: 920.71 requests per second
