### PR TITLE
Support for the NT 10.0 kernel for Windows 10

### DIFF
--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -261,6 +261,12 @@
     short_name: W10
     version: 10
 -
+  user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; Touch; rv:11.0) like Gecko
+  os:
+    name: Windows 10
+    short_name: W10
+    version: 10
+-
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; de; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20
   os:
     name: Windows 2000

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -122,6 +122,10 @@
 ##########
 # Windows
 ##########
+- regex: 'CYGWIN_NT-10.0|Windows NT 10.0|Windows 10'
+  name: 'Windows 10'
+  version: '10'
+
 - regex: 'CYGWIN_NT-6.4|Windows NT 6.4|Windows 10'
   name: 'Windows 10'
   version: '10'


### PR DESCRIPTION
Since Microsoft bumped the Windows 10 kernel to v10.0
