### PR TITLE
All iPhone submodels (S, C) are capitalized. Update Airness device regex.

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -224,10 +224,10 @@ Apple:
       model: 'iPhone 5'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone5[C,][34]'
-      model: 'iPhone 5c'
+      model: 'iPhone 5C'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone6[C,][12]'
-      model: 'iPhone 5s'
+      model: 'iPhone 5S'
       device: 'smartphone'
     - regex: '(?:Apple-)?iPhone7[C,]1'
       model: 'iPhone 6 Plus'
@@ -331,7 +331,7 @@ Acer:
 
 # Airness
 Airness:
-  regex: 'AIRNESS-([a-z0-9]+)'
+  regex: 'AIRNESS-([\w0-9]+)'
   device: 'feature phone'
   model: '$1'
 


### PR DESCRIPTION
I updated the model name for iPhone 5C/5S since the other iPhone versions are already capitalized (`iPhone 4S`, `iPhone 3GS`, etc).

Also I updated the Airness device regex as the headers look something like this:
`AIRNESS-AIR99/REV 2.2.1/Teleca Q03B1`
