### PR TITLE
Remove composer.json from gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea/*
 vendor/*
-composer*
+composer.lock
+composer.phar


### PR DESCRIPTION
I use a git based deployment workflow for my piwik installation. 
As `composer.json` and `.gitignore` are part of the `piwik.zip` release file, I have to ensure that `composer.json` is under my version control  (by manually `git add -f`).

I think this is cumbersome and unnecessary&hellip;
