### PR TITLE
Run PHPunit without memcached extension 

### DIFF
--- a/Cache/CacheMemcache.php
+++ b/Cache/CacheMemcache.php
@@ -25,6 +25,9 @@ class CacheMemcache implements CacheInterface
     public function __construct($server='localhost', $port=11211)
     {
         if (empty(self::$memcache)) {
+            if (!class_exists('Memcache')) {
+                throw new \Exception('You need to have the php memcached extension');
+            }
             self::$memcache = new \Memcache();
             self::$memcache->connect($server, $port) or die ("Could not connect");
         }


### PR DESCRIPTION
Hi!

I don't have the Memcached extension on some computer.
This is a small participation, but it's allow me to:
- Run most of the tests ;
- Having a explicit error message.

Cheers,  
Thomas.
