### PR TITLE
Updated with official Win10 IE12 UserAgent string

### DIFF
--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -448,7 +448,7 @@
     version: 4.01
     engine: Trident
 -
-  user_agent: Mozilla/5.0 (Windows NT 6.4; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.143 Safari/537.36 Edge/12.0
+  user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0
   client:
     type: browser
     name: Internet Explorer


### PR DESCRIPTION
Based on #5303, Microsoft updated the 'official' Win10IEUAString, (https://gist.github.com/jacobrossi/c9699b27df2f4e97c0bd/revisions)
