### PR TITLE
forces versions in test fixtures to be strings

### DIFF
--- a/Tests/fixtures/camera.yml
+++ b/Tests/fixtures/camera.yml
@@ -4,7 +4,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22,7 +22,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0
+    version: "4.0"
   client:
     type: browser
     name: Android Browser
@@ -40,12 +40,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 15.0.1162.60140
+    version: "15.0.1162.60140"
     engine: Blink
   device:
     type: camera
@@ -58,12 +58,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 35.0.1916.141
+    version: "35.0.1916.141"
     engine: Blink
   device:
     type: camera
@@ -76,12 +76,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: camera

--- a/Tests/fixtures/console.yml
+++ b/Tests/fixtures/console.yml
@@ -4,12 +4,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: console
@@ -22,7 +22,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -40,12 +40,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: console
@@ -58,12 +58,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: console
@@ -76,12 +76,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: console
@@ -94,7 +94,7 @@
   os:
     name: Nintendo Mobile
     short_name: NDS
-    version: 3DS
+    version: "3DS"
   client:
     type: browser
     name: NetFront
@@ -112,12 +112,12 @@
   os:
     name: Nintendo Mobile
     short_name: NDS
-    version: DS
+    version: "DS"
   client:
     type: browser
     name: Bunjalloo
     short_name: BJ
-    version: 0.7.6
+    version: "0.7.6"
     engine:
   device:
     type: console
@@ -130,12 +130,12 @@
   os:
     name: Nintendo
     short_name: WII
-    version: Wii
+    version: "Wii"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 9.30
+    version: "9.30"
     engine: Presto
   device:
     type: console
@@ -148,7 +148,7 @@
   os:
     name: Nintendo
     short_name: WII
-    version: Wii
+    version: "Wii"
   client:
     type: browser
     name: NetFront
@@ -166,7 +166,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -184,7 +184,7 @@
   os:
     name: PlayStation
     short_name: PS3
-    version: 3
+    version: "3"
   client:
     type: browser
     name: NetFront
@@ -202,7 +202,7 @@
   os:
     name: PlayStation
     short_name: PS3
-    version: 4
+    version: "4"
   client:
     type: browser
     name: NetFront
@@ -220,7 +220,7 @@
   os:
     name: PlayStation Portable
     short_name: PSP
-    version: Portable
+    version: "Portable"
   client:
     type: browser
     name: NetFront
@@ -238,12 +238,12 @@
   os:
     name: PlayStation Portable
     short_name: PSP
-    version: Vita
+    version: "Vita"
   client:
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.2
+    version: "3.2"
     engine: Blink
   device:
     type: console

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -27,7 +27,7 @@
     type: browser
     name: Amiga Voyager
     short_name: AV
-    version: 3.2
+    version: "3.2"
     engine:
   device:
     type: desktop
@@ -40,12 +40,12 @@
   os:
     name: AmigaOS
     short_name: AMG
-    version: 1.3
+    version: "1.3"
   client:
     type: browser
     name: SeaMonkey
     short_name: SM
-    version: 1.1.15
+    version: "1.1.15"
     engine: Gecko
   device:
     type: desktop
@@ -58,12 +58,12 @@
   os:
     name: AmigaOS
     short_name: AMG
-    version: 3.9
+    version: "3.9"
   client:
     type: browser
     name: IBrowse
     short_name: IB
-    version: 2.4
+    version: "2.4"
     engine:
   device:
     type: desktop
@@ -76,12 +76,12 @@
   os:
     name: AmigaOS
     short_name: AMG
-    version: 4.0
+    version: "4.0"
   client:
     type: browser
     name: IBrowse
     short_name: IB
-    version: 3.0
+    version: "3.0"
     engine:
   device:
     type: desktop
@@ -99,7 +99,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 12.0.742.100
+    version: "12.0.742.100"
     engine: WebKit
   device:
     type: desktop
@@ -117,7 +117,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 4.0
+    version: "4.0"
     engine: Gecko
   device:
     type: desktop
@@ -135,7 +135,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 23.0
+    version: "23.0"
     engine: Gecko
   device:
     type: desktop
@@ -153,7 +153,7 @@
     type: browser
     name: NetPositive
     short_name: NP
-    version: 2.2.1
+    version: "2.2.1"
     engine:
   device:
     type: desktop
@@ -166,12 +166,12 @@
   os:
     name: CentOS
     short_name: CES
-    version: 3.0.6
+    version: "3.0.6"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.0.6
+    version: "3.0.6"
     engine: Gecko
   device:
     type: desktop
@@ -184,12 +184,12 @@
   os:
     name: CentOS
     short_name: CES
-    version: 3.6
+    version: "3.6"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.6.13
+    version: "3.6.13"
     engine: Gecko
   device:
     type: desktop
@@ -202,12 +202,12 @@
   os:
     name: Chrome OS
     short_name: COS
-    version: 4731.101.0
+    version: "4731.101.0"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.67
+    version: "31.0.1650.67"
     engine: Blink
   device:
     type: desktop
@@ -225,7 +225,7 @@
     type: browser
     name: Epiphany
     short_name: EP
-    version: 2.30.6
+    version: "2.30.6"
     engine: WebKit
   device:
     type: desktop
@@ -243,7 +243,7 @@
     type: browser
     name: Epiphany
     short_name: EP
-    version: 3.8.2
+    version: "3.8.2"
     engine: WebKit
   device:
     type: desktop
@@ -261,7 +261,7 @@
     type: browser
     name: Konqueror
     short_name: KO
-    version: 3.5
+    version: "3.5"
     engine: KHTML
   device:
     type: desktop
@@ -274,12 +274,12 @@
   os:
     name: Debian
     short_name: DEB
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Conkeror
     short_name: CK
-    version: 1.0
+    version: "1.0"
     engine: Gecko
   device:
     type: desktop
@@ -292,12 +292,12 @@
   os:
     name: Debian
     short_name: DEB
-    version: 3.0.6
+    version: "3.0.6"
   client:
     type: browser
     name: Iceweasel
     short_name: IW
-    version: 3.0.6
+    version: "3.0.6"
     engine: Gecko
   device:
     type: desktop
@@ -310,12 +310,12 @@
   os:
     name: Debian
     short_name: DEB
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: Epiphany
     short_name: EP
-    version: 3.4.2
+    version: "3.4.2"
     engine: WebKit
   device:
     type: desktop
@@ -328,12 +328,12 @@
   os:
     name: Debian
     short_name: DEB
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: Epiphany
     short_name: EP
-    version: 3.4.2
+    version: "3.4.2"
     engine: WebKit
   device:
     type: desktop
@@ -346,12 +346,12 @@
   os:
     name: Fedora
     short_name: FED
-    version: 1.9.0.8
+    version: "1.9.0.8"
   client:
     type: browser
     name: Kazehakase
     short_name: KZ
-    version: 0.5.6
+    version: "0.5.6"
     engine: Gecko
   device:
     type: desktop
@@ -364,12 +364,12 @@
   os:
     name: Fedora
     short_name: FED
-    version: 2.0.0.8
+    version: "2.0.0.8"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 2.0.0.8
+    version: "2.0.0.8"
     engine: Gecko
   device:
     type: desktop
@@ -382,12 +382,12 @@
   os:
     name: Fedora
     short_name: FED
-    version: 4.1.3
+    version: "4.1.3"
   client:
     type: browser
     name: Konqueror
     short_name: KO
-    version: 4.1
+    version: "4.1"
     engine: KHTML
   device:
     type: desktop
@@ -400,12 +400,12 @@
   os:
     name: Fedora
     short_name: FED
-    version: 4.11.4
+    version: "4.11.4"
   client:
     type: browser
     name: Konqueror
     short_name: KO
-    version: 4.11
+    version: "4.11"
     engine: KHTML
   device:
     type: desktop
@@ -423,7 +423,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 25.0
+    version: "25.0"
     engine: Gecko
   device:
     type: desktop
@@ -441,7 +441,7 @@
     type: browser
     name: Galeon
     short_name: GA
-    version: 1.3.21
+    version: "1.3.21"
     engine: Gecko
   device:
     type: desktop
@@ -454,7 +454,7 @@
   os:
     name: FreeBSD
     short_name: BSD
-    version: 2.2.8
+    version: "2.2.8"
   client: null
   device:
     type: desktop
@@ -472,7 +472,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -490,7 +490,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.0.7
+    version: "3.0.7"
     engine: Gecko
   device:
     type: desktop
@@ -508,7 +508,7 @@
     type: browser
     name: Conkeror
     short_name: CK
-    version: 1.0
+    version: "1.0"
     engine: Gecko
   device:
     type: desktop
@@ -526,7 +526,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 4.0
+    version: "4.0"
     engine: Gecko
   device:
     type: desktop
@@ -544,7 +544,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: GranParadiso (3.0.11)
+    version: "GranParadiso (3.0.11)"
     engine: Gecko
   device:
     type: desktop
@@ -562,7 +562,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: Minefield (3.0)
+    version: "Minefield (3.0)"
     engine: Gecko
   device:
     type: desktop
@@ -580,7 +580,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: Shiretoko (3.5)
+    version: "Shiretoko (3.5)"
     engine: Gecko
   device:
     type: desktop
@@ -598,7 +598,7 @@
     type: browser
     name: Iceape
     short_name: IA
-    version: 2.7.12
+    version: "2.7.12"
     engine: Gecko
   device:
     type: desktop
@@ -616,7 +616,7 @@
     type: browser
     name: Iceweasel
     short_name: IW
-    version: 17.0.10
+    version: "17.0.10"
     engine: Gecko
   device:
     type: desktop
@@ -634,7 +634,7 @@
     type: browser
     name: Konqueror
     short_name: KO
-    version: 4.8
+    version: "4.8"
     engine: KHTML
   device:
     type: desktop
@@ -652,7 +652,7 @@
     type: browser
     name: Links
     short_name: LI
-    version: 2.1
+    version: "2.1"
     engine: Text-based
   device:
     type: desktop
@@ -670,7 +670,7 @@
     type: browser
     name: MicroB
     short_name: MB
-    version: 0.9.7
+    version: "0.9.7"
     engine: Gecko
   device:
     type: desktop
@@ -688,7 +688,7 @@
     type: browser
     name: Midori
     short_name: MI
-    version: 0.5
+    version: "0.5"
     engine: WebKit
   device:
     type: desktop
@@ -706,7 +706,7 @@
     type: browser
     name: Midori
     short_name: MI
-    version: 0.5
+    version: "0.5"
     engine: WebKit
   device:
     type: desktop
@@ -724,7 +724,7 @@
     type: browser
     name: NCSA Mosaic
     short_name: MC
-    version: 2.7
+    version: "2.7"
     engine:
   device:
     type: desktop
@@ -742,7 +742,7 @@
     type: browser
     name: Netscape
     short_name: NS
-    version: 6.01
+    version: "6.01"
     engine: Gecko
   device:
     type: desktop
@@ -760,7 +760,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.10
+    version: "12.10"
     engine: Presto
   device:
     type: desktop
@@ -778,7 +778,7 @@
     type: browser
     name: Phoenix
     short_name: PX
-    version: 0.4
+    version: "0.4"
     engine: Gecko
   device:
     type: desktop
@@ -796,7 +796,7 @@
     type: browser
     name: Puffin
     short_name: PU
-    version: 2.10977
+    version: "2.10977"
     engine: WebKit
   device:
     type: desktop
@@ -814,7 +814,7 @@
     type: browser
     name: Rekonq
     short_name: RK
-    version: 2.3.2
+    version: "2.3.2"
     engine: WebKit
   device:
     type: desktop
@@ -832,7 +832,7 @@
     type: browser
     name: SeaMonkey
     short_name: SM
-    version: 2.26
+    version: "2.26"
     engine: Gecko
   device:
     type: desktop
@@ -850,7 +850,7 @@
     type: browser
     name: Snowshoe
     short_name: SN
-    version: 1.0.0
+    version: "1.0.0"
     engine: WebKit
   device:
     type: desktop
@@ -868,7 +868,7 @@
     type: browser
     name: Swiftfox
     short_name: SX
-    version: 2.0
+    version: "2.0"
     engine: Gecko
   device:
     type: desktop
@@ -885,7 +885,7 @@
   client:
     type: pim
     name: Thunderbird
-    version: 17.0.5
+    version: "17.0.5"
   device:
     type: desktop
     brand:
@@ -902,7 +902,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: BonEcho (2.0.0.21)
+    version: "BonEcho (2.0.0.21)"
     engine: Gecko
   device:
     type: desktop
@@ -951,7 +951,7 @@
   os:
     name: IRIX
     short_name: IRI
-    version: 5.3
+    version: "5.3"
   client: null
   device:
     type: desktop
@@ -969,7 +969,7 @@
     type: browser
     name: Konqueror
     short_name: KO
-    version: 3.5
+    version: "3.5"
     engine: KHTML
   device:
     type: desktop
@@ -982,12 +982,12 @@
   os:
     name: Kubuntu
     short_name: KBT
-    version: 8.04
+    version: "8.04"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.0.1
+    version: "3.0.1"
     engine: Gecko
   device:
     type: desktop
@@ -1005,7 +1005,7 @@
     type: browser
     name: Arora
     short_name: AR
-    version: 0.10.1
+    version: "0.10.1"
     engine: WebKit
   device:
     type: desktop
@@ -1023,7 +1023,7 @@
     type: browser
     name: Cheshire
     short_name: CS
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: desktop
@@ -1041,7 +1041,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 4.01
+    version: "4.01"
     engine: Trident
   device:
     type: desktop
@@ -1059,7 +1059,7 @@
     type: browser
     name: Midori
     short_name: MI
-    version: 0.4
+    version: "0.4"
     engine: WebKit
   device:
     type: desktop
@@ -1077,7 +1077,7 @@
     type: browser
     name: Opera Next
     short_name: 'ON'
-    version: 20.0.1387.37
+    version: "20.0.1387.37"
     engine: Blink
   device:
     type: desktop
@@ -1112,7 +1112,7 @@
   client:
     type: mediaplayer
     name: SubStream
-    version: 0.7
+    version: "0.7"
   device:
     type: desktop
     brand:
@@ -1129,7 +1129,7 @@
     type: browser
     name: Sunrise
     short_name: SR
-    version: 0.833
+    version: "0.833"
     engine: WebKit
   device:
     type: desktop
@@ -1147,7 +1147,7 @@
     type: browser
     name: Sunrise
     short_name: SR
-    version: 1.6.5
+    version: "1.6.5"
     engine: WebKit
   device:
     type: desktop
@@ -1160,11 +1160,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.3.9
+    version: "10.3.9"
   client:
     type: mediaplayer
     name: QuickTime
-    version: 7.0.4
+    version: "7.0.4"
   device:
     type: desktop
     brand:
@@ -1176,12 +1176,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.5.6
+    version: "10.5.6"
   client:
     type: browser
     name: Fluid
     short_name: FD
-    version: 0.9.6
+    version: "0.9.6"
     engine: WebKit
   device:
     type: desktop
@@ -1194,12 +1194,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.5.8
+    version: "10.5.8"
   client:
     type: browser
     name: iCab
     short_name: IC
-    version: 4.8
+    version: "4.8"
     engine: WebKit
   device:
     type: desktop
@@ -1212,12 +1212,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.5.8
+    version: "10.5.8"
   client:
     type: browser
     name: Safari
     short_name: SF
-    version: 4.0.4
+    version: "4.0.4"
     engine: WebKit
   device:
     type: desktop
@@ -1230,12 +1230,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.6
+    version: "10.6"
   client:
     type: browser
     name: Camino
     short_name: CA
-    version: 2.1.2
+    version: "2.1.2"
     engine: Gecko
   device:
     type: desktop
@@ -1248,12 +1248,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.6
+    version: "10.6"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.5.6
+    version: "3.5.6"
     engine: Gecko
   device:
     type: desktop
@@ -1266,11 +1266,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.6
+    version: "10.6"
   client:
     type: pim
     name: Postbox
-    version: 1.1.3
+    version: "1.1.3"
   device:
     type: desktop
     brand:
@@ -1282,11 +1282,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.6.8
+    version: "10.6.8"
   client:
     type: mediaplayer
     name: QuickTime
-    version: 7.6.6
+    version: "7.6.6"
   device:
     type: desktop
     brand:
@@ -1298,12 +1298,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.6.8
+    version: "10.6.8"
   client:
     type: browser
     name: Safari
     short_name: SF
-    version: 5.0.5
+    version: "5.0.5"
     engine: WebKit
   device:
     type: desktop
@@ -1316,12 +1316,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.7
+    version: "10.7"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -1334,12 +1334,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.8.5
+    version: "10.8.5"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
     engine: Blink
   device:
     type: desktop
@@ -1352,12 +1352,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.8.5
+    version: "10.8.5"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 4.1.2.2000
+    version: "4.1.2.2000"
     engine: WebKit
   device:
     type: desktop
@@ -1370,12 +1370,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.1
+    version: "10.9.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
     engine: Blink
   device:
     type: desktop
@@ -1388,12 +1388,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9
+    version: "10.9"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -1406,12 +1406,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.1
+    version: "10.9.1"
   client:
     type: browser
     name: OmniWeb
     short_name: OW
-    version: 624.0
+    version: "624.0"
     engine: WebKit
   device:
     type: desktop
@@ -1424,12 +1424,12 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.1
+    version: "10.9.1"
   client:
     type: browser
     name: Safari
     short_name: SF
-    version: 7.0.1
+    version: "7.0.1"
     engine: WebKit
   device:
     type: desktop
@@ -1442,12 +1442,12 @@
   os:
     name: Mandriva
     short_name: MDR
-    version: 1.9.2.17
+    version: "1.9.2.17"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.6.17
+    version: "3.6.17"
     engine: Gecko
   device:
     type: desktop
@@ -1460,12 +1460,12 @@
   os:
     name: Mint
     short_name: MIN
-    version: 16
+    version: "16"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 25.0.1
+    version: "25.0.1"
     engine: Gecko
   device:
     type: desktop
@@ -1483,7 +1483,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 1.5.0.7
+    version: "1.5.0.7"
     engine: Gecko
   device:
     type: desktop
@@ -1501,7 +1501,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.45
+    version: "28.0.1500.45"
     engine: Blink
   device:
     type: desktop
@@ -1519,7 +1519,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -1537,7 +1537,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 10.0.12
+    version: "10.0.12"
     engine: Gecko
   device:
     type: desktop
@@ -1550,7 +1550,7 @@
   os:
     name: OSF1
     short_name: T64
-    version: 4.0
+    version: "4.0"
   client: null
   device:
     type: desktop
@@ -1563,7 +1563,7 @@
   os:
     name: OSF1
     short_name: T64
-    version: 5.1
+    version: "5.1"
   client: null
   device:
     type: desktop
@@ -1580,7 +1580,7 @@
   client:
     type: library
     name: Wget
-    version: 1.11.4
+    version: "1.11.4"
   device:
     type: desktop
     brand:
@@ -1592,12 +1592,12 @@
   os:
     name: Red Hat
     short_name: RHT
-    version: 4.3.4
+    version: "4.3.4"
   client:
     type: browser
     name: Konqueror
     short_name: KO
-    version: 4.3
+    version: "4.3"
     engine: KHTML
   device:
     type: desktop
@@ -1615,7 +1615,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.16
+    version: "12.16"
     engine: Presto
   device:
     type: desktop
@@ -1633,7 +1633,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 12.0.742.100
+    version: "12.0.742.100"
     engine: WebKit
   device:
     type: desktop
@@ -1646,12 +1646,12 @@
   os:
     name: Slackware
     short_name: SLW
-    version: 13.0
+    version: "13.0"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.5.2
+    version: "3.5.2"
     engine: Gecko
   device:
     type: desktop
@@ -1669,7 +1669,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.5.9
+    version: "3.5.9"
     engine: Gecko
   device:
     type: desktop
@@ -1682,7 +1682,7 @@
   os:
     name: Solaris
     short_name: SOS
-    version: 5.10
+    version: "5.10"
   client: null
   device:
     type: desktop
@@ -1695,12 +1695,12 @@
   os:
     name: Solaris
     short_name: SOS
-    version: 5.10
+    version: "5.10"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 5.0
+    version: "5.0"
     engine: Trident
   device:
     type: desktop
@@ -1713,7 +1713,7 @@
   os:
     name: Solaris
     short_name: SOS
-    version: 10.1
+    version: "10.1"
   client: null
   device:
     type: desktop
@@ -1726,7 +1726,7 @@
   os:
     name: Solaris
     short_name: SOS
-    version: 5.5.1
+    version: "5.5.1"
   client: null
   device:
     type: desktop
@@ -1739,12 +1739,12 @@
   os:
     name: SUSE
     short_name: SSE
-    version: 3.6.24
+    version: "3.6.24"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.6.24
+    version: "3.6.24"
     engine: Gecko
   device:
     type: desktop
@@ -1757,12 +1757,12 @@
   os:
     name: SUSE
     short_name: SSE
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
     engine: Blink
   device:
     type: desktop
@@ -1780,7 +1780,7 @@
     type: browser
     name: ABrowse
     short_name: AB
-    version: 0.6
+    version: "0.6"
     engine: WebKit
   device:
     type: desktop
@@ -1798,7 +1798,7 @@
     type: browser
     name: Chromium
     short_name: CR
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
     engine: Blink
   device:
     type: desktop
@@ -1816,7 +1816,7 @@
     type: browser
     name: Elinks
     short_name: EL
-    version: 0.12
+    version: "0.12"
     engine: Text-based
   device:
     type: desktop
@@ -1834,7 +1834,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -1847,12 +1847,12 @@
   os:
     name: Ubuntu
     short_name: UBT
-    version: 1.1.9
+    version: "1.1.9"
   client:
     type: browser
     name: SeaMonkey
     short_name: SM
-    version: 1.1.9
+    version: "1.1.9"
     engine: Gecko
   device:
     type: desktop
@@ -1865,12 +1865,12 @@
   os:
     name: Ubuntu
     short_name: UBT
-    version: 9.04
+    version: "9.04"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.0.14
+    version: "3.0.14"
     engine: Gecko
   device:
     type: desktop
@@ -1883,12 +1883,12 @@
   os:
     name: Ubuntu
     short_name: UBT
-    version: 9.10
+    version: "9.10"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.5.6
+    version: "3.5.6"
     engine: Gecko
   device:
     type: desktop
@@ -1901,12 +1901,12 @@
   os:
     name: Ubuntu
     short_name: UBT
-    version: 9.25
+    version: "9.25"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.8
+    version: "3.8"
     engine: Gecko
   device:
     type: desktop
@@ -1919,12 +1919,12 @@
   os:
     name: Ubuntu
     short_name: UBT
-    version: 10.10
+    version: "10.10"
   client:
     type: browser
     name: Epiphany
     short_name: EP
-    version: 2.30.6
+    version: "2.30.6"
     engine: WebKit
   device:
     type: desktop
@@ -1942,7 +1942,7 @@
     type: browser
     name: Beonex
     short_name: BE
-    version: 0.8.1
+    version: "0.8.1"
     engine: Gecko
   device:
     type: desktop
@@ -1960,7 +1960,7 @@
     type: browser
     name: BrowseX
     short_name: BX
-    version: 2.0.0
+    version: "2.0.0"
     engine:
   device:
     type: desktop
@@ -1977,7 +1977,7 @@
   client:
     type: pim
     name: Postbox
-    version: 1.0
+    version: "1.0"
   device:
     type: desktop
     brand:
@@ -1989,12 +1989,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Amigo
     short_name: AO
-    version: 28.0.1500.74
+    version: "28.0.1500.74"
     engine: Blink
   device:
     type: desktop
@@ -2007,12 +2007,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Baidu Spark
     short_name: BS
-    version: 26.4
+    version: "26.4"
     engine: WebKit
   device:
     type: desktop
@@ -2025,12 +2025,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1403.0
+    version: "26.0.1403.0"
     engine: WebKit
   device:
     type: desktop
@@ -2043,12 +2043,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 27.0.1453.110
+    version: "27.0.1453.110"
     engine: WebKit
   device:
     type: desktop
@@ -2061,12 +2061,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.63
+    version: "31.0.1650.63"
     engine: Blink
   device:
     type: desktop
@@ -2079,12 +2079,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Chrome Frame
     short_name: CF
-    version: 19.0.1084.52
+    version: "19.0.1084.52"
     engine: WebKit
   device:
     type: desktop
@@ -2097,12 +2097,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: ChromePlus
     short_name: CP
-    version: 1.6.0.0
+    version: "1.6.0.0"
     engine: WebKit
   device:
     type: desktop
@@ -2115,12 +2115,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Comodo Dragon
     short_name: CD
-    version: 17.1.0.0
+    version: "17.1.0.0"
     engine: WebKit
   device:
     type: desktop
@@ -2133,12 +2133,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: CoolNovo
     short_name: CN
-    version: 1.6.5.28
+    version: "1.6.5.28"
     engine: WebKit
   device:
     type: desktop
@@ -2151,12 +2151,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -2169,12 +2169,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: Lorentz (3.6.3)
+    version: "Lorentz (3.6.3)"
     engine: Gecko
   device:
     type: desktop
@@ -2187,12 +2187,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: Namoroka (3.6.13)
+    version: "Namoroka (3.6.13)"
     engine: Gecko
   device:
     type: desktop
@@ -2205,12 +2205,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Flock
     short_name: FL
-    version: 2.5.6
+    version: "2.5.6"
     engine: Gecko
   device:
     type: desktop
@@ -2223,12 +2223,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: IceDragon
     short_name: ID
-    version: 26.0.0.2
+    version: "26.0.0.2"
     engine: Gecko
   device:
     type: desktop
@@ -2241,12 +2241,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -2259,12 +2259,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -2277,12 +2277,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -2295,12 +2295,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -2313,12 +2313,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -2331,12 +2331,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -2349,12 +2349,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Iron
     short_name: IR
-    version: 26.0.1450.0
+    version: "26.0.1450.0"
     engine: WebKit
   device:
     type: desktop
@@ -2367,11 +2367,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: pim
     name: Microsoft Outlook
-    version: 14.0.6106
+    version: "14.0.6106"
   device:
     type: desktop
     brand:
@@ -2383,11 +2383,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: pim
     name: Microsoft Outlook
-    version: 14.0.7113
+    version: "14.0.7113"
   device:
     type: desktop
     brand:
@@ -2399,11 +2399,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: pim
     name: Microsoft Outlook
-    version: 14.0.7113
+    version: "14.0.7113"
   device:
     type: desktop
     brand:
@@ -2415,12 +2415,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 12.16
+    version: "12.16"
     engine: Presto
   device:
     type: desktop
@@ -2433,12 +2433,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 18.0.1284.49
+    version: "18.0.1284.49"
     engine: Blink
   device:
     type: desktop
@@ -2451,12 +2451,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Opera Next
     short_name: 'ON'
-    version: 20.0.1387.37
+    version: "20.0.1387.37"
     engine: Blink
   device:
     type: desktop
@@ -2469,11 +2469,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: mediaplayer
     name: QuickTime
-    version: 7.7.5
+    version: "7.7.5"
   device:
     type: desktop
     brand:
@@ -2485,12 +2485,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: RockMelt
     short_name: RM
-    version: 0.16.91.483
+    version: "0.16.91.483"
     engine: WebKit
   device:
     type: desktop
@@ -2503,12 +2503,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Sleipnir
     short_name: SL
-    version: 2.9.18
+    version: "2.9.18"
     engine: Trident
   device:
     type: desktop
@@ -2521,12 +2521,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Sogou Explorer
     short_name: SE
-    version: 2
+    version: "2"
     engine:
   device:
     type: desktop
@@ -2539,12 +2539,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Sogou Explorer
     short_name: SE
-    version: 2
+    version: "2"
     engine: WebKit
   device:
     type: desktop
@@ -2557,12 +2557,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Baidu Spark
     short_name: BS
-    version: 2
+    version: "2"
     engine: WebKit
   device:
     type: desktop
@@ -2575,12 +2575,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 24.0.1312.57
+    version: "24.0.1312.57"
     engine: WebKit
   device:
     type: desktop
@@ -2593,12 +2593,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: CometBird
     short_name: CO
-    version: 11.0
+    version: "11.0"
     engine: Gecko
   device:
     type: desktop
@@ -2611,12 +2611,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -2629,12 +2629,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: IceDragon
     short_name: ID
-    version: 25.0.0.1
+    version: "25.0.0.1"
     engine: Gecko
   device:
     type: desktop
@@ -2647,12 +2647,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Opera Next
     short_name: 'ON'
-    version: 12.50
+    version: "12.50"
     engine: Presto
   device:
     type: desktop
@@ -2665,12 +2665,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Opera Next
     short_name: 'ON'
-    version: 15.0.1147.18
+    version: "15.0.1147.18"
     engine: Blink
   device:
     type: desktop
@@ -2683,12 +2683,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Pale Moon
     short_name: PM
-    version: 24.3.1
+    version: "24.3.1"
     engine: Gecko
   device:
     type: desktop
@@ -2701,12 +2701,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: SeaMonkey
     short_name: SM
-    version: 2.17.1
+    version: "2.17.1"
     engine: Gecko
   device:
     type: desktop
@@ -2719,12 +2719,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 13.10.1500.9323
+    version: "13.10.1500.9323"
     engine: Blink
   device:
     type: desktop
@@ -2737,12 +2737,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.76
+    version: "32.0.1700.76"
     engine: Blink
   device:
     type: desktop
@@ -2755,12 +2755,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: desktop
@@ -2773,12 +2773,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -2791,12 +2791,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 18.0.1284.68
+    version: "18.0.1284.68"
     engine: Blink
   device:
     type: desktop
@@ -2809,7 +2809,7 @@
   os:
     name: Windows
     short_name: WIN
-    version: 95
+    version: "95"
   client: null
   device:
     type: desktop
@@ -2822,12 +2822,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 95
+    version: "95"
   client:
     type: browser
     name: Firebird
     short_name: FB
-    version: 0.7
+    version: "0.7"
     engine: Gecko
   device:
     type: desktop
@@ -2840,12 +2840,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 95
+    version: "95"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 3.02
+    version: "3.02"
     engine: Trident
   device:
     type: desktop
@@ -2858,12 +2858,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 2000
+    version: "2000"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 2.0.0.20
+    version: "2.0.0.20"
     engine: Gecko
   device:
     type: desktop
@@ -2876,12 +2876,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 2000
+    version: "2000"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -2894,12 +2894,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 2000
+    version: "2000"
   client:
     type: browser
     name: Lunascape
     short_name: LS
-    version: 2.1.3
+    version: "2.1.3"
     engine:
   device:
     type: desktop
@@ -2912,7 +2912,7 @@
   os:
     name: Windows
     short_name: WIN
-    version: 2000
+    version: "2000"
   client:
     type: browser
     name: Off By One
@@ -2930,12 +2930,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 2000
+    version: "2000"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 6.0
+    version: "6.0"
     engine: Presto
   device:
     type: desktop
@@ -2948,12 +2948,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: ME
+    version: "ME"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -2966,12 +2966,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: NT
+    version: "NT"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 4.01
+    version: "4.01"
     engine: Trident
   device:
     type: desktop
@@ -2984,12 +2984,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Server 2003
+    version: "Server 2003"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: Minefield (3.0)
+    version: "Minefield (3.0)"
     engine: Gecko
   device:
     type: desktop
@@ -3002,12 +3002,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Server 2003
+    version: "Server 2003"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3020,12 +3020,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Server 2003
+    version: "Server 2003"
   client:
     type: browser
     name: Lunascape
     short_name: LS
-    version: 4.9.9.94
+    version: "4.9.9.94"
     engine: WebKit
   device:
     type: desktop
@@ -3038,12 +3038,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 18.0
+    version: "18.0"
     engine: Gecko
   device:
     type: desktop
@@ -3056,12 +3056,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: 3.5.6
+    version: "3.5.6"
     engine: Gecko
   device:
     type: desktop
@@ -3074,12 +3074,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: desktop
@@ -3092,12 +3092,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: desktop
@@ -3110,12 +3110,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -3128,12 +3128,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: browser
     name: Opera Next
     short_name: 'ON'
-    version: 12.10
+    version: "12.10"
     engine: Presto
   device:
     type: desktop
@@ -3146,11 +3146,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: mediaplayer
     name: QuickTime
-    version: 7.0.2
+    version: "7.0.2"
   device:
     type: desktop
     brand:
@@ -3162,11 +3162,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: Vista
+    version: "Vista"
   client:
     type: mediaplayer
     name: QuickTime
-    version: 7.7.4
+    version: "7.7.4"
   device:
     type: desktop
     brand:
@@ -3178,7 +3178,7 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client: null
   device:
     type: desktop
@@ -3191,7 +3191,7 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Avant Browser
@@ -3209,12 +3209,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Baidu Spark
     short_name: BS
-    version: 2
+    version: "2"
     engine: WebKit
   device:
     type: desktop
@@ -3227,12 +3227,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Baidu Spark
     short_name: BS
-    version: 2.6
+    version: "2.6"
     engine: Trident
   device:
     type: desktop
@@ -3245,12 +3245,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 23.0.1271.64
+    version: "23.0.1271.64"
     engine: WebKit
   device:
     type: desktop
@@ -3263,12 +3263,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Chrome Frame
     short_name: CF
-    version: 32.0.1700.76
+    version: "32.0.1700.76"
     engine: WebKit
   device:
     type: desktop
@@ -3281,12 +3281,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: CoolNovo
     short_name: CN
-    version: 2.0.9.20
+    version: "2.0.9.20"
     engine: WebKit
   device:
     type: desktop
@@ -3299,12 +3299,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: GranParadiso (3.0.2)
+    version: "GranParadiso (3.0.2)"
     engine: Gecko
   device:
     type: desktop
@@ -3317,12 +3317,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Firefox
     short_name: FF
-    version: Shiretoko (3.1)
+    version: "Shiretoko (3.1)"
     engine: Gecko
   device:
     type: desktop
@@ -3335,12 +3335,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Fireweb Navigator
     short_name: FN
-    version: 2.4
+    version: "2.4"
     engine:
   device:
     type: desktop
@@ -3353,12 +3353,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Google Earth
     short_name: GE
-    version: 5.2.1.1329
+    version: "5.2.1.1329"
     engine: WebKit
   device:
     type: desktop
@@ -3371,12 +3371,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3389,12 +3389,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3407,12 +3407,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3425,12 +3425,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3443,12 +3443,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3461,12 +3461,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: desktop
@@ -3479,12 +3479,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: desktop
@@ -3497,12 +3497,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: desktop
@@ -3515,12 +3515,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -3533,12 +3533,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: K-meleon
     short_name: KM
-    version: 1.5.4
+    version: "1.5.4"
     engine: Gecko
   device:
     type: desktop
@@ -3551,12 +3551,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Kapiko
     short_name: KP
-    version: 3.0
+    version: "3.0"
     engine: Gecko
   device:
     type: desktop
@@ -3569,12 +3569,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Konqueror
     short_name: KO
-    version: 3.4
+    version: "3.4"
     engine: KHTML
   device:
     type: desktop
@@ -3587,7 +3587,7 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Liebao
@@ -3605,12 +3605,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 2.0
+    version: "2.0"
     engine: Trident
   device:
     type: desktop
@@ -3623,12 +3623,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 3.0
+    version: "3.0"
     engine: WebKit
   device:
     type: desktop
@@ -3641,12 +3641,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 4.2.0.4000
+    version: "4.2.0.4000"
     engine: WebKit
   device:
     type: desktop
@@ -3659,12 +3659,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 8.00
+    version: "8.00"
     engine: Presto
   device:
     type: desktop
@@ -3677,12 +3677,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 9.27
+    version: "9.27"
     engine: Presto
   device:
     type: desktop
@@ -3695,12 +3695,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 9.70
+    version: "9.70"
     engine: Presto
   device:
     type: desktop
@@ -3713,12 +3713,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 10.10
+    version: "10.10"
     engine: Presto
   device:
     type: desktop
@@ -3731,12 +3731,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: QQ Browser
     short_name: QQ
-    version: 8.0.3197.400
+    version: "8.0.3197.400"
     engine: WebKit
   device:
     type: desktop
@@ -3749,11 +3749,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: mediaplayer
     name: XBMC
-    version: 9.04
+    version: "9.04"
   device:
     type: desktop
     brand:
@@ -3765,12 +3765,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3783,12 +3783,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3801,12 +3801,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3819,12 +3819,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3837,12 +3837,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3855,11 +3855,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: pim
     name: Microsoft Outlook
-    version: 14.0.7113
+    version: "14.0.7113"
   device:
     type: desktop
     brand: CQ
@@ -3871,12 +3871,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -3889,12 +3889,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -3907,12 +3907,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -3925,12 +3925,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -3943,12 +3943,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -3961,12 +3961,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -3979,12 +3979,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -3997,12 +3997,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -4015,12 +4015,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4033,11 +4033,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: pim
     name: Microsoft Outlook
-    version: 14.0.7113
+    version: "14.0.7113"
   device:
     type: desktop
     brand: GA
@@ -4049,12 +4049,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4067,12 +4067,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4085,12 +4085,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4103,12 +4103,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4121,12 +4121,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4139,12 +4139,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 8.0
+    version: "8.0"
     engine: Trident
   device:
     type: desktop
@@ -4157,12 +4157,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -4175,12 +4175,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4193,12 +4193,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4211,12 +4211,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: desktop
@@ -4229,12 +4229,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -4247,12 +4247,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: desktop
@@ -4265,12 +4265,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4283,12 +4283,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4301,12 +4301,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4319,12 +4319,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4337,12 +4337,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4355,12 +4355,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4373,12 +4373,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4391,12 +4391,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4409,12 +4409,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4427,12 +4427,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4445,12 +4445,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: desktop
@@ -4463,12 +4463,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4481,12 +4481,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4499,12 +4499,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4517,12 +4517,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop
@@ -4535,12 +4535,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: desktop

--- a/Tests/fixtures/feature_phone.yml
+++ b/Tests/fixtures/feature_phone.yml
@@ -21,7 +21,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.3.0.4
+    version: "6.3.0.4"
     engine:
   device:
     type: feature phone
@@ -36,7 +36,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.3.0.7
+    version: "6.3.0.7"
     engine:
   device:
     type: feature phone
@@ -121,7 +121,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2
+    version: "6.2"
     engine:
   device:
     type: feature phone
@@ -139,7 +139,7 @@
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 10.00
+    version: "10.00"
     engine: Presto
   device:
     type: feature phone
@@ -154,7 +154,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2
+    version: "6.2"
     engine:
   device:
     type: feature phone
@@ -169,7 +169,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2
+    version: "6.2"
     engine:
   device:
     type: feature phone
@@ -182,12 +182,12 @@
   os:
     name: Brew
     short_name: BMP
-    version: 1.0.4
+    version: "1.0.4"
   client:
     type: browser
     name: NetFront
     short_name: NF
-    version: 4.1
+    version: "4.1"
     engine: NetFront
   device:
     type: feature phone
@@ -215,7 +215,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 6.12
+    version: "6.12"
     engine: Trident
   device:
     type: feature phone
@@ -230,7 +230,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -245,7 +245,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -260,7 +260,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -275,7 +275,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -290,7 +290,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -305,7 +305,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.4
+    version: "3.4"
     engine: NetFront
   device:
     type: feature phone
@@ -335,7 +335,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.0.311
+    version: "9.2.0.311"
     engine:
   device:
     type: feature phone
@@ -350,7 +350,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.4
+    version: "3.4"
     engine: NetFront
   device:
     type: feature phone
@@ -381,12 +381,12 @@
   os:
     name: Symbian OS Series 60
     short_name: S60
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: feature phone
@@ -399,12 +399,12 @@
   os:
     name: Symbian OS Series 60
     short_name: S60
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: feature phone
@@ -459,7 +459,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.0.342
+    version: "9.4.0.342"
     engine:
   device:
     type: feature phone
@@ -472,12 +472,12 @@
   os:
     name: Symbian OS Series 60
     short_name: S60
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: feature phone
@@ -490,12 +490,12 @@
   os:
     name: Symbian OS Series 60
     short_name: S60
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: feature phone
@@ -525,7 +525,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: feature phone
@@ -540,7 +540,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 7.2.6
+    version: "7.2.6"
     engine:
   device:
     type: feature phone
@@ -555,7 +555,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 7.2.6
+    version: "7.2.6"
     engine:
   device:
     type: feature phone
@@ -570,7 +570,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 7.2.6
+    version: "7.2.6"
     engine:
   device:
     type: feature phone
@@ -585,7 +585,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.3.3
+    version: "6.2.3.3"
     engine:
   device:
     type: feature phone
@@ -600,7 +600,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.2.6
+    version: "6.2.2.6"
     engine:
   device:
     type: feature phone
@@ -613,12 +613,12 @@
   os:
     name: Brew
     short_name: BMP
-    version: 3.1.5
+    version: "3.1.5"
   client:
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5.1
+    version: "3.5.1"
     engine: NetFront
   device:
     type: feature phone
@@ -631,12 +631,12 @@
   os:
     name: Brew
     short_name: BMP
-    version: 1.0.2
+    version: "1.0.2"
   client:
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5.1
+    version: "3.5.1"
     engine: NetFront
   device:
     type: feature phone
@@ -651,7 +651,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.4
+    version: "3.4"
     engine: NetFront
   device:
     type: feature phone
@@ -666,7 +666,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3
+    version: "3"
     engine: NetFront
   device:
     type: feature phone
@@ -694,7 +694,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: feature phone

--- a/Tests/fixtures/feed_reader.yml
+++ b/Tests/fixtures/feed_reader.yml
@@ -7,7 +7,7 @@
   client:
     type: feed reader
     name: Akregator
-    version: 4.11.5
+    version: "4.11.5"
   device:
     type: desktop
     brand:
@@ -23,7 +23,7 @@
   client:
     type: feed reader
     name: Akregator
-    version: 4.12.3
+    version: "4.12.3"
   device:
     type: desktop
     brand:
@@ -36,7 +36,7 @@
   client:
     type: feed reader
     name: Akregator
-    version: 1.2.9
+    version: "1.2.9"
   device:
     type:
     brand:
@@ -49,7 +49,7 @@
   client:
     type: feed reader
     name: Apple PubSub
-    version: 65.28
+    version: "65.28"
   device:
     type:
     brand:
@@ -65,7 +65,7 @@
   client:
     type: feed reader
     name: FeedDemon
-    version: 4.5
+    version: "4.5"
   device:
     type: desktop
     brand:
@@ -77,11 +77,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: XP
+    version: "XP"
   client:
     type: feed reader
     name: FeedDemon
-    version: 4.5
+    version: "4.5"
   device:
     type: desktop
     brand:
@@ -97,7 +97,7 @@
   client:
     type: feed reader
     name: Feeddler RSS Reader
-    version: 2.4
+    version: "2.4"
   device:
     type: desktop
     brand:
@@ -113,7 +113,7 @@
   client:
     type: feed reader
     name: Feeddler RSS Reader
-    version: 2.4
+    version: "2.4"
   device:
     type: desktop
     brand:
@@ -125,11 +125,11 @@
   os:
     name: iOS
     short_name: IOS
-    version: 5.1.1
+    version: "5.1.1"
   client:
     type: feed reader
     name: Feeddler RSS Reader
-    version: 2.4
+    version: "2.4"
   device:
     type: tablet
     brand: AP
@@ -142,7 +142,7 @@
   client:
     type: feed reader
     name: JetBrains Omea Reader
-    version: 2.2
+    version: "2.2"
   device:
     type:
     brand:
@@ -158,7 +158,7 @@
   client:
     type: feed reader
     name: Liferea
-    version: 1.6.4
+    version: "1.6.4"
   device:
     type: desktop
     brand:
@@ -174,7 +174,7 @@
   client:
     type: feed reader
     name: Liferea
-    version: 1.10
+    version: "1.10"
   device:
     type: desktop
     brand:
@@ -190,7 +190,7 @@
   client:
     type: feed reader
     name: Liferea
-    version: 1.10.6
+    version: "1.10.6"
   device:
     type: desktop
     brand:
@@ -202,11 +202,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.2
+    version: "10.9.2"
   client:
     type: feed reader
     name: NetNewsWire
-    version: 4.0.0
+    version: "4.0.0"
   device:
     type: desktop
     brand:
@@ -218,11 +218,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.2
+    version: "10.9.2"
   client:
     type: feed reader
     name: NetNewsWire
-    version: 3.3.2
+    version: "3.3.2"
   device:
     type: desktop
     brand:
@@ -238,7 +238,7 @@
   client:
     type: feed reader
     name: NetNewsWire
-    version: 4.0.0
+    version: "4.0.0"
   device:
     type: desktop
     brand:
@@ -254,7 +254,7 @@
   client:
     type: feed reader
     name: Newsbeuter
-    version: 2.7
+    version: "2.7"
   device:
     type: desktop
     brand:
@@ -270,7 +270,7 @@
   client:
     type: feed reader
     name: NewsBlur Mobile App
-    version: 3.6
+    version: "3.6"
   device:
     type: smartphone
     brand: AP
@@ -286,7 +286,7 @@
   client:
     type: feed reader
     name: NewsBlur Mobile App
-    version: 3.6
+    version: "3.6"
   device:
     type: tablet
     brand: AP
@@ -302,7 +302,7 @@
   client:
     type: feed reader
     name: NewsBlur
-    version: 4.0.1
+    version: "4.0.1"
   device:
     type: desktop
     brand:
@@ -318,7 +318,7 @@
   client:
     type: feed reader
     name: Newsbeuter
-    version: 2.4
+    version: "2.4"
   device:
     type: desktop
     brand:
@@ -334,7 +334,7 @@
   client:
     type: feed reader
     name: Pulp
-    version: 1.5.2
+    version: "1.5.2"
   device:
     type: tablet
     brand: AP
@@ -346,11 +346,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.9.2
+    version: "10.9.2"
   client:
     type: feed reader
     name: ReadKit
-    version: 2.4.0
+    version: "2.4.0"
   device:
     type: desktop
     brand:
@@ -366,7 +366,7 @@
   client:
     type: feed reader
     name: ReadKit
-    version: 7017
+    version: "7017"
   device:
     type: desktop
     brand:
@@ -382,7 +382,7 @@
   client:
     type: feed reader
     name: Reeder
-    version: 3.2
+    version: "3.2"
   device:
     type: desktop
     brand:
@@ -395,7 +395,7 @@
   client:
     type: feed reader
     name: RSS Bandit
-    version: 1.9.0.1002
+    version: "1.9.0.1002"
   device:
     type:
     brand:
@@ -407,11 +407,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: NT
+    version: "NT"
   client:
     type: feed reader
     name: RSS Bandit
-    version: 1.9.0.1002
+    version: "1.9.0.1002"
   device:
     type: desktop
     brand:
@@ -440,7 +440,7 @@
   client:
     type: feed reader
     name: RSSOwl
-    version: 2.2.1.201312301314
+    version: "2.2.1.201312301314"
   device:
     type: desktop
     brand:
@@ -453,7 +453,7 @@
   client:
     type: feed reader
     name: RSSOwl
-    version: 2.2.1.201312301316
+    version: "2.2.1.201312301316"
   device:
     type:
     brand:

--- a/Tests/fixtures/mediaplayer.yml
+++ b/Tests/fixtures/mediaplayer.yml
@@ -7,7 +7,7 @@
   client:
     type: mediaplayer
     name: Songbird
-    version: 1.12.1
+    version: "1.12.1"
   device:
     type: desktop
     brand:
@@ -23,7 +23,7 @@
   client:
     type: mediaplayer
     name: Nightingale
-    version: 1.12.2
+    version: "1.12.2"
   device:
     type: desktop
     brand:
@@ -35,11 +35,11 @@
   os:
     name: Mac
     short_name: MAC
-    version: 10.7
+    version: "10.7"
   client:
     type: mediaplayer
     name: iTunes
-    version: 10.2.1
+    version: "10.2.1"
   device:
     type: desktop
     brand:
@@ -51,11 +51,11 @@
   os:
     name: Windows
     short_name: WIN
-    version: 7
+    version: "7"
   client:
     type: mediaplayer
     name: iTunes
-    version: 10.2.1
+    version: "10.2.1"
   device:
     type: desktop
     brand:
@@ -68,7 +68,7 @@
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -84,7 +84,7 @@
   client:
     type: mediaplayer
     name: FlyCast
-    version: 1.34
+    version: "1.34"
   device:
     type: smartphone
     brand: RM
@@ -100,7 +100,7 @@
   client:
     type: mediaplayer
     name: XBMC
-    version: 9.04
+    version: "9.04"
   device:
     type: desktop
     brand:
@@ -116,7 +116,7 @@
   client:
     type: mediaplayer
     name: SubStream
-    version: 0.7
+    version: "0.7"
   device:
     type: desktop
     brand:
@@ -128,11 +128,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: mediaplayer
     name: Stagefright
-    version: 1.2
+    version: "1.2"
   device:
     type: smartphone
     brand: SA

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -3,11 +3,11 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.6
+    version: "7.0.6"
   client:
     type: mobile app
     name: Pulse
-    version: 4.0.5
+    version: "4.0.5"
   device:
     type: smartphone
     brand: AP
@@ -19,11 +19,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: mobile app
     name: AndroidDownloadManager
-    version: 4.1.1
+    version: "4.1.1"
   device:
     type: smartphone
     brand: MR

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -4,12 +4,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.0.0
+    version: "33.0.0.0"
     engine: Blink
   device:
     type: phablet
@@ -22,12 +22,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.76
+    version: "34.0.1847.76"
     engine: Blink
   device:
     type: phablet

--- a/Tests/fixtures/portable_media_player.yml
+++ b/Tests/fixtures/portable_media_player.yml
@@ -4,7 +4,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Mobile Safari
@@ -22,7 +22,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.3.0
+    version: "4.3.0"
   client:
     type: browser
     name: Mobile Safari
@@ -40,7 +40,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3
+    version: "2.3"
   client:
     type: browser
     name: Android Browser
@@ -58,7 +58,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -81,7 +81,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 6.12
+    version: "6.12"
     engine: Trident
   device:
     type: portable media player
@@ -94,7 +94,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -112,7 +112,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -130,7 +130,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser

--- a/Tests/fixtures/smart_display.yml
+++ b/Tests/fixtures/smart_display.yml
@@ -4,7 +4,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -9,7 +9,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 22.0
+    version: "22.0"
     engine: Gecko
   device:
     type: smartphone
@@ -27,7 +27,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: smartphone
@@ -40,7 +40,7 @@
   os:
     name: Android
     short_name: AND
-    version: 0.5
+    version: "0.5"
   client:
     type: browser
     name: Android Browser
@@ -58,12 +58,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -76,12 +76,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -94,7 +94,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -112,7 +112,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -130,7 +130,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -153,7 +153,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -166,12 +166,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -184,12 +184,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -202,12 +202,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -225,7 +225,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -243,7 +243,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -256,7 +256,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -274,7 +274,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -292,7 +292,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -315,7 +315,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 18.1
+    version: "18.1"
     engine: Gecko
   device:
     type: smartphone
@@ -328,12 +328,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: smartphone
@@ -346,12 +346,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -364,12 +364,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -384,7 +384,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.1.377
+    version: "9.4.1.377"
     engine:
   device:
     type: smartphone
@@ -397,12 +397,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -415,7 +415,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -433,7 +433,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -451,7 +451,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -469,7 +469,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -487,7 +487,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -505,7 +505,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -523,7 +523,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -541,12 +541,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -559,7 +559,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -577,7 +577,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -595,7 +595,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -613,7 +613,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -631,12 +631,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -649,12 +649,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -672,7 +672,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 18.1
+    version: "18.1"
     engine: Gecko
   device:
     type: smartphone
@@ -687,7 +687,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.1.234
+    version: "8.7.1.234"
     engine:
   device:
     type: smartphone
@@ -700,12 +700,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 3.1.2
+    version: "3.1.2"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 4.0
+    version: "4.0"
     engine: WebKit
   device:
     type: smartphone
@@ -718,7 +718,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Mobile Safari
@@ -736,7 +736,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Mobile Safari
@@ -754,7 +754,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.3.3
+    version: "4.3.3"
   client:
     type: browser
     name: Mobile Safari
@@ -772,7 +772,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 5.0.1
+    version: "5.0.1"
   client:
     type: browser
     name: Mobile Safari
@@ -790,12 +790,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 5.1
+    version: "5.1"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 5.1
+    version: "5.1"
     engine: WebKit
   device:
     type: smartphone
@@ -808,12 +808,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6.0
+    version: "6.0"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -826,12 +826,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6
+    version: "6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8
+    version: "8.8"
     engine: WebKit
   device:
     type: smartphone
@@ -844,12 +844,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: smartphone
@@ -862,11 +862,11 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.6
+    version: "7.0.6"
   client:
     type: mobile app
     name: WeChat
-    version: 5.2
+    version: "5.2"
   device:
     type: smartphone
     brand: AP
@@ -878,7 +878,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6.1.6
+    version: "6.1.6"
   client:
     type: browser
     name: Mobile Safari
@@ -896,7 +896,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
@@ -914,12 +914,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -932,11 +932,11 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: mobile app
     name: Sina Weibo
-    version: 4.2.5
+    version: "4.2.5"
   device:
     type: smartphone
     brand: AP
@@ -948,7 +948,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.1
+    version: "7.1"
   client:
     type: browser
     name: Mobile Safari
@@ -979,12 +979,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -997,7 +997,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.1
+    version: "7.1"
   client:
     type: browser
     name: Mobile Safari
@@ -1015,12 +1015,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.5
+    version: "7.0.5"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -1033,7 +1033,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.6
+    version: "7.0.6"
   client:
     type: browser
     name: Mobile Safari
@@ -1077,7 +1077,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.6
+    version: "7.0.6"
   client:
     type: browser
     name: Mobile Safari
@@ -1095,12 +1095,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.6
+    version: "7.0.6"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -1113,7 +1113,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.1
+    version: "7.1"
   client:
     type: browser
     name: Mobile Safari
@@ -1131,12 +1131,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.1
+    version: "7.1"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 6.0
+    version: "6.0"
     engine: WebKit
   device:
     type: smartphone
@@ -1149,12 +1149,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -1167,7 +1167,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1185,12 +1185,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -1203,12 +1203,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -1221,12 +1221,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -1239,7 +1239,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1257,12 +1257,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -1275,7 +1275,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1293,7 +1293,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1311,12 +1311,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -1329,7 +1329,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1347,12 +1347,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -1365,12 +1365,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: smartphone
@@ -1383,12 +1383,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -1401,7 +1401,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -1419,12 +1419,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 37.0.2062.117
+    version: "37.0.2062.117"
     engine: Blink
   device:
     type: smartphone
@@ -1437,7 +1437,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1455,7 +1455,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1473,12 +1473,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -1491,12 +1491,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.1.275
+    version: "9.0.1.275"
     engine: WebKit
   device:
     type: smartphone
@@ -1509,7 +1509,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1527,12 +1527,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.1.362
+    version: "9.4.1.362"
     engine: WebKit
   device:
     type: smartphone
@@ -1545,12 +1545,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.2.365
+    version: "9.4.2.365"
     engine: WebKit
   device:
     type: smartphone
@@ -1563,7 +1563,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1581,7 +1581,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1599,7 +1599,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -1617,12 +1617,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.3.272
+    version: "8.8.3.272"
     engine:
   device:
     type: smartphone
@@ -1635,7 +1635,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1653,7 +1653,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1671,7 +1671,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1689,12 +1689,12 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.3.324
+    version: "9.2.3.324"
     engine: WebKit
   device:
     type: smartphone
@@ -1707,7 +1707,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -1725,7 +1725,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1743,7 +1743,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1761,7 +1761,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1779,7 +1779,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1797,7 +1797,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1815,7 +1815,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -1833,7 +1833,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1851,7 +1851,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -1869,7 +1869,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1887,7 +1887,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -1905,7 +1905,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1923,12 +1923,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -1941,12 +1941,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -1959,12 +1959,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -1977,7 +1977,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1995,7 +1995,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2013,7 +2013,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2031,12 +2031,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -2049,7 +2049,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2067,7 +2067,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2085,7 +2085,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2103,7 +2103,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2121,12 +2121,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -2139,12 +2139,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -2157,7 +2157,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2180,7 +2180,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -2193,7 +2193,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2211,12 +2211,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.1.1.420
+    version: "9.1.1.420"
     engine:
   device:
     type: smartphone
@@ -2229,7 +2229,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2247,7 +2247,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2265,7 +2265,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2283,7 +2283,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2301,12 +2301,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine: WebKit
   device:
     type: smartphone
@@ -2319,12 +2319,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.5.418
+    version: "9.7.5.418"
     engine: WebKit
   device:
     type: smartphone
@@ -2337,7 +2337,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2357,7 +2357,7 @@
     type: browser
     name: SEMC-Browser
     short_name: SC
-    version: 4.0.3
+    version: "4.0.3"
     engine:
   device:
     type: smartphone
@@ -2370,7 +2370,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2388,12 +2388,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -2406,7 +2406,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2424,7 +2424,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2442,7 +2442,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2460,7 +2460,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -2478,7 +2478,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2496,7 +2496,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2514,12 +2514,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Baidu Browser
     short_name: BD
-    version: 4.5.20.0
+    version: "4.5.20.0"
     engine: WebKit
   device:
     type: smartphone
@@ -2532,7 +2532,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2550,7 +2550,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2568,7 +2568,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2586,7 +2586,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2604,7 +2604,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2622,7 +2622,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -2640,7 +2640,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0
+    version: "4.0"
   client:
     type: browser
     name: Android Browser
@@ -2658,7 +2658,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2676,12 +2676,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.3.413
+    version: "9.6.3.413"
     engine: WebKit
   device:
     type: smartphone
@@ -2694,7 +2694,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -2712,7 +2712,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2730,7 +2730,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2748,7 +2748,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -2766,12 +2766,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -2784,7 +2784,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.9
+    version: "4.2.9"
   client:
     type: browser
     name: Android Browser
@@ -2802,7 +2802,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2820,7 +2820,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2838,7 +2838,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2856,12 +2856,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -2874,7 +2874,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2892,7 +2892,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2910,12 +2910,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -2928,12 +2928,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -2946,7 +2946,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2964,7 +2964,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2982,12 +2982,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 4.1.4.2000
+    version: "4.1.4.2000"
     engine: WebKit
   device:
     type: smartphone
@@ -3000,7 +3000,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3018,7 +3018,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3036,12 +3036,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -3054,7 +3054,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3072,7 +3072,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3090,12 +3090,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -3108,7 +3108,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3126,7 +3126,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3144,12 +3144,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: smartphone
@@ -3162,7 +3162,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3185,7 +3185,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.6
+    version: "7.6"
     engine: Trident
   device:
     type: smartphone
@@ -3198,7 +3198,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3216,7 +3216,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3234,7 +3234,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -3252,7 +3252,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3270,7 +3270,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3288,7 +3288,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3306,7 +3306,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3324,12 +3324,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -3342,7 +3342,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3360,7 +3360,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3378,7 +3378,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3396,7 +3396,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3414,7 +3414,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3432,7 +3432,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3450,12 +3450,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -3468,12 +3468,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.1.362
+    version: "9.4.1.362"
     engine: WebKit
   device:
     type: smartphone
@@ -3486,7 +3486,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -3504,12 +3504,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -3522,12 +3522,12 @@
   os:
     name: Android
     short_name: AND
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 37.0.0.0
+    version: "37.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -3540,7 +3540,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -3558,7 +3558,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -3576,7 +3576,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3594,7 +3594,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3612,7 +3612,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3630,7 +3630,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -3648,7 +3648,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -3666,7 +3666,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3684,7 +3684,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3702,7 +3702,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -3720,7 +3720,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3738,7 +3738,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3756,7 +3756,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3774,7 +3774,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -3792,12 +3792,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -3810,12 +3810,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -3828,12 +3828,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -3846,12 +3846,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -3864,7 +3864,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3882,7 +3882,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3900,12 +3900,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -3918,7 +3918,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3936,7 +3936,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3954,7 +3954,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -3972,7 +3972,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3990,12 +3990,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -4008,12 +4008,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -4026,7 +4026,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -4044,7 +4044,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4062,12 +4062,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -4080,7 +4080,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -4098,7 +4098,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4116,12 +4116,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -4134,7 +4134,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4152,7 +4152,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4170,7 +4170,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4188,7 +4188,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4206,7 +4206,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4224,7 +4224,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4242,7 +4242,7 @@
   os:
     name: MildWild
     short_name: MLD
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: Android Browser
@@ -4260,7 +4260,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4278,7 +4278,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4296,7 +4296,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4314,7 +4314,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4332,7 +4332,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4350,12 +4350,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -4368,7 +4368,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4386,7 +4386,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4404,7 +4404,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4422,7 +4422,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4440,7 +4440,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4458,12 +4458,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -4476,7 +4476,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4494,7 +4494,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4512,7 +4512,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -4530,7 +4530,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -4548,7 +4548,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4566,12 +4566,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -4584,7 +4584,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4602,7 +4602,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4620,7 +4620,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4638,7 +4638,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4656,7 +4656,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4674,7 +4674,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4692,7 +4692,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4710,7 +4710,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4728,7 +4728,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4746,7 +4746,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4764,7 +4764,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4782,7 +4782,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4800,7 +4800,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4818,7 +4818,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4836,7 +4836,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -4854,7 +4854,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4872,7 +4872,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4890,7 +4890,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4908,7 +4908,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4926,7 +4926,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4944,7 +4944,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4962,7 +4962,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Android Browser
@@ -4980,7 +4980,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4998,12 +4998,12 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.133
+    version: "18.0.1025.133"
     engine: WebKit
   device:
     type: smartphone
@@ -5016,7 +5016,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5034,11 +5034,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: mobile app
     name: Sina Weibo
-    version: 4.2.6
+    version: "4.2.6"
   device:
     type: smartphone
     brand: HT
@@ -5050,7 +5050,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5068,7 +5068,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5086,7 +5086,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.2
+    version: "10.2"
   client:
     type: browser
     name: Android Browser
@@ -5104,7 +5104,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5122,7 +5122,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5140,12 +5140,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 15.0.1162.61541
+    version: "15.0.1162.61541"
     engine: Blink
   device:
     type: smartphone
@@ -5158,7 +5158,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5176,7 +5176,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5199,7 +5199,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 4.01
+    version: "4.01"
     engine: Trident
   device:
     type: smartphone
@@ -5212,7 +5212,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -5230,7 +5230,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -5248,7 +5248,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -5266,12 +5266,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -5284,7 +5284,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -5302,7 +5302,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5320,7 +5320,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5338,12 +5338,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 6.5.3.5
+    version: "6.5.3.5"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: smartphone
@@ -5356,7 +5356,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5374,7 +5374,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.0.0
+    version: "10.0.0"
   client:
     type: browser
     name: Android Browser
@@ -5392,7 +5392,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Android Browser
@@ -5415,7 +5415,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -5428,12 +5428,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 6.5
+    version: "6.5"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: smartphone
@@ -5451,7 +5451,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -5464,12 +5464,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 6.5
+    version: "6.5"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: smartphone
@@ -5482,12 +5482,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -5500,12 +5500,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.1.381
+    version: "9.5.1.381"
     engine:
   device:
     type: smartphone
@@ -5518,12 +5518,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -5536,12 +5536,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -5554,7 +5554,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.5
+    version: "1.5"
   client:
     type: browser
     name: Android Browser
@@ -5572,7 +5572,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5590,7 +5590,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -5608,7 +5608,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -5626,7 +5626,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -5644,7 +5644,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -5662,7 +5662,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Android Browser
@@ -5680,7 +5680,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5698,7 +5698,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5716,7 +5716,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5734,12 +5734,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -5752,7 +5752,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -5770,7 +5770,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -5788,12 +5788,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -5806,7 +5806,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -5824,7 +5824,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5842,12 +5842,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -5860,12 +5860,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.6.428
+    version: "9.7.6.428"
     engine: WebKit
   device:
     type: smartphone
@@ -5878,7 +5878,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5896,7 +5896,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -5914,7 +5914,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -5932,7 +5932,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5950,7 +5950,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5968,7 +5968,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5986,7 +5986,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6004,7 +6004,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6022,7 +6022,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6040,7 +6040,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6058,7 +6058,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6076,7 +6076,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6094,7 +6094,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6112,7 +6112,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6130,7 +6130,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6148,7 +6148,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6166,7 +6166,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6184,7 +6184,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6202,12 +6202,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -6220,7 +6220,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1.2
+    version: "10.1.2"
   client:
     type: browser
     name: Android Browser
@@ -6238,7 +6238,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6256,7 +6256,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6274,7 +6274,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6292,7 +6292,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6310,7 +6310,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6328,7 +6328,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6346,7 +6346,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -6364,7 +6364,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -6382,7 +6382,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -6400,7 +6400,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -6418,12 +6418,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -6436,12 +6436,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -6454,7 +6454,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -6472,12 +6472,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -6490,7 +6490,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6513,7 +6513,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.6
+    version: "7.6"
     engine: Trident
   device:
     type: smartphone
@@ -6526,7 +6526,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -6544,12 +6544,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -6562,7 +6562,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6580,12 +6580,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -6598,7 +6598,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6616,12 +6616,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -6634,7 +6634,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6652,12 +6652,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -6670,7 +6670,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6688,7 +6688,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6706,12 +6706,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.1599.82
+    version: "30.0.1599.82"
     engine: Blink
   device:
     type: smartphone
@@ -6724,7 +6724,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6742,7 +6742,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6760,7 +6760,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6778,7 +6778,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6796,7 +6796,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6814,7 +6814,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -6832,7 +6832,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -6850,7 +6850,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -6873,7 +6873,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -6886,12 +6886,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -6904,7 +6904,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6922,7 +6922,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6940,7 +6940,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6958,7 +6958,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6976,12 +6976,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.2.404
+    version: "9.6.2.404"
     engine: WebKit
   device:
     type: smartphone
@@ -6994,7 +6994,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7012,7 +7012,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -7035,7 +7035,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.11
+    version: "7.11"
     engine: Trident
   device:
     type: smartphone
@@ -7053,7 +7053,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -7066,12 +7066,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -7084,7 +7084,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7102,7 +7102,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -7120,7 +7120,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -7138,12 +7138,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -7161,7 +7161,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 6.12
+    version: "6.12"
     engine: Trident
   device:
     type: smartphone
@@ -7174,7 +7174,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -7192,7 +7192,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Android Browser
@@ -7210,7 +7210,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -7228,7 +7228,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -7246,12 +7246,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -7264,12 +7264,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -7282,7 +7282,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7300,7 +7300,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7318,7 +7318,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7336,12 +7336,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -7354,7 +7354,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7372,7 +7372,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7390,7 +7390,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7408,12 +7408,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.2.365
+    version: "9.4.2.365"
     engine: WebKit
   device:
     type: smartphone
@@ -7426,7 +7426,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -7459,7 +7459,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7477,12 +7477,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -7495,7 +7495,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -7513,7 +7513,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -7531,7 +7531,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -7549,7 +7549,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -7569,7 +7569,7 @@
     type: browser
     name: Obigo
     short_name: OB
-    version: Q03C
+    version: "Q03C"
     engine:
   device:
     type: smartphone
@@ -7584,7 +7584,7 @@
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 10.10
+    version: "10.10"
     engine: Presto
   device:
     type: smartphone
@@ -7599,7 +7599,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 9.80
+    version: "9.80"
     engine: Presto
   device:
     type: smartphone
@@ -7612,12 +7612,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -7630,12 +7630,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -7648,12 +7648,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -7666,7 +7666,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -7684,7 +7684,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7702,7 +7702,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7720,7 +7720,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7740,7 +7740,7 @@
     type: browser
     name: Obigo
     short_name: OB
-    version: Q05A
+    version: "Q05A"
     engine:
   device:
     type: smartphone
@@ -7753,12 +7753,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -7771,7 +7771,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7789,7 +7789,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -7807,7 +7807,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -7825,7 +7825,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7843,7 +7843,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7861,7 +7861,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7879,7 +7879,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7897,7 +7897,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7915,12 +7915,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -7933,7 +7933,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7951,7 +7951,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -7969,7 +7969,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7987,12 +7987,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -8005,12 +8005,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.132
+    version: "33.0.1750.132"
     engine: Blink
   device:
     type: smartphone
@@ -8023,7 +8023,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8041,7 +8041,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8059,7 +8059,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8077,12 +8077,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -8095,7 +8095,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8113,7 +8113,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8131,7 +8131,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8149,7 +8149,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8167,12 +8167,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -8185,12 +8185,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.2.365
+    version: "9.4.2.365"
     engine:
   device:
     type: smartphone
@@ -8203,12 +8203,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -8221,12 +8221,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -8239,7 +8239,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8257,7 +8257,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8275,7 +8275,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8293,12 +8293,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine:
   device:
     type: smartphone
@@ -8311,7 +8311,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8329,7 +8329,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8347,12 +8347,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -8365,7 +8365,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8383,7 +8383,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8401,7 +8401,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8419,7 +8419,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8437,7 +8437,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -8455,7 +8455,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8473,7 +8473,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -8491,12 +8491,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Baidu Browser
     short_name: BD
-    version: 3.1.6.4
+    version: "3.1.6.4"
     engine: WebKit
   device:
     type: smartphone
@@ -8509,7 +8509,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8527,7 +8527,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8545,7 +8545,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -8563,12 +8563,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -8581,7 +8581,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8599,7 +8599,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8617,7 +8617,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8635,7 +8635,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -8653,7 +8653,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8671,12 +8671,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -8689,7 +8689,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8707,7 +8707,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -8725,7 +8725,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -8743,7 +8743,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -8761,7 +8761,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -8779,12 +8779,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.0.419
+    version: "9.2.0.419"
     engine:
   device:
     type: smartphone
@@ -8797,7 +8797,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -8815,7 +8815,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -8833,12 +8833,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -8851,7 +8851,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -8869,7 +8869,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -8887,12 +8887,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -8910,7 +8910,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -8923,7 +8923,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8941,12 +8941,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -8959,7 +8959,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8977,12 +8977,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3
+    version: "2.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -8995,12 +8995,12 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 4.0.1
+    version: "4.0.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.0.419
+    version: "9.2.0.419"
     engine: WebKit
   device:
     type: smartphone
@@ -9013,12 +9013,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.133
+    version: "18.0.1025.133"
     engine: WebKit
   device:
     type: smartphone
@@ -9031,7 +9031,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9049,7 +9049,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9067,7 +9067,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9085,12 +9085,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -9103,7 +9103,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9121,12 +9121,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 16.0.1212.64462
+    version: "16.0.1212.64462"
     engine: Blink
   device:
     type: smartphone
@@ -9144,7 +9144,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 7.9.0.94
+    version: "7.9.0.94"
     engine:
   device:
     type: smartphone
@@ -9157,7 +9157,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9175,12 +9175,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -9193,7 +9193,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9216,7 +9216,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -9229,7 +9229,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9247,7 +9247,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9265,12 +9265,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -9283,12 +9283,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -9301,7 +9301,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9319,7 +9319,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9337,7 +9337,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -9355,7 +9355,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -9373,7 +9373,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -9396,7 +9396,7 @@
     type: browser
     name: Sailfish Browser
     short_name: SA
-    version: 1.0
+    version: "1.0"
     engine: Gecko
   device:
     type: smartphone
@@ -9409,7 +9409,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9427,7 +9427,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9450,7 +9450,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -9463,12 +9463,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 3.1.0.403
+    version: "3.1.0.403"
     engine: WebKit
   device:
     type: smartphone
@@ -9481,12 +9481,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.5.418
+    version: "9.7.5.418"
     engine: WebKit
   device:
     type: smartphone
@@ -9499,12 +9499,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -9517,7 +9517,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9535,7 +9535,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9553,7 +9553,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9571,7 +9571,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -9589,12 +9589,12 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.5.3.246
+    version: "8.5.3.246"
     engine: WebKit
   device:
     type: smartphone
@@ -9607,7 +9607,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -9625,7 +9625,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9643,12 +9643,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.1.1.420
+    version: "9.1.1.420"
     engine:
   device:
     type: smartphone
@@ -9661,7 +9661,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -9679,7 +9679,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9697,7 +9697,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9715,12 +9715,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.0.282
+    version: "9.0.0.282"
     engine: WebKit
   device:
     type: smartphone
@@ -9733,12 +9733,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine:
   device:
     type: smartphone
@@ -9751,7 +9751,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9769,7 +9769,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9787,7 +9787,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9805,7 +9805,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9823,7 +9823,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9841,7 +9841,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9859,12 +9859,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.2.394
+    version: "9.5.2.394"
     engine: WebKit
   device:
     type: smartphone
@@ -9877,7 +9877,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Android Browser
@@ -9895,7 +9895,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9913,12 +9913,12 @@
   os:
     name: YunOs
     short_name: YNS
-    version: 1.0.0.3
+    version: "1.0.0.3"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 4.0
+    version: "4.0"
     engine: WebKit
   device:
     type: smartphone
@@ -9931,7 +9931,7 @@
   os:
     name: YunOs
     short_name: YNS
-    version: 1.0.0.3
+    version: "1.0.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9949,7 +9949,7 @@
   os:
     name: YunOs
     short_name: YNS
-    version: 1.5.1.18
+    version: "1.5.1.18"
   client:
     type: browser
     name: Android Browser
@@ -9967,7 +9967,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9985,7 +9985,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10003,7 +10003,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10021,12 +10021,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -10039,7 +10039,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10057,7 +10057,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10075,7 +10075,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10093,12 +10093,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -10111,12 +10111,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -10129,12 +10129,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -10147,7 +10147,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10165,12 +10165,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -10183,12 +10183,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -10201,12 +10201,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 27.0.1453.90
+    version: "27.0.1453.90"
     engine: WebKit
   device:
     type: smartphone
@@ -10219,7 +10219,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -10237,12 +10237,12 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.6.428
+    version: "9.7.6.428"
     engine: WebKit
   device:
     type: smartphone
@@ -10255,7 +10255,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10273,7 +10273,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10291,12 +10291,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -10309,7 +10309,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10327,7 +10327,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10345,7 +10345,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -10363,12 +10363,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine:
   device:
     type: smartphone
@@ -10381,7 +10381,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10399,7 +10399,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10417,7 +10417,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -10435,7 +10435,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10453,7 +10453,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Android Browser
@@ -10471,7 +10471,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10489,7 +10489,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Android Browser
@@ -10507,12 +10507,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -10525,7 +10525,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10543,12 +10543,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -10561,7 +10561,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -10579,12 +10579,12 @@
   os:
     name: Brew
     short_name: BMP
-    version: 1.0.4
+    version: "1.0.4"
   client:
     type: browser
     name: NetFront
     short_name: NF
-    version: 4.2
+    version: "4.2"
     engine: NetFront
   device:
     type: smartphone
@@ -10597,7 +10597,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10615,7 +10615,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10633,12 +10633,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -10651,7 +10651,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10669,7 +10669,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10687,7 +10687,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10710,7 +10710,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -10723,7 +10723,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -10741,7 +10741,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10759,7 +10759,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10777,7 +10777,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10795,7 +10795,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10813,7 +10813,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10831,7 +10831,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10849,7 +10849,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -10867,12 +10867,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -10885,12 +10885,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -10903,7 +10903,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10921,7 +10921,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10939,12 +10939,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -10957,12 +10957,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -10975,7 +10975,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10993,7 +10993,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11011,7 +11011,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11029,7 +11029,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11047,7 +11047,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11065,7 +11065,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -11083,12 +11083,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -11101,7 +11101,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -11119,12 +11119,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -11137,7 +11137,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -11155,12 +11155,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -11173,7 +11173,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11191,7 +11191,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11209,12 +11209,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -11227,7 +11227,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11245,12 +11245,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -11263,12 +11263,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -11281,7 +11281,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7
+    version: "7"
   client:
     type: browser
     name: Android Browser
@@ -11317,7 +11317,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11335,7 +11335,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11353,7 +11353,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11371,12 +11371,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -11389,7 +11389,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11407,7 +11407,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11425,7 +11425,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11443,7 +11443,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -11461,7 +11461,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11479,7 +11479,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11497,7 +11497,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11515,7 +11515,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11533,12 +11533,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -11551,7 +11551,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11569,12 +11569,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -11587,7 +11587,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -11605,12 +11605,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 29.0.1547.72
+    version: "29.0.1547.72"
     engine: Blink
   device:
     type: smartphone
@@ -11623,7 +11623,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -11641,7 +11641,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11659,7 +11659,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -11677,7 +11677,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9.0.0
+    version: "9.0.0"
   client:
     type: browser
     name: Android Browser
@@ -11695,7 +11695,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9.9.9
+    version: "9.9.9"
   client:
     type: browser
     name: Android Browser
@@ -11713,7 +11713,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11731,7 +11731,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -11751,7 +11751,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.3.0.326
+    version: "9.3.0.326"
     engine:
   device:
     type: smartphone
@@ -11764,12 +11764,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -11782,12 +11782,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.0.419
+    version: "9.2.0.419"
     engine:
   device:
     type: smartphone
@@ -11800,7 +11800,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11818,12 +11818,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.480
+    version: "9.5.0.480"
     engine:
   device:
     type: smartphone
@@ -11836,7 +11836,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11854,7 +11854,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11872,12 +11872,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.0.460
+    version: "9.4.0.460"
     engine:
   device:
     type: smartphone
@@ -11890,12 +11890,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -11908,12 +11908,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -11926,12 +11926,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -11944,12 +11944,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -11962,7 +11962,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11980,7 +11980,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11998,7 +11998,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12016,12 +12016,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -12034,7 +12034,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -12052,12 +12052,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -12070,7 +12070,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12088,7 +12088,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12106,7 +12106,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -12124,12 +12124,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -12142,7 +12142,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12160,7 +12160,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12178,12 +12178,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -12196,7 +12196,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -12214,12 +12214,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -12232,7 +12232,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -12250,7 +12250,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -12268,12 +12268,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.9.2.373
+    version: "8.9.2.373"
     engine:
   device:
     type: smartphone
@@ -12291,7 +12291,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -12304,12 +12304,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -12322,7 +12322,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12340,7 +12340,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -12358,12 +12358,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -12381,7 +12381,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -12394,12 +12394,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.359
+    version: "8.8.1.359"
     engine:
   device:
     type: smartphone
@@ -12412,7 +12412,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -12430,7 +12430,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -12448,7 +12448,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12466,7 +12466,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -12484,7 +12484,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -12502,7 +12502,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12520,7 +12520,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12538,7 +12538,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12556,7 +12556,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12574,7 +12574,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12592,7 +12592,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12610,7 +12610,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12628,7 +12628,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12646,7 +12646,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12664,7 +12664,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.0.1
+    version: "2.0.1"
   client:
     type: browser
     name: Android Browser
@@ -12682,7 +12682,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12700,7 +12700,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -12718,7 +12718,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -12736,7 +12736,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -12754,7 +12754,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -12772,12 +12772,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -12790,7 +12790,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1.2
+    version: "10.1.2"
   client:
     type: browser
     name: Android Browser
@@ -12808,7 +12808,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12826,12 +12826,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -12844,7 +12844,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12862,12 +12862,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 27.0.1453.90
+    version: "27.0.1453.90"
     engine: WebKit
   device:
     type: smartphone
@@ -12880,7 +12880,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12898,7 +12898,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -12916,7 +12916,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -12934,7 +12934,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -12952,7 +12952,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12970,7 +12970,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12988,7 +12988,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -13006,12 +13006,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1631.1
+    version: "31.0.1631.1"
     engine: Blink
   device:
     type: smartphone
@@ -13024,12 +13024,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -13042,12 +13042,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -13060,12 +13060,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13078,12 +13078,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -13096,12 +13096,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -13114,12 +13114,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -13132,7 +13132,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -13150,12 +13150,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -13168,12 +13168,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: smartphone
@@ -13186,7 +13186,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -13204,12 +13204,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -13222,12 +13222,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13240,7 +13240,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -13258,7 +13258,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -13276,12 +13276,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -13294,7 +13294,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -13312,7 +13312,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -13330,7 +13330,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -13348,12 +13348,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13366,12 +13366,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 6.5.3.5
+    version: "6.5.3.5"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: smartphone
@@ -13384,7 +13384,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -13402,7 +13402,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -13420,7 +13420,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -13438,7 +13438,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -13456,7 +13456,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -13474,7 +13474,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.5
+    version: "1.5"
   client:
     type: browser
     name: Android Browser
@@ -13492,7 +13492,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -13510,7 +13510,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -13528,7 +13528,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -13546,7 +13546,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -13564,7 +13564,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -13582,7 +13582,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -13600,7 +13600,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -13618,11 +13618,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: mobile app
     name: AndroidDownloadManager
-    version: 4.1.1
+    version: "4.1.1"
   device:
     type: smartphone
     brand: MR
@@ -13634,12 +13634,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -13652,7 +13652,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -13670,7 +13670,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -13688,7 +13688,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -13706,7 +13706,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -13724,12 +13724,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.1.494
+    version: "9.5.1.494"
     engine:
   device:
     type: smartphone
@@ -13742,12 +13742,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -13760,12 +13760,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13778,12 +13778,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13796,12 +13796,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -13814,12 +13814,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -13832,12 +13832,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -13850,12 +13850,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -13868,12 +13868,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.135
+    version: "33.0.1750.135"
     engine: Blink
   device:
     type: smartphone
@@ -13886,12 +13886,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13904,12 +13904,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13922,12 +13922,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -13940,12 +13940,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: smartphone
@@ -13958,12 +13958,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.2.404
+    version: "9.6.2.404"
     engine: WebKit
   device:
     type: smartphone
@@ -13976,7 +13976,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -13994,7 +13994,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -14012,7 +14012,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -14030,7 +14030,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -14048,7 +14048,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -14066,7 +14066,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14084,7 +14084,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14102,7 +14102,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14120,7 +14120,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14138,7 +14138,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14156,7 +14156,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14174,7 +14174,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -14192,7 +14192,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14210,7 +14210,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14228,7 +14228,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -14246,7 +14246,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14264,12 +14264,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 27.0.1453.90
+    version: "27.0.1453.90"
     engine: WebKit
   device:
     type: smartphone
@@ -14282,12 +14282,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: smartphone
@@ -14300,12 +14300,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 25.0.1364.169
+    version: "25.0.1364.169"
     engine: WebKit
   device:
     type: smartphone
@@ -14320,7 +14320,7 @@
     type: browser
     name: Obigo
     short_name: OB
-    version: QO3C
+    version: "QO3C"
     engine:
   device:
     type: smartphone
@@ -14333,7 +14333,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14351,7 +14351,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -14369,12 +14369,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -14387,7 +14387,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -14405,12 +14405,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -14423,7 +14423,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -14441,7 +14441,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -14459,7 +14459,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14477,7 +14477,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -14500,7 +14500,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.3.0.326
+    version: "9.3.0.326"
     engine:
   device:
     type: smartphone
@@ -14518,7 +14518,7 @@
     type: browser
     name: Nokia Ovi Browser
     short_name: NV
-    version: 3.9.0.0.22
+    version: "3.9.0.0.22"
     engine: Gecko
   device:
     type: smartphone
@@ -14531,12 +14531,12 @@
   os:
     name: Symbian^3
     short_name: SY3
-    version: Anna
+    version: "Anna"
   client:
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.3.1.37
+    version: "7.3.1.37"
     engine: WebKit
   device:
     type: smartphone
@@ -14554,7 +14554,7 @@
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 8.3.1.4
+    version: "8.3.1.4"
     engine: WebKit
   device:
     type: smartphone
@@ -14567,12 +14567,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -14585,12 +14585,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 10.0
+    version: "10.0"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 12.0
+    version: "12.0"
     engine: Edge
   device:
     type: smartphone
@@ -14603,12 +14603,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -14621,12 +14621,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -14639,12 +14639,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -14657,12 +14657,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -14675,12 +14675,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -14693,12 +14693,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: smartphone
@@ -14711,12 +14711,12 @@
   os:
     name: Symbian OS Series 60
     short_name: S60
-    version: 3.0
+    version: "3.0"
   client:
     type: browser
     name: Nokia OSS Browser
     short_name: 'NO'
-    version: 3.0
+    version: "3.0"
     engine:
   device:
     type: smartphone
@@ -14734,7 +14734,7 @@
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 7.2.6.4
+    version: "7.2.6.4"
     engine: WebKit
   device:
     type: smartphone
@@ -14752,7 +14752,7 @@
     type: browser
     name: Nokia Browser
     short_name: NB
-    version: 8.5.0
+    version: "8.5.0"
     engine: WebKit
   device:
     type: smartphone
@@ -14765,12 +14765,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.8.0.435
+    version: "9.8.0.435"
     engine: WebKit
   device:
     type: smartphone
@@ -14783,12 +14783,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.1599.82
+    version: "30.0.1599.82"
     engine: Blink
   device:
     type: smartphone
@@ -14801,7 +14801,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -14849,7 +14849,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14867,7 +14867,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14885,7 +14885,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14903,7 +14903,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -14921,12 +14921,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -14939,12 +14939,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -14957,7 +14957,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -14975,7 +14975,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -14993,7 +14993,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15011,7 +15011,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -15029,7 +15029,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -15047,7 +15047,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -15065,7 +15065,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15083,7 +15083,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -15101,12 +15101,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -15119,7 +15119,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15137,7 +15137,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15155,7 +15155,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -15173,12 +15173,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -15191,7 +15191,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -15209,7 +15209,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -15227,12 +15227,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -15245,7 +15245,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -15263,7 +15263,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15283,7 +15283,7 @@
     type: browser
     name: Obigo
     short_name: OB
-    version: Q05A
+    version: "Q05A"
     engine:
   device:
     type: smartphone
@@ -15301,7 +15301,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.6
+    version: "7.6"
     engine: Trident
   device:
     type: smartphone
@@ -15314,12 +15314,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.135
+    version: "33.0.1750.135"
     engine: Blink
   device:
     type: smartphone
@@ -15332,7 +15332,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15350,7 +15350,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -15368,12 +15368,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -15386,12 +15386,12 @@
   os:
     name: palmOS
     short_name: POS
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Xiino
     short_name: XI
-    version: 1.0.9
+    version: "1.0.9"
     engine:
   device:
     type: smartphone
@@ -15404,7 +15404,7 @@
   os:
     name: palmOS
     short_name: POS
-    version: 5.4.9
+    version: "5.4.9"
   client: null
   device:
     type: smartphone
@@ -15422,7 +15422,7 @@
     type: browser
     name: Palm Blazer
     short_name: PL
-    version: 4.3
+    version: "4.3"
     engine:
   device:
     type: smartphone
@@ -15435,12 +15435,12 @@
   os:
     name: webOS
     short_name: WOS
-    version: 1.4.5
+    version: "1.4.5"
   client:
     type: browser
     name: wOSBrowser
     short_name: WO
-    version: 1.4.5
+    version: "1.4.5"
     engine: WebKit
   device:
     type: smartphone
@@ -15453,12 +15453,12 @@
   os:
     name: webOS
     short_name: WOS
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Palm Pre
     short_name: PR
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -15476,7 +15476,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -15512,7 +15512,7 @@
     type: browser
     name: Palm Blazer
     short_name: PL
-    version: 4.3
+    version: "4.3"
     engine:
   device:
     type: smartphone
@@ -15530,7 +15530,7 @@
     type: browser
     name: Palm WebPro
     short_name: PW
-    version: 3.5
+    version: "3.5"
     engine:
   device:
     type: smartphone
@@ -15548,7 +15548,7 @@
     type: browser
     name: Palm Blazer
     short_name: PL
-    version: 4.0
+    version: "4.0"
     engine:
   device:
     type: smartphone
@@ -15561,7 +15561,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15579,7 +15579,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15597,7 +15597,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15615,7 +15615,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -15633,7 +15633,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15651,12 +15651,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -15669,7 +15669,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -15687,12 +15687,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -15705,12 +15705,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -15723,7 +15723,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -15741,12 +15741,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -15759,7 +15759,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -15777,7 +15777,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -15795,7 +15795,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -15813,7 +15813,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -15833,7 +15833,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 4.2.15645
+    version: "4.2.15645"
     engine: Presto
   device:
     type: smartphone
@@ -15846,12 +15846,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -15864,7 +15864,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -15884,7 +15884,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 4.2.18216
+    version: "4.2.18216"
     engine: Presto
   device:
     type: smartphone
@@ -15897,7 +15897,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -15915,12 +15915,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -15933,7 +15933,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -15951,7 +15951,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -15969,7 +15969,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0
+    version: "4.0"
   client:
     type: browser
     name: Android Browser
@@ -15987,12 +15987,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16005,12 +16005,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16023,7 +16023,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -16041,12 +16041,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16059,12 +16059,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -16081,7 +16081,7 @@
   client:
     type: mediaplayer
     name: FlyCast
-    version: 1.34
+    version: "1.34"
   device:
     type: smartphone
     brand: RM
@@ -16098,7 +16098,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.1.0.216
+    version: "8.1.0.216"
     engine:
   device:
     type: smartphone
@@ -16111,12 +16111,12 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 11.10
+    version: "11.10"
   client:
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 4.5.33868
+    version: "4.5.33868"
     engine: Presto
   device:
     type: smartphone
@@ -16129,7 +16129,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 4.0.0
+    version: "4.0.0"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16147,7 +16147,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 5.0.0.681
+    version: "5.0.0.681"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16165,7 +16165,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 7.1.0.714
+    version: "7.1.0.714"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16183,7 +16183,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 6.0.0.448
+    version: "6.0.0.448"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16201,7 +16201,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 7.1.0.755
+    version: "7.1.0.755"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16219,7 +16219,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 10.1.0.4651
+    version: "10.1.0.4651"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16237,7 +16237,7 @@
   os:
     name: BlackBerry OS
     short_name: BLB
-    version: 10.1.0.4633
+    version: "10.1.0.4633"
   client:
     type: browser
     name: BlackBerry Browser
@@ -16255,12 +16255,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -16273,7 +16273,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -16291,12 +16291,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -16309,7 +16309,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -16327,12 +16327,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -16345,12 +16345,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -16363,12 +16363,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -16381,7 +16381,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -16399,7 +16399,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -16417,12 +16417,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -16435,12 +16435,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16453,12 +16453,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16471,12 +16471,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.514
+    version: "33.0.1750.514"
     engine: Blink
   device:
     type: smartphone
@@ -16489,12 +16489,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -16507,7 +16507,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -16525,7 +16525,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -16543,7 +16543,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -16561,12 +16561,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Baidu Browser
     short_name: BD
-    version: 4.3.16.2
+    version: "4.3.16.2"
     engine: WebKit
   device:
     type: smartphone
@@ -16579,12 +16579,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16597,12 +16597,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16615,12 +16615,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16633,12 +16633,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16651,12 +16651,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16669,12 +16669,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.58
+    version: "32.0.1700.58"
     engine: Blink
   device:
     type: smartphone
@@ -16687,12 +16687,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -16705,12 +16705,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -16723,12 +16723,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -16741,11 +16741,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: mobile app
     name: WeChat
-    version: 5.2.380
+    version: "5.2.380"
   device:
     type: smartphone
     brand: SA
@@ -16757,12 +16757,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16775,12 +16775,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16793,12 +16793,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -16811,12 +16811,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -16829,12 +16829,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -16847,12 +16847,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -16865,11 +16865,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: mediaplayer
     name: Stagefright
-    version: 1.2
+    version: "1.2"
   device:
     type: smartphone
     brand: SA
@@ -16881,12 +16881,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -16899,7 +16899,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -16917,12 +16917,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16935,12 +16935,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16953,12 +16953,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -16971,12 +16971,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -16989,7 +16989,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -17007,7 +17007,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -17025,7 +17025,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -17043,12 +17043,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17061,7 +17061,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Maxthon
@@ -17079,7 +17079,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17097,7 +17097,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17115,12 +17115,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.133
+    version: "18.0.1025.133"
     engine: WebKit
   device:
     type: smartphone
@@ -17133,7 +17133,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -17151,7 +17151,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17169,7 +17169,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17187,12 +17187,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -17205,7 +17205,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -17223,7 +17223,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17241,12 +17241,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17259,7 +17259,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17277,7 +17277,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17295,7 +17295,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17313,12 +17313,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 19.0.1340.69721
+    version: "19.0.1340.69721"
     engine: Blink
   device:
     type: smartphone
@@ -17331,12 +17331,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17349,7 +17349,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -17367,7 +17367,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -17385,7 +17385,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -17403,12 +17403,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -17421,7 +17421,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17439,7 +17439,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17457,12 +17457,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Baidu Browser
     short_name: BD
-    version: 4.2.13.3
+    version: "4.2.13.3"
     engine: WebKit
   device:
     type: smartphone
@@ -17475,12 +17475,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -17493,12 +17493,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -17511,12 +17511,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17529,12 +17529,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17547,12 +17547,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17565,12 +17565,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17583,12 +17583,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -17601,12 +17601,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -17619,12 +17619,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17637,12 +17637,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -17655,12 +17655,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17673,12 +17673,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17691,12 +17691,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -17709,7 +17709,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -17727,7 +17727,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17745,7 +17745,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17763,7 +17763,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17781,7 +17781,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -17799,12 +17799,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine:
   device:
     type: smartphone
@@ -17817,7 +17817,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -17835,7 +17835,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17853,7 +17853,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -17871,12 +17871,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -17889,12 +17889,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: smartphone
@@ -17907,12 +17907,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -17925,7 +17925,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -17943,7 +17943,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -17961,7 +17961,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -17979,7 +17979,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.3
+    version: "4.2.3"
   client:
     type: browser
     name: Android Browser
@@ -17997,12 +17997,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -18015,12 +18015,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: smartphone
@@ -18033,7 +18033,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18051,7 +18051,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18069,7 +18069,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18089,7 +18089,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.3.3
+    version: "6.2.3.3"
     engine:
   device:
     type: smartphone
@@ -18104,7 +18104,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.0.30281
+    version: "7.0.30281"
     engine: Presto
   device:
     type: smartphone
@@ -18119,7 +18119,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: smartphone
@@ -18134,7 +18134,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 4.1
+    version: "4.1"
     engine: NetFront
   device:
     type: smartphone
@@ -18147,7 +18147,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.1.0
+    version: "7.1.0"
   client:
     type: browser
     name: Android Browser
@@ -18165,7 +18165,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -18183,7 +18183,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -18206,7 +18206,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -18224,7 +18224,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 9.5
+    version: "9.5"
     engine: Presto
   device:
     type: smartphone
@@ -18242,7 +18242,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -18255,7 +18255,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18273,12 +18273,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -18291,7 +18291,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18309,7 +18309,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18327,7 +18327,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18345,12 +18345,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -18363,7 +18363,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18381,12 +18381,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -18399,12 +18399,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -18417,12 +18417,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -18435,7 +18435,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18453,12 +18453,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -18471,7 +18471,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -18489,7 +18489,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18507,7 +18507,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18525,12 +18525,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -18543,12 +18543,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -18561,12 +18561,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -18579,7 +18579,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18597,12 +18597,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.0
+    version: "8.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: smartphone
@@ -18615,12 +18615,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: smartphone
@@ -18633,7 +18633,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18651,7 +18651,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18669,7 +18669,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -18687,7 +18687,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18705,7 +18705,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -18723,7 +18723,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -18741,7 +18741,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18759,7 +18759,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18777,7 +18777,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18795,7 +18795,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18813,7 +18813,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -18831,7 +18831,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18849,12 +18849,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -18867,12 +18867,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -18885,7 +18885,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -18903,12 +18903,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -18921,7 +18921,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -18939,12 +18939,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.1.401
+    version: "9.6.1.401"
     engine:
   device:
     type: smartphone
@@ -18957,12 +18957,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -18975,7 +18975,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -18993,7 +18993,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.9
+    version: "4.0.9"
   client:
     type: browser
     name: Android Browser
@@ -19011,7 +19011,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -19029,7 +19029,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -19047,7 +19047,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -19065,7 +19065,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19083,7 +19083,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -19101,7 +19101,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -19119,7 +19119,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -19137,7 +19137,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19155,12 +19155,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -19173,12 +19173,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -19191,12 +19191,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -19209,12 +19209,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -19227,7 +19227,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -19245,12 +19245,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -19263,12 +19263,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -19281,7 +19281,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Android Browser
@@ -19299,12 +19299,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -19317,7 +19317,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19335,7 +19335,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -19353,12 +19353,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 29.0.1547.72
+    version: "29.0.1547.72"
     engine: Blink
   device:
     type: smartphone
@@ -19371,7 +19371,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -19389,7 +19389,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -19407,7 +19407,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -19445,7 +19445,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 0.8
+    version: "0.8"
     engine:
   device:
     type: smartphone
@@ -19460,7 +19460,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 0.8
+    version: "0.8"
     engine:
   device:
     type: smartphone
@@ -19475,7 +19475,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 1.0
+    version: "1.0"
     engine:
   device:
     type: smartphone
@@ -19490,7 +19490,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 0.8
+    version: "0.8"
     engine:
   device:
     type: smartphone
@@ -19505,7 +19505,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 1.0
+    version: "1.0"
     engine:
   device:
     type: smartphone
@@ -19518,12 +19518,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -19536,12 +19536,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -19554,7 +19554,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19572,12 +19572,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 2.0
+    version: "2.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 3.0
+    version: "3.0"
     engine: WebKit
   device:
     type: smartphone
@@ -19590,12 +19590,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 2.0
+    version: "2.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 3.0
+    version: "3.0"
     engine: WebKit
   device:
     type: smartphone
@@ -19608,12 +19608,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 2.0
+    version: "2.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 3.0
+    version: "3.0"
     engine: WebKit
   device:
     type: smartphone
@@ -19626,7 +19626,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19644,7 +19644,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19662,7 +19662,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19680,7 +19680,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19698,7 +19698,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19716,7 +19716,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -19734,7 +19734,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -19752,7 +19752,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -19770,7 +19770,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19788,7 +19788,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19806,7 +19806,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19824,7 +19824,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -19842,7 +19842,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -19860,7 +19860,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19878,7 +19878,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -19896,7 +19896,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -19914,7 +19914,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19932,7 +19932,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19950,7 +19950,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19968,7 +19968,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -19986,7 +19986,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -20004,12 +20004,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -20027,7 +20027,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -20040,7 +20040,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -20058,12 +20058,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 2.0
+    version: "2.0"
     engine: WebKit
   device:
     type: smartphone
@@ -20076,11 +20076,11 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -20092,11 +20092,11 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -20108,11 +20108,11 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -20124,11 +20124,11 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -20140,12 +20140,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.0.347
+    version: "9.4.0.347"
     engine: WebKit
   device:
     type: smartphone
@@ -20158,7 +20158,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20176,7 +20176,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20194,12 +20194,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 2.0
+    version: "2.0"
     engine: WebKit
   device:
     type: smartphone
@@ -20212,11 +20212,11 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: mediaplayer
     name: NexPlayer
-    version: 3.0
+    version: "3.0"
   device:
     type: smartphone
     brand: SA
@@ -20228,12 +20228,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 2.0
+    version: "2.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 3.0
+    version: "3.0"
     engine: WebKit
   device:
     type: smartphone
@@ -20246,12 +20246,12 @@
   os:
     name: Bada
     short_name: SBA
-    version: 1.0
+    version: "1.0"
   client:
     type: browser
     name: Dolphin
     short_name: DF
-    version: 2.0
+    version: "2.0"
     engine: WebKit
   device:
     type: smartphone
@@ -20264,12 +20264,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.5
+    version: "7.5"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type: smartphone
@@ -20284,7 +20284,7 @@
     type: browser
     name: Jasmine
     short_name: JS
-    version: 1.0
+    version: "1.0"
     engine:
   device:
     type: smartphone
@@ -20297,12 +20297,12 @@
   os:
     name: Brew
     short_name: BMP
-    version: 3.1.5
+    version: "3.1.5"
   client:
     type: browser
     name: Polaris
     short_name: PO
-    version: 6.2
+    version: "6.2"
     engine:
   device:
     type: smartphone
@@ -20315,7 +20315,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -20335,7 +20335,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.3.8
+    version: "6.2.3.8"
     engine:
   device:
     type: smartphone
@@ -20348,7 +20348,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20368,7 +20368,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.4
+    version: "3.4"
     engine: NetFront
   device:
     type: smartphone
@@ -20381,7 +20381,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -20399,12 +20399,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -20417,12 +20417,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -20435,7 +20435,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -20453,12 +20453,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -20471,12 +20471,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -20489,7 +20489,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20507,7 +20507,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -20525,7 +20525,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -20543,7 +20543,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -20561,7 +20561,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20579,12 +20579,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -20597,7 +20597,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -20615,7 +20615,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -20633,7 +20633,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -20651,7 +20651,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20674,7 +20674,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 3.2.0.340
+    version: "3.2.0.340"
     engine:
   device:
     type: smartphone
@@ -20687,12 +20687,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: smartphone
@@ -20705,7 +20705,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -20723,7 +20723,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -20741,12 +20741,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -20759,12 +20759,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -20779,7 +20779,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 4.1
+    version: "4.1"
     engine: NetFront
   device:
     type: smartphone
@@ -20794,7 +20794,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: smartphone
@@ -20807,7 +20807,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -20825,7 +20825,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -20845,7 +20845,7 @@
     type: browser
     name: NetFront
     short_name: NF
-    version: 3.5
+    version: "3.5"
     engine: NetFront
   device:
     type: smartphone
@@ -20858,7 +20858,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -20876,7 +20876,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -20894,7 +20894,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -20912,7 +20912,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -20930,7 +20930,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20948,7 +20948,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -20966,7 +20966,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -20984,7 +20984,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -21002,12 +21002,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -21020,12 +21020,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -21038,7 +21038,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -21056,7 +21056,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -21074,7 +21074,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21092,7 +21092,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -21110,7 +21110,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21128,7 +21128,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21146,7 +21146,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21164,7 +21164,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -21182,7 +21182,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -21200,7 +21200,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -21218,7 +21218,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -21236,12 +21236,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -21254,7 +21254,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -21272,7 +21272,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -21290,7 +21290,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -21308,7 +21308,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21326,7 +21326,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -21344,7 +21344,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -21362,7 +21362,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -21380,12 +21380,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -21398,12 +21398,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.62
+    version: "34.0.1847.62"
     engine: Blink
   device:
     type: smartphone
@@ -21416,7 +21416,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21434,12 +21434,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.308
+    version: "18.0.1025.308"
     engine: WebKit
   device:
     type: smartphone
@@ -21452,7 +21452,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -21470,12 +21470,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -21488,12 +21488,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -21506,12 +21506,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -21524,12 +21524,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -21542,7 +21542,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -21560,7 +21560,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -21578,7 +21578,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -21596,7 +21596,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -21614,12 +21614,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 6.5
+    version: "6.5"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 6.0
+    version: "6.0"
     engine: Trident
   device:
     type: smartphone
@@ -21632,7 +21632,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21650,7 +21650,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21668,7 +21668,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21686,7 +21686,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21704,7 +21704,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21722,7 +21722,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21740,7 +21740,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21758,7 +21758,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21776,7 +21776,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.2
+    version: "2.3.2"
   client:
     type: browser
     name: Android Browser
@@ -21794,7 +21794,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.2
+    version: "2.3.2"
   client:
     type: browser
     name: Android Browser
@@ -21812,7 +21812,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.2
+    version: "2.3.2"
   client:
     type: browser
     name: Android Browser
@@ -21830,7 +21830,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21848,7 +21848,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21866,7 +21866,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21884,12 +21884,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -21902,7 +21902,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -21920,7 +21920,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21938,7 +21938,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21956,7 +21956,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -21974,12 +21974,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.359
+    version: "8.8.1.359"
     engine:
   device:
     type: smartphone
@@ -21992,7 +21992,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22010,7 +22010,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22028,7 +22028,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22046,7 +22046,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22064,7 +22064,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22082,7 +22082,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22100,7 +22100,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22118,7 +22118,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22136,7 +22136,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22154,7 +22154,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22172,7 +22172,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22190,7 +22190,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22208,7 +22208,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22226,7 +22226,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22244,7 +22244,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22262,7 +22262,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22280,12 +22280,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: NetFront Life
     short_name: NL
-    version: 2.3
+    version: "2.3"
     engine: NetFront
   device:
     type: smartphone
@@ -22298,7 +22298,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22316,7 +22316,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22334,7 +22334,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22352,7 +22352,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22370,7 +22370,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.2
+    version: "2.3.2"
   client:
     type: browser
     name: Android Browser
@@ -22388,7 +22388,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22406,7 +22406,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22424,7 +22424,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22442,7 +22442,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22460,7 +22460,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22478,7 +22478,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22496,7 +22496,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22514,7 +22514,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -22532,7 +22532,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22550,7 +22550,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -22568,7 +22568,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22586,7 +22586,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -22604,7 +22604,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22622,7 +22622,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22640,7 +22640,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -22658,7 +22658,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client: null
   device:
     type: smartphone
@@ -22671,7 +22671,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22689,7 +22689,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22707,7 +22707,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -22725,7 +22725,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -22743,7 +22743,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -22761,7 +22761,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22779,7 +22779,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22797,7 +22797,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22815,7 +22815,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -22833,7 +22833,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -22851,7 +22851,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -22869,7 +22869,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -22887,7 +22887,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -22905,12 +22905,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 27.0.1453.90
+    version: "27.0.1453.90"
     engine: WebKit
   device:
     type: smartphone
@@ -22925,7 +22925,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 4.2.19039
+    version: "4.2.19039"
     engine: Presto
   device:
     type: smartphone
@@ -22938,12 +22938,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -22956,7 +22956,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -22974,12 +22974,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.9.2.373
+    version: "8.9.2.373"
     engine:
   device:
     type: smartphone
@@ -22992,7 +22992,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -23010,7 +23010,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23028,7 +23028,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -23046,7 +23046,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -23064,7 +23064,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -23082,7 +23082,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -23100,7 +23100,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23118,7 +23118,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23136,7 +23136,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23154,12 +23154,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -23172,12 +23172,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -23190,12 +23190,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 35.0.1916.141
+    version: "35.0.1916.141"
     engine: Blink
   device:
     type: smartphone
@@ -23208,12 +23208,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 35.0.1916.141
+    version: "35.0.1916.141"
     engine: Blink
   device:
     type: smartphone
@@ -23226,7 +23226,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23244,7 +23244,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23262,7 +23262,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23280,7 +23280,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23298,7 +23298,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23316,7 +23316,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23334,7 +23334,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23352,12 +23352,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -23375,7 +23375,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -23388,7 +23388,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23406,7 +23406,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -23424,12 +23424,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -23442,12 +23442,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -23460,12 +23460,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -23478,7 +23478,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -23496,12 +23496,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -23514,12 +23514,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -23532,12 +23532,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -23550,12 +23550,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.128
+    version: "36.0.1985.128"
     engine: Blink
   device:
     type: smartphone
@@ -23568,12 +23568,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -23586,12 +23586,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 35.0.1916.122
+    version: "35.0.1916.122"
     engine: Blink
   device:
     type: smartphone
@@ -23604,12 +23604,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.135
+    version: "36.0.1985.135"
     engine: Blink
   device:
     type: smartphone
@@ -23622,12 +23622,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.9.2.467
+    version: "9.9.2.467"
     engine: WebKit
   device:
     type: smartphone
@@ -23640,12 +23640,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -23658,7 +23658,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -23676,7 +23676,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -23694,7 +23694,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -23712,7 +23712,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23730,7 +23730,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23748,7 +23748,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23766,7 +23766,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23784,7 +23784,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23802,7 +23802,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23820,7 +23820,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23838,7 +23838,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23856,7 +23856,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23874,7 +23874,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23892,7 +23892,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23910,7 +23910,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -23928,7 +23928,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23946,7 +23946,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -23964,12 +23964,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -23982,12 +23982,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -24000,7 +24000,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24018,7 +24018,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24036,7 +24036,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24054,12 +24054,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.135
+    version: "33.0.1750.135"
     engine: Blink
   device:
     type: smartphone
@@ -24072,12 +24072,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: smartphone
@@ -24090,12 +24090,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -24108,12 +24108,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -24126,12 +24126,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -24144,12 +24144,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.135
+    version: "36.0.1985.135"
     engine: Blink
   device:
     type: smartphone
@@ -24162,12 +24162,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -24180,12 +24180,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -24198,12 +24198,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.135
+    version: "36.0.1985.135"
     engine: Blink
   device:
     type: smartphone
@@ -24216,7 +24216,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -24234,7 +24234,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24252,7 +24252,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24270,7 +24270,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24288,7 +24288,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24306,7 +24306,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24324,7 +24324,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -24342,7 +24342,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24360,7 +24360,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24378,7 +24378,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24396,7 +24396,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24414,12 +24414,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -24432,7 +24432,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24450,12 +24450,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -24468,7 +24468,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24486,7 +24486,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24504,7 +24504,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -24522,7 +24522,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24540,7 +24540,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24558,7 +24558,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24576,12 +24576,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -24594,7 +24594,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24612,12 +24612,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -24630,7 +24630,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24648,7 +24648,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24666,12 +24666,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -24684,12 +24684,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.359
+    version: "8.8.1.359"
     engine:
   device:
     type: smartphone
@@ -24702,12 +24702,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -24720,12 +24720,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -24738,7 +24738,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24756,7 +24756,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24774,7 +24774,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24792,7 +24792,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24810,12 +24810,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Maxthon
     short_name: MX
-    version: 4.1.5.2000
+    version: "4.1.5.2000"
     engine: WebKit
   device:
     type: smartphone
@@ -24828,7 +24828,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24846,7 +24846,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -24864,12 +24864,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -24882,12 +24882,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.135
+    version: "36.0.1985.135"
     engine: Blink
   device:
     type: smartphone
@@ -24900,12 +24900,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.3
+    version: "4.4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 36.0.1985.131
+    version: "36.0.1985.131"
     engine: Blink
   device:
     type: smartphone
@@ -24918,12 +24918,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -24936,12 +24936,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -24954,12 +24954,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 35.0.1916.141
+    version: "35.0.1916.141"
     engine: Blink
   device:
     type: smartphone
@@ -24972,7 +24972,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -24990,7 +24990,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25008,7 +25008,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25026,12 +25026,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -25044,7 +25044,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25062,7 +25062,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25080,7 +25080,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25098,12 +25098,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -25116,7 +25116,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -25134,7 +25134,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -25152,7 +25152,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -25170,7 +25170,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -25188,12 +25188,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.5.0.360
+    version: "9.5.0.360"
     engine: WebKit
   device:
     type: smartphone
@@ -25206,7 +25206,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25224,7 +25224,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -25242,7 +25242,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -25260,7 +25260,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -25278,12 +25278,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -25296,12 +25296,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: smartphone
@@ -25314,7 +25314,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -25332,12 +25332,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: smartphone
@@ -25350,12 +25350,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -25368,7 +25368,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -25386,12 +25386,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -25404,12 +25404,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -25422,12 +25422,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25440,7 +25440,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -25458,7 +25458,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -25476,12 +25476,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25494,12 +25494,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25512,12 +25512,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25530,12 +25530,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.9.2.467
+    version: "9.9.2.467"
     engine: WebKit
   device:
     type: smartphone
@@ -25548,7 +25548,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -25566,12 +25566,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -25584,7 +25584,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -25602,7 +25602,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -25620,7 +25620,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -25638,7 +25638,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -25656,12 +25656,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -25674,12 +25674,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25692,12 +25692,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25710,12 +25710,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 37.0.2062.117
+    version: "37.0.2062.117"
     engine: Blink
   device:
     type: smartphone
@@ -25728,12 +25728,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25746,12 +25746,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -25764,12 +25764,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25782,12 +25782,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.9.2.467
+    version: "9.9.2.467"
     engine: WebKit
   device:
     type: smartphone
@@ -25800,12 +25800,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.2171.59
+    version: "39.0.2171.59"
     engine: Blink
   device:
     type: smartphone
@@ -25818,12 +25818,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.2171.93
+    version: "39.0.2171.93"
     engine: Blink
   device:
     type: smartphone
@@ -25836,12 +25836,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4
+    version: "4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 38.0.2125.102
+    version: "38.0.2125.102"
     engine: Blink
   device:
     type: smartphone
@@ -25854,12 +25854,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 40.0.2214.89
+    version: "40.0.2214.89"
     engine: Blink
   device:
     type: smartphone
@@ -25872,7 +25872,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -25890,12 +25890,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.1599.92
+    version: "30.0.1599.92"
     engine: Blink
   device:
     type: smartphone
@@ -25908,12 +25908,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -25926,12 +25926,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -25944,12 +25944,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: smartphone
@@ -25982,12 +25982,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.3.2.349
+    version: "9.3.2.349"
     engine:
   device:
     type: smartphone
@@ -26000,12 +26000,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.9
+    version: "4.0.9"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.7.0.315
+    version: "8.7.0.315"
     engine:
   device:
     type: smartphone
@@ -26018,7 +26018,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26036,12 +26036,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 37.0.2062.117
+    version: "37.0.2062.117"
     engine: Blink
   device:
     type: smartphone
@@ -26054,7 +26054,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -26072,7 +26072,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26090,7 +26090,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26108,7 +26108,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26126,7 +26126,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -26144,7 +26144,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26162,7 +26162,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26180,7 +26180,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26198,7 +26198,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -26216,7 +26216,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -26234,7 +26234,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -26252,7 +26252,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26270,7 +26270,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26288,7 +26288,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -26306,7 +26306,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26324,7 +26324,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26342,7 +26342,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -26360,7 +26360,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Android Browser
@@ -26378,7 +26378,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26396,7 +26396,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -26414,7 +26414,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26432,12 +26432,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -26450,7 +26450,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26468,7 +26468,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -26486,7 +26486,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26504,12 +26504,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -26522,7 +26522,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -26540,12 +26540,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -26558,7 +26558,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26576,12 +26576,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.3.413
+    version: "9.6.3.413"
     engine: WebKit
   device:
     type: smartphone
@@ -26594,7 +26594,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -26612,12 +26612,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -26630,7 +26630,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -26648,12 +26648,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.0.276
+    version: "8.6.0.276"
     engine:
   device:
     type: smartphone
@@ -26668,7 +26668,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.1.0.291
+    version: "9.1.0.291"
     engine:
   device:
     type: smartphone
@@ -26691,7 +26691,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -26711,7 +26711,7 @@
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 10.10
+    version: "10.10"
     engine: Presto
   device:
     type: smartphone
@@ -26739,7 +26739,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.11
+    version: "7.11"
     engine: Trident
   device:
     type: smartphone
@@ -26752,7 +26752,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -26770,7 +26770,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -26788,7 +26788,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -26811,7 +26811,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -26824,7 +26824,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.3
+    version: "2.2.3"
   client:
     type: browser
     name: Android Browser
@@ -26842,7 +26842,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -26860,12 +26860,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.0.2.389
+    version: "9.0.2.389"
     engine:
   device:
     type: smartphone
@@ -26883,7 +26883,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.1.32052
+    version: "7.1.32052"
     engine: Presto
   device:
     type: smartphone
@@ -26898,7 +26898,7 @@
     type: browser
     name: Obigo
     short_name: OB
-    version: Q03C
+    version: "Q03C"
     engine:
   device:
     type: smartphone
@@ -26911,7 +26911,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -26929,7 +26929,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -26947,7 +26947,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Maxthon
@@ -26970,7 +26970,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 8.12
+    version: "8.12"
     engine: Trident
   device:
     type: smartphone
@@ -26983,12 +26983,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27001,7 +27001,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -27019,7 +27019,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -27037,7 +27037,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -27055,7 +27055,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27073,12 +27073,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -27091,12 +27091,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27109,12 +27109,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -27127,7 +27127,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27145,7 +27145,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -27163,7 +27163,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27181,12 +27181,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.2.0.242
+    version: "8.2.0.242"
     engine:
   device:
     type: smartphone
@@ -27199,12 +27199,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -27217,7 +27217,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27235,12 +27235,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -27253,7 +27253,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27271,12 +27271,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -27289,12 +27289,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27307,12 +27307,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27325,7 +27325,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -27343,12 +27343,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: smartphone
@@ -27361,7 +27361,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -27379,7 +27379,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27397,12 +27397,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: smartphone
@@ -27415,7 +27415,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -27433,12 +27433,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -27451,7 +27451,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27469,12 +27469,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: MIUI Browser
     short_name: MU
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -27487,12 +27487,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: MIUI Browser
     short_name: MU
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -27505,12 +27505,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.5.418
+    version: "9.7.5.418"
     engine: WebKit
   device:
     type: smartphone
@@ -27523,12 +27523,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: MIUI Browser
     short_name: MU
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -27541,12 +27541,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.7.5.418
+    version: "9.7.5.418"
     engine: WebKit
   device:
     type: smartphone
@@ -27559,12 +27559,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: MIUI Browser
     short_name: MU
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -27577,12 +27577,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.94
+    version: "32.0.1700.94"
     engine: Blink
   device:
     type: smartphone
@@ -27595,12 +27595,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: MIUI Browser
     short_name: MU
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type: smartphone
@@ -27613,12 +27613,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 7.9.3.103
+    version: "7.9.3.103"
     engine: WebKit
   device:
     type: smartphone
@@ -27631,7 +27631,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27649,7 +27649,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -27667,7 +27667,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27685,7 +27685,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27703,7 +27703,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27721,12 +27721,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27739,7 +27739,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27757,7 +27757,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -27775,12 +27775,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: smartphone
@@ -27793,7 +27793,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27811,12 +27811,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.3.272
+    version: "8.8.3.272"
     engine: WebKit
   device:
     type: smartphone
@@ -27829,7 +27829,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -27847,7 +27847,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -27865,7 +27865,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -27883,7 +27883,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -27901,12 +27901,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -27919,7 +27919,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -27937,7 +27937,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -27955,12 +27955,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: smartphone
@@ -27973,7 +27973,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -27991,7 +27991,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -28009,7 +28009,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -28027,12 +28027,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: smartphone
@@ -28045,12 +28045,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: smartphone
@@ -28065,7 +28065,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.4.1.377
+    version: "9.4.1.377"
     engine:
   device:
     type: smartphone
@@ -28078,7 +28078,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -28096,7 +28096,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -28114,7 +28114,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -28132,7 +28132,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -28150,12 +28150,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.243
+    version: "8.8.1.243"
     engine:
   device:
     type: smartphone
@@ -28168,12 +28168,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Baidu Browser
     short_name: BD
-    version: 4.0.7.10
+    version: "4.0.7.10"
     engine: WebKit
   device:
     type: smartphone
@@ -28186,7 +28186,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0
+    version: "4.0"
   client:
     type: browser
     name: Android Browser
@@ -28204,7 +28204,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -28222,7 +28222,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -28240,7 +28240,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -28258,7 +28258,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -28276,12 +28276,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: smartphone
@@ -28294,7 +28294,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -28312,7 +28312,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -28330,7 +28330,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -28348,7 +28348,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -28366,7 +28366,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -28384,7 +28384,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -9,7 +9,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 20.0
+    version: "20.0"
     engine: Gecko
   device:
     type: tablet
@@ -27,7 +27,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: 26.0
+    version: "26.0"
     engine: Gecko
   device:
     type: tablet
@@ -40,7 +40,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -58,7 +58,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -76,7 +76,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -94,7 +94,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -112,7 +112,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -130,7 +130,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -148,7 +148,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -171,7 +171,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -184,7 +184,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -202,7 +202,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -220,7 +220,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -238,7 +238,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -256,7 +256,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -274,7 +274,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -292,7 +292,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -310,7 +310,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -328,7 +328,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -382,12 +382,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.1599.92
+    version: "30.0.1599.92"
     engine: Blink
   device:
     type: tablet
@@ -418,7 +418,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -436,7 +436,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -454,7 +454,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -472,12 +472,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -490,7 +490,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -508,12 +508,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 14.10.2062.12160.01
+    version: "14.10.2062.12160.01"
     engine: Blink
   device:
     type: tablet
@@ -526,12 +526,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -544,7 +544,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -562,7 +562,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -580,7 +580,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -598,7 +598,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -616,12 +616,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.1599.92
+    version: "30.0.1599.92"
     engine: Blink
   device:
     type: tablet
@@ -634,12 +634,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -652,7 +652,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -670,12 +670,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 35.0.1916.138
+    version: "35.0.1916.138"
     engine: Blink
   device:
     type: tablet
@@ -688,12 +688,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 39.0.2171.59
+    version: "39.0.2171.59"
     engine: Blink
   device:
     type: tablet
@@ -706,7 +706,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -724,7 +724,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -742,7 +742,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -760,7 +760,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -778,7 +778,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -796,12 +796,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 38.0.2125.114
+    version: "38.0.2125.114"
     engine: Blink
   device:
     type: tablet
@@ -814,12 +814,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.5.2.240
+    version: "8.5.2.240"
     engine: WebKit
   device:
     type: tablet
@@ -832,12 +832,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 14.0.1074.54070
+    version: "14.0.1074.54070"
     engine: Presto
   device:
     type: tablet
@@ -850,12 +850,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.514
+    version: "9.6.0.514"
     engine:
   device:
     type: tablet
@@ -868,7 +868,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Android Browser
@@ -886,12 +886,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 38.0.2125.114
+    version: "38.0.2125.114"
     engine: Blink
   device:
     type: tablet
@@ -904,7 +904,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -922,7 +922,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -940,7 +940,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -958,7 +958,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -976,7 +976,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -994,7 +994,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1012,7 +1012,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -1030,7 +1030,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1048,7 +1048,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1066,7 +1066,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1084,7 +1084,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1102,7 +1102,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1120,7 +1120,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1138,7 +1138,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1156,7 +1156,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1174,12 +1174,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.3.1.344
+    version: "9.3.1.344"
     engine: WebKit
   device:
     type: tablet
@@ -1192,7 +1192,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1210,12 +1210,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.1599.82
+    version: "30.0.1599.82"
     engine: Blink
   device:
     type: tablet
@@ -1228,7 +1228,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1246,7 +1246,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1264,12 +1264,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -1282,12 +1282,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -1300,12 +1300,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -1318,12 +1318,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -1336,7 +1336,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1354,12 +1354,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -1372,7 +1372,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1390,12 +1390,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -1408,7 +1408,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1426,7 +1426,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1444,12 +1444,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -1462,7 +1462,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -1480,7 +1480,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1498,7 +1498,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1516,12 +1516,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -1534,7 +1534,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -1552,7 +1552,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1570,12 +1570,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -1588,7 +1588,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.0.1
+    version: "3.0.1"
   client:
     type: browser
     name: Android Browser
@@ -1606,7 +1606,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -1624,7 +1624,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1642,7 +1642,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1660,7 +1660,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -1678,7 +1678,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1696,7 +1696,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1714,7 +1714,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1732,12 +1732,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -1750,12 +1750,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -1768,7 +1768,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1786,7 +1786,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1804,12 +1804,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -1822,7 +1822,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -1840,12 +1840,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -1858,7 +1858,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1876,7 +1876,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1894,7 +1894,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1912,7 +1912,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1930,7 +1930,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1948,7 +1948,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -1966,12 +1966,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -1984,7 +1984,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 4.3.2
+    version: "4.3.2"
   client:
     type: browser
     name: Mobile Safari
@@ -2002,7 +2002,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 5.1.1
+    version: "5.1.1"
   client:
     type: browser
     name: Mobile Safari
@@ -2020,12 +2020,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6.0.1
+    version: "6.0.1"
   client:
     type: browser
     name: Chrome Mobile iOS
     short_name: CI
-    version: 31.0.1650.18
+    version: "31.0.1650.18"
     engine: WebKit
   device:
     type: tablet
@@ -2038,12 +2038,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6.0.1
+    version: "6.0.1"
   client:
     type: browser
     name: Mercury
     short_name: ME
-    version: 8.0.1
+    version: "8.0.1"
     engine: WebKit
   device:
     type: tablet
@@ -2056,12 +2056,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 6.0.1
+    version: "6.0.1"
   client:
     type: browser
     name: Mercury
     short_name: ME
-    version: 8.1
+    version: "8.1"
     engine: WebKit
   device:
     type: tablet
@@ -2074,12 +2074,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: Chrome Mobile iOS
     short_name: CI
-    version: 32.0.1700.20
+    version: "32.0.1700.20"
     engine: WebKit
   device:
     type: tablet
@@ -2092,12 +2092,12 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version: 7.0
+    version: "7.0"
     engine: WebKit
   device:
     type: tablet
@@ -2110,7 +2110,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: 7.0.4
+    version: "7.0.4"
   client:
     type: browser
     name: Mobile Safari
@@ -2154,7 +2154,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2172,7 +2172,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2190,12 +2190,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2208,7 +2208,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2226,12 +2226,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -2244,12 +2244,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2262,12 +2262,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -2280,7 +2280,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2298,7 +2298,7 @@
   os:
     name: Android
     short_name: AND
-    version: 1.6
+    version: "1.6"
   client:
     type: browser
     name: Android Browser
@@ -2316,7 +2316,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2334,7 +2334,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2352,7 +2352,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -2370,7 +2370,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2388,7 +2388,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -2406,12 +2406,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2424,7 +2424,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2442,12 +2442,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -2460,12 +2460,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -2478,7 +2478,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2496,7 +2496,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2514,7 +2514,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -2532,12 +2532,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2550,12 +2550,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -2568,12 +2568,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2586,7 +2586,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -2604,12 +2604,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2622,7 +2622,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2640,7 +2640,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -2658,12 +2658,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -2676,7 +2676,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2694,12 +2694,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -2712,7 +2712,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2730,7 +2730,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -2748,12 +2748,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -2766,12 +2766,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -2784,12 +2784,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -2802,12 +2802,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -2820,12 +2820,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2838,7 +2838,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -2856,12 +2856,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -2874,12 +2874,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 36.0.1985.131
+    version: "36.0.1985.131"
     engine: Blink
   device:
     type: tablet
@@ -2892,12 +2892,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 16.0.1212.65583
+    version: "16.0.1212.65583"
     engine: Blink
   device:
     type: tablet
@@ -2910,12 +2910,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -2928,12 +2928,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -2946,12 +2946,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.1599.92
+    version: "30.0.1599.92"
     engine: Blink
   device:
     type: tablet
@@ -2964,12 +2964,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -2982,7 +2982,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3000,7 +3000,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3018,7 +3018,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3036,12 +3036,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3.1
+    version: "4.3.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 35.0.1916.117
+    version: "35.0.1916.117"
     engine: Blink
   device:
     type: tablet
@@ -3054,7 +3054,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3072,12 +3072,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -3090,7 +3090,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3108,7 +3108,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3126,12 +3126,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -3144,7 +3144,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3162,7 +3162,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3180,12 +3180,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 19.0.1340.69721
+    version: "19.0.1340.69721"
     engine: Blink
   device:
     type: tablet
@@ -3198,12 +3198,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.2.0.308
+    version: "9.2.0.308"
     engine:
   device:
     type: tablet
@@ -3216,7 +3216,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3234,7 +3234,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3252,7 +3252,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3270,7 +3270,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3288,7 +3288,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.1
+    version: "2.2.1"
   client:
     type: browser
     name: Android Browser
@@ -3306,7 +3306,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -3324,7 +3324,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -3342,12 +3342,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -3360,12 +3360,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -3378,7 +3378,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -3396,7 +3396,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.1.0
+    version: "7.1.0"
   client:
     type: browser
     name: Android Browser
@@ -3414,7 +3414,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3432,7 +3432,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3450,7 +3450,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3468,12 +3468,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -3486,7 +3486,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3504,7 +3504,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -3522,7 +3522,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3540,7 +3540,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3558,12 +3558,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.3.0.143
+    version: "8.3.0.143"
     engine: WebKit
   device:
     type: tablet
@@ -3576,7 +3576,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3594,7 +3594,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -3612,12 +3612,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -3630,12 +3630,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -3648,7 +3648,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.1
+    version: "2.3.1"
   client:
     type: browser
     name: Android Browser
@@ -3666,7 +3666,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3684,7 +3684,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3702,7 +3702,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3720,7 +3720,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -3738,7 +3738,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3756,12 +3756,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -3774,7 +3774,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3792,7 +3792,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3810,7 +3810,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3828,7 +3828,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3846,7 +3846,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3864,12 +3864,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: tablet
@@ -3882,7 +3882,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3900,7 +3900,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3918,7 +3918,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -3936,7 +3936,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3954,7 +3954,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -3972,7 +3972,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -3990,7 +3990,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4008,7 +4008,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4026,7 +4026,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4044,7 +4044,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -4062,7 +4062,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.1
+    version: "2.1"
   client:
     type: browser
     name: Android Browser
@@ -4080,7 +4080,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4098,7 +4098,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4116,7 +4116,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4134,7 +4134,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4152,7 +4152,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4170,7 +4170,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4188,7 +4188,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4206,12 +4206,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -4224,12 +4224,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -4242,7 +4242,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4260,7 +4260,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4278,7 +4278,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4296,7 +4296,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4314,7 +4314,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4332,7 +4332,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4350,7 +4350,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -4368,7 +4368,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4386,7 +4386,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4404,7 +4404,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4422,7 +4422,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4440,12 +4440,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -4458,7 +4458,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4476,7 +4476,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4494,7 +4494,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4512,7 +4512,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4530,7 +4530,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4548,7 +4548,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4566,12 +4566,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -4584,7 +4584,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4602,7 +4602,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4620,7 +4620,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4638,7 +4638,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4656,7 +4656,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4674,7 +4674,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4692,7 +4692,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4710,12 +4710,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -4728,7 +4728,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4746,7 +4746,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -4764,7 +4764,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4782,7 +4782,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4800,7 +4800,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4818,7 +4818,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -4836,12 +4836,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.170
+    version: "33.0.1750.170"
     engine: Blink
   device:
     type: tablet
@@ -4854,12 +4854,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -4872,7 +4872,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4890,7 +4890,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2.2
+    version: "2.2.2"
   client:
     type: browser
     name: Android Browser
@@ -4908,7 +4908,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -4926,12 +4926,12 @@
   os:
     name: Windows Phone
     short_name: WPH
-    version: 7.0
+    version: "7.0"
   client:
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 7.0
+    version: "7.0"
     engine: Trident
   device:
     type: tablet
@@ -4944,7 +4944,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4962,7 +4962,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -4980,7 +4980,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -4998,7 +4998,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -5016,7 +5016,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -5034,7 +5034,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -5052,7 +5052,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5070,7 +5070,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -5088,12 +5088,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -5106,7 +5106,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -5124,12 +5124,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -5142,7 +5142,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -5160,7 +5160,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2
+    version: "4.2"
   client:
     type: browser
     name: Android Browser
@@ -5178,12 +5178,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -5196,12 +5196,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -5214,7 +5214,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -5232,7 +5232,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1.0
+    version: "10.1.0"
   client:
     type: browser
     name: Android Browser
@@ -5250,12 +5250,12 @@
   os:
     name: Android
     short_name: AND
-    version: 5.0
+    version: "5.0"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 38.0.2125.509
+    version: "38.0.2125.509"
     engine: Blink
   device:
     type: tablet
@@ -5268,7 +5268,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -5286,12 +5286,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5304,12 +5304,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -5322,12 +5322,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5340,12 +5340,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -5358,7 +5358,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -5376,7 +5376,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -5394,12 +5394,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 25.0.1364.169
+    version: "25.0.1364.169"
     engine: WebKit
   device:
     type: tablet
@@ -5412,12 +5412,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5430,12 +5430,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5448,7 +5448,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -5466,7 +5466,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -5484,12 +5484,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5507,7 +5507,7 @@
     type: browser
     name: wOSBrowser
     short_name: WO
-    version: 3.0.5
+    version: "3.0.5"
     engine: WebKit
   device:
     type: tablet
@@ -5520,7 +5520,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.1
+    version: "3.2.1"
   client:
     type: browser
     name: Android Browser
@@ -5538,7 +5538,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Android Browser
@@ -5556,7 +5556,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -5574,7 +5574,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -5592,7 +5592,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -5610,7 +5610,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5628,12 +5628,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -5646,12 +5646,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -5664,7 +5664,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5682,12 +5682,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -5700,12 +5700,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -5718,12 +5718,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -5736,7 +5736,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5754,7 +5754,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5772,7 +5772,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -5790,7 +5790,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -5808,12 +5808,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -5831,7 +5831,7 @@
     type: browser
     name: Kindle Browser
     short_name: KI
-    version: 2.0
+    version: "2.0"
     engine: NetFront
   device:
     type: tablet
@@ -5849,7 +5849,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 1.0.22.153
+    version: "1.0.22.153"
     engine: Blink
   device:
     type: tablet
@@ -5867,7 +5867,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.10
+    version: "3.10"
     engine: Blink
   device:
     type: tablet
@@ -5880,12 +5880,12 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.4
+    version: "2.3.4"
   client:
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 1.0.22.153
+    version: "1.0.22.153"
     engine: Blink
   device:
     type: tablet
@@ -5898,12 +5898,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -5916,7 +5916,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -5939,7 +5939,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.8
+    version: "3.8"
     engine: Blink
   device:
     type: tablet
@@ -5952,7 +5952,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -5975,7 +5975,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.12
+    version: "3.12"
     engine: Blink
   device:
     type: tablet
@@ -5993,7 +5993,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.12
+    version: "3.12"
     engine: Blink
   device:
     type: tablet
@@ -6006,12 +6006,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.42
+    version: "31.0.1650.42"
     engine: Blink
   device:
     type: tablet
@@ -6024,12 +6024,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -6042,12 +6042,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 2.2
+    version: "2.2"
     engine: Blink
   device:
     type: tablet
@@ -6065,7 +6065,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.12
+    version: "3.12"
     engine: Blink
   device:
     type: tablet
@@ -6083,7 +6083,7 @@
     type: browser
     name: Mobile Silk
     short_name: MS
-    version: 3.8
+    version: "3.8"
     engine: Blink
   device:
     type: tablet
@@ -6096,12 +6096,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -6114,12 +6114,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -6132,12 +6132,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: tablet
@@ -6155,7 +6155,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -6168,7 +6168,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6186,12 +6186,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -6204,7 +6204,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6222,7 +6222,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6240,12 +6240,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -6258,7 +6258,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -6276,12 +6276,12 @@
   os:
     name: Android
     short_name: AND
-    version: 3.0.1
+    version: "3.0.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 16.0.1212.63780
+    version: "16.0.1212.63780"
     engine: Blink
   device:
     type: tablet
@@ -6294,7 +6294,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6312,7 +6312,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6330,7 +6330,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6348,7 +6348,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6366,7 +6366,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6384,7 +6384,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6402,12 +6402,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -6420,7 +6420,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6438,7 +6438,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6456,7 +6456,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6474,12 +6474,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: tablet
@@ -6492,12 +6492,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -6510,7 +6510,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6528,7 +6528,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6546,7 +6546,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6564,7 +6564,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6582,7 +6582,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6600,7 +6600,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6618,7 +6618,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6636,7 +6636,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6654,7 +6654,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6672,7 +6672,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6690,7 +6690,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6708,7 +6708,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6726,7 +6726,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -6744,7 +6744,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6762,7 +6762,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6780,7 +6780,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6798,7 +6798,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6816,7 +6816,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6834,7 +6834,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6852,7 +6852,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -6870,7 +6870,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6888,7 +6888,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6906,7 +6906,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -6924,7 +6924,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6942,12 +6942,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.1599.82
+    version: "30.0.1599.82"
     engine: Blink
   device:
     type: tablet
@@ -6960,12 +6960,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: tablet
@@ -6978,7 +6978,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -6996,7 +6996,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7014,7 +7014,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7032,7 +7032,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7050,7 +7050,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7068,7 +7068,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7086,7 +7086,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -7104,7 +7104,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7122,7 +7122,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7140,7 +7140,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7158,7 +7158,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7176,12 +7176,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -7194,7 +7194,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7212,12 +7212,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -7230,7 +7230,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7248,12 +7248,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -7266,12 +7266,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -7284,7 +7284,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7302,12 +7302,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -7320,7 +7320,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7338,7 +7338,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7356,7 +7356,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7374,7 +7374,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7392,7 +7392,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7410,7 +7410,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7428,12 +7428,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -7446,7 +7446,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7464,7 +7464,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7482,7 +7482,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7500,7 +7500,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7518,7 +7518,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7536,7 +7536,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7554,7 +7554,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7572,7 +7572,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -7590,7 +7590,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7608,7 +7608,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7626,7 +7626,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7644,12 +7644,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -7662,7 +7662,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7680,7 +7680,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7698,12 +7698,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: tablet
@@ -7716,7 +7716,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7734,7 +7734,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7752,7 +7752,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7770,7 +7770,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -7788,7 +7788,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -7806,12 +7806,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -7824,7 +7824,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7842,7 +7842,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7860,7 +7860,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7878,7 +7878,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7896,7 +7896,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -7914,7 +7914,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7932,7 +7932,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7950,7 +7950,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -7968,7 +7968,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.0.1
+    version: "3.0.1"
   client:
     type: browser
     name: Android Browser
@@ -7986,7 +7986,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -8004,7 +8004,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -8022,7 +8022,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8040,12 +8040,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 18.0.1290.67495
+    version: "18.0.1290.67495"
     engine: Blink
   device:
     type: tablet
@@ -8058,7 +8058,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8076,7 +8076,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -8094,7 +8094,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8112,7 +8112,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.2
+    version: "3.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8130,7 +8130,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -8148,7 +8148,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2.2
+    version: "3.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8166,12 +8166,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -8184,7 +8184,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -8202,12 +8202,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -8220,7 +8220,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -8238,7 +8238,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.3
+    version: "2.3.3"
   client:
     type: browser
     name: Android Browser
@@ -8256,12 +8256,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 14.0.1074.58201
+    version: "14.0.1074.58201"
     engine: Presto
   device:
     type: tablet
@@ -8274,7 +8274,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8292,7 +8292,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8310,7 +8310,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8328,7 +8328,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8346,7 +8346,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8364,12 +8364,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: tablet
@@ -8382,12 +8382,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: tablet
@@ -8400,7 +8400,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8418,7 +8418,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8436,7 +8436,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8454,7 +8454,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8472,12 +8472,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.6.1.262
+    version: "8.6.1.262"
     engine: WebKit
   device:
     type: tablet
@@ -8490,12 +8490,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -8508,7 +8508,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8526,12 +8526,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 19.0.1340.69721
+    version: "19.0.1340.69721"
     engine: Blink
   device:
     type: tablet
@@ -8544,7 +8544,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8562,7 +8562,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8580,7 +8580,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8598,7 +8598,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8616,7 +8616,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8634,11 +8634,11 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: mobile app
     name: AndroidDownloadManager
-    version: 4.1.1
+    version: "4.1.1"
   device:
     type: tablet
     brand: PL
@@ -8650,7 +8650,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8668,7 +8668,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8686,7 +8686,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -8704,7 +8704,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8722,7 +8722,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8740,7 +8740,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -8758,7 +8758,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8776,7 +8776,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8794,7 +8794,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8812,7 +8812,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8830,7 +8830,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8848,7 +8848,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -8866,7 +8866,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -8884,12 +8884,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -8902,7 +8902,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8920,7 +8920,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8938,12 +8938,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -8956,7 +8956,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8974,7 +8974,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -8992,7 +8992,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9010,7 +9010,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9028,12 +9028,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -9046,7 +9046,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9064,7 +9064,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9082,7 +9082,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9100,7 +9100,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9118,7 +9118,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.1
+    version: "2.3.1"
   client:
     type: browser
     name: Android Browser
@@ -9136,7 +9136,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -9154,7 +9154,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9172,7 +9172,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9190,7 +9190,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9208,12 +9208,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -9226,12 +9226,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -9244,7 +9244,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9262,7 +9262,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9280,12 +9280,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
   device:
     type: tablet
@@ -9298,7 +9298,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9316,12 +9316,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 27.0.1453.90
+    version: "27.0.1453.90"
     engine: WebKit
   device:
     type: tablet
@@ -9334,7 +9334,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9352,7 +9352,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9370,12 +9370,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9388,7 +9388,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9406,7 +9406,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9424,12 +9424,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9442,12 +9442,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9460,12 +9460,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9478,12 +9478,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9496,7 +9496,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9514,7 +9514,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9532,7 +9532,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -9550,7 +9550,7 @@
   os:
     name: BlackBerry Tablet OS
     short_name: QNX
-    version: 2.1.0
+    version: "2.1.0"
   client:
     type: browser
     name: BlackBerry Browser
@@ -9568,7 +9568,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -9586,12 +9586,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9604,12 +9604,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -9622,12 +9622,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -9640,12 +9640,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -9658,7 +9658,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9676,7 +9676,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9694,12 +9694,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 25.0.1364.123
+    version: "25.0.1364.123"
     engine: WebKit
   device:
     type: tablet
@@ -9712,7 +9712,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -9730,12 +9730,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -9748,12 +9748,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9766,12 +9766,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9784,12 +9784,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -9802,7 +9802,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.2
+    version: "2.2"
   client:
     type: browser
     name: Android Browser
@@ -9820,7 +9820,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -9838,7 +9838,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10
+    version: "10"
   client:
     type: browser
     name: Android Browser
@@ -9856,7 +9856,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9.0.0
+    version: "9.0.0"
   client:
     type: browser
     name: Android Browser
@@ -9874,7 +9874,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -9892,7 +9892,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -9910,7 +9910,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -9928,7 +9928,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9946,7 +9946,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9964,7 +9964,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -9982,7 +9982,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10000,7 +10000,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 10.1
+    version: "10.1"
   client:
     type: browser
     name: Android Browser
@@ -10018,7 +10018,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10036,7 +10036,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10054,12 +10054,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -10072,7 +10072,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10090,7 +10090,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10108,7 +10108,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10126,7 +10126,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10144,7 +10144,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10162,7 +10162,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10180,7 +10180,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10198,12 +10198,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -10216,7 +10216,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10234,7 +10234,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10252,7 +10252,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10270,7 +10270,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10288,12 +10288,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.359
+    version: "8.8.1.359"
     engine:
   device:
     type: tablet
@@ -10306,12 +10306,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 20.0.1396.73172
+    version: "20.0.1396.73172"
     engine: Blink
   device:
     type: tablet
@@ -10324,7 +10324,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -10342,7 +10342,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10360,7 +10360,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10378,7 +10378,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -10396,7 +10396,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10414,12 +10414,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.132
+    version: "33.0.1750.132"
     engine: Blink
   device:
     type: tablet
@@ -10432,7 +10432,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10450,7 +10450,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10468,12 +10468,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -10486,7 +10486,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10504,7 +10504,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10522,12 +10522,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.8.1.359
+    version: "8.8.1.359"
     engine:
   device:
     type: tablet
@@ -10540,7 +10540,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10558,12 +10558,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -10576,12 +10576,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -10594,7 +10594,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10612,7 +10612,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -10630,7 +10630,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10648,7 +10648,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -10666,12 +10666,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -10684,12 +10684,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -10702,12 +10702,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.166
+    version: "33.0.1750.166"
     engine: Blink
   device:
     type: tablet
@@ -10720,12 +10720,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -10738,12 +10738,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10756,12 +10756,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10774,12 +10774,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -10792,12 +10792,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -10810,7 +10810,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -10828,7 +10828,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -10846,7 +10846,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -10864,7 +10864,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -10882,12 +10882,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10900,12 +10900,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10918,12 +10918,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10936,12 +10936,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -10954,12 +10954,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: tablet
@@ -10972,12 +10972,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 35.0.1916.141
+    version: "35.0.1916.141"
     engine: Blink
   device:
     type: tablet
@@ -10990,12 +10990,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -11008,12 +11008,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -11026,12 +11026,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -11044,12 +11044,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11062,7 +11062,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Android Browser
@@ -11080,7 +11080,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -11098,7 +11098,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11116,12 +11116,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 9.6.0.378
+    version: "9.6.0.378"
     engine: WebKit
   device:
     type: tablet
@@ -11134,7 +11134,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11152,7 +11152,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11170,7 +11170,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11188,7 +11188,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -11206,7 +11206,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11224,7 +11224,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11242,7 +11242,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11260,12 +11260,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8
+    version: "8"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 10.0
+    version: "10.0"
     engine: Trident
   device:
     type: tablet
@@ -11278,7 +11278,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -11296,12 +11296,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -11314,7 +11314,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.1
+    version: "3.1"
   client:
     type: browser
     name: Android Browser
@@ -11332,7 +11332,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11350,7 +11350,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11368,12 +11368,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 31.0.1650.59
+    version: "31.0.1650.59"
     engine: Blink
   device:
     type: tablet
@@ -11386,7 +11386,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11404,7 +11404,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11422,12 +11422,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11440,12 +11440,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -11458,12 +11458,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -11476,12 +11476,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.2
+    version: "4.1.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 18.0.1025.166
+    version: "18.0.1025.166"
     engine: WebKit
   device:
     type: tablet
@@ -11494,12 +11494,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.3
+    version: "4.3"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 19.0.1340.69721
+    version: "19.0.1340.69721"
     engine: Blink
   device:
     type: tablet
@@ -11512,12 +11512,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -11530,12 +11530,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11548,12 +11548,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 37.0.2062.117
+    version: "37.0.2062.117"
     engine: Blink
   device:
     type: tablet
@@ -11566,12 +11566,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Opera
     short_name: OP
-    version: 21.0.1437.74904
+    version: "21.0.1437.74904"
     engine: Blink
   device:
     type: tablet
@@ -11584,7 +11584,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11602,7 +11602,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11620,12 +11620,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11638,12 +11638,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11656,7 +11656,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11674,7 +11674,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -11692,7 +11692,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11710,7 +11710,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11728,7 +11728,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11746,7 +11746,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11764,7 +11764,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11782,12 +11782,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11800,7 +11800,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11818,12 +11818,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11836,12 +11836,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11854,12 +11854,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -11872,7 +11872,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -11890,7 +11890,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11908,7 +11908,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11926,12 +11926,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 33.0.1750.136
+    version: "33.0.1750.136"
     engine: Blink
   device:
     type: tablet
@@ -11944,12 +11944,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
   device:
     type: tablet
@@ -11962,7 +11962,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -11980,7 +11980,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -11998,7 +11998,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12016,7 +12016,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12034,12 +12034,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -12052,7 +12052,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12070,7 +12070,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12088,7 +12088,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12106,7 +12106,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12124,7 +12124,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12142,7 +12142,7 @@
   os:
     name: Android
     short_name: AND
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Android Browser
@@ -12160,7 +12160,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12178,7 +12178,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12196,12 +12196,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.1599.82
+    version: "30.0.1599.82"
     engine: Blink
   device:
     type: tablet
@@ -12214,12 +12214,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 28.0.1500.94
+    version: "28.0.1500.94"
     engine: Blink
   device:
     type: tablet
@@ -12232,12 +12232,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 34.0.1847.114
+    version: "34.0.1847.114"
     engine: Blink
   device:
     type: tablet
@@ -12250,12 +12250,12 @@
   os:
     name: Windows
     short_name: WIN
-    version: 8.1
+    version: "8.1"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 11.0
+    version: "11.0"
     engine: Trident
   device:
     type: tablet
@@ -12268,7 +12268,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
   client:
     type: browser
     name: Android Browser
@@ -12286,12 +12286,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 32.0.1700.99
+    version: "32.0.1700.99"
     engine: Blink
   device:
     type: tablet
@@ -12304,7 +12304,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12322,7 +12322,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3
+    version: "2.3"
   client:
     type: browser
     name: Android Browser
@@ -12340,7 +12340,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12358,7 +12358,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -12376,7 +12376,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12394,7 +12394,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -12412,7 +12412,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12430,7 +12430,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12448,7 +12448,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12466,12 +12466,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 16.0.1212.65583
+    version: "16.0.1212.65583"
     engine: Blink
   device:
     type: tablet
@@ -12484,7 +12484,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -12502,7 +12502,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -12520,7 +12520,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -12538,7 +12538,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -9,7 +9,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 10.30
+    version: "10.30"
     engine: Presto
   device:
     type: tv
@@ -27,7 +27,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 10.60
+    version: "10.60"
     engine: Presto
   device:
     type: tv
@@ -61,7 +61,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -79,7 +79,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -97,7 +97,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -115,7 +115,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -133,7 +133,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 4.0
+    version: "4.0"
     engine: Presto
   device:
     type: tv
@@ -151,7 +151,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -177,12 +177,12 @@
   os:
     name: Google TV
     short_name: GTV
-    version: 3.2
+    version: "3.2"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 11.0.696.77
+    version: "11.0.696.77"
     engine: WebKit
   device:
     type: tv
@@ -195,12 +195,12 @@
   os:
     name: Google TV
     short_name: GTV
-    version: 92754
+    version: "092754"
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 11.0.696.77
+    version: "11.0.696.77"
     engine: WebKit
   device:
     type: tv
@@ -218,7 +218,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -233,7 +233,7 @@
     type: browser
     name: ANTGalio
     short_name: AG
-    version: 3.1.1.23.04.09
+    version: "3.1.1.23.04.09"
     engine:
   device:
     type: tv
@@ -251,7 +251,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -269,7 +269,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -284,7 +284,7 @@
     type: browser
     name: ANTGalio
     short_name: AG
-    version: 3.1.1.23.04.09
+    version: "3.1.1.23.04.09"
     engine:
   device:
     type: tv
@@ -302,7 +302,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -320,7 +320,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -338,7 +338,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -356,7 +356,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -374,7 +374,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -392,7 +392,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -410,7 +410,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -494,7 +494,7 @@
     type: browser
     name: Safari
     short_name: SF
-    version: 5.0
+    version: "5.0"
     engine: WebKit
   device:
     type: tv
@@ -560,7 +560,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -588,7 +588,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -621,7 +621,7 @@
     type: browser
     name: ANTGalio
     short_name: AG
-    version: 3.2.0
+    version: "3.2.0"
     engine:
   device:
     type: tv
@@ -636,7 +636,7 @@
     type: browser
     name: ANTGalio
     short_name: AG
-    version: 3.3.0.26.02
+    version: "3.3.0.26.02"
     engine:
   device:
     type: tv
@@ -654,7 +654,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -702,7 +702,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.10
+    version: "11.10"
     engine: Presto
   device:
     type: tv
@@ -720,7 +720,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -733,7 +733,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -751,7 +751,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
   client:
     type: browser
     name: Android Browser
@@ -787,7 +787,7 @@
     type: browser
     name: Safari
     short_name: SF
-    version: 5.0
+    version: "5.0"
     engine: WebKit
   device:
     type: tv
@@ -842,7 +842,7 @@
     type: browser
     name: Espial TV Browser
     short_name: ES
-    version: 6.1.5
+    version: "6.1.5"
     engine: WebKit
   device:
     type: tv
@@ -860,7 +860,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -878,7 +878,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.10
+    version: "12.10"
     engine: Presto
   device:
     type: tv
@@ -896,7 +896,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -914,7 +914,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.10
+    version: "12.10"
     engine: Presto
   device:
     type: tv
@@ -932,7 +932,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.00
+    version: "11.00"
     engine: Presto
   device:
     type: tv
@@ -950,7 +950,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -968,7 +968,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.11
+    version: "12.11"
     engine: Presto
   device:
     type: tv
@@ -986,7 +986,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -1004,7 +1004,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.00
+    version: "11.00"
     engine: Presto
   device:
     type: tv
@@ -1072,7 +1072,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -1090,7 +1090,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.10
+    version: "11.10"
     engine: Presto
   device:
     type: tv
@@ -1108,7 +1108,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -1126,7 +1126,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -1144,7 +1144,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.60
+    version: "11.60"
     engine: Presto
   device:
     type: tv
@@ -1162,7 +1162,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 10.60
+    version: "10.60"
     engine: Presto
   device:
     type: tv
@@ -1180,7 +1180,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 10.60
+    version: "10.60"
     engine: Presto
   device:
     type: tv
@@ -1208,7 +1208,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -1226,7 +1226,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -1244,7 +1244,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -1262,7 +1262,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -1280,7 +1280,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.50
+    version: "11.50"
     engine: Presto
   device:
     type: tv
@@ -1298,7 +1298,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -1316,7 +1316,7 @@
     type: browser
     name: ANTGalio
     short_name: AG
-    version: 3.0.2.1.22.43.08
+    version: "3.0.2.1.22.43.08"
     engine:
   device:
     type: tv
@@ -1334,7 +1334,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 11.10
+    version: "11.10"
     engine: Presto
   device:
     type: tv
@@ -1352,7 +1352,7 @@
     type: browser
     name: Opera
     short_name: OP
-    version: 12.00
+    version: "12.00"
     engine: Presto
   device:
     type: tv
@@ -1365,12 +1365,12 @@
   os:
     name: WebTV
     short_name: WTV
-    version: 1.2
+    version: "1.2"
   client:
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 2.0
+    version: "2.0"
     engine: Trident
   device:
     type: tv

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -16,7 +16,7 @@
     type: browser
     name: Amaya
     short_name: AM
-    version: 9.51
+    version: "9.51"
     engine:
   device:
     type:
@@ -31,7 +31,7 @@
     type: browser
     name: Dillo
     short_name: DI
-    version: 0.8.5
+    version: "0.8.5"
     engine: Dillo
   device:
     type:
@@ -46,7 +46,7 @@
     type: browser
     name: HotJava
     short_name: HJ
-    version: 1.1.2
+    version: "1.1.2"
     engine:
   device:
     type:
@@ -61,7 +61,7 @@
     type: browser
     name: Lynx
     short_name: LX
-    version: 2.8.8
+    version: "2.8.8"
     engine: Text-based
   device:
     type:
@@ -76,7 +76,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.3.2
+    version: "6.2.3.2"
     engine:
   device:
     type:
@@ -91,7 +91,7 @@
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
-    version: 6.2.3.8
+    version: "6.2.3.8"
     engine:
   device:
     type:
@@ -106,7 +106,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 5.0.22371
+    version: "5.0.22371"
     engine: Presto
   device:
     type:
@@ -120,7 +120,7 @@
   client:
     type: pim
     name: The Bat!
-    version: 4.0.0.22
+    version: "4.0.0.22"
   device:
     type:
     brand:
@@ -134,7 +134,7 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 8.4.0.150
+    version: "8.4.0.150"
     engine:
   device:
     type:
@@ -152,7 +152,7 @@
     type: browser
     name: Fennec
     short_name: FE
-    version: 10.0
+    version: "10.0"
     engine: Gecko
   device:
     type:
@@ -170,7 +170,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.5.32193
+    version: "7.5.32193"
     engine: Presto
   device:
     type:
@@ -188,7 +188,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.5.33361
+    version: "7.5.33361"
     engine: Presto
   device:
     type:
@@ -206,7 +206,7 @@
     type: browser
     name: Opera Mini
     short_name: OI
-    version: 7.5.33361
+    version: "7.5.33361"
     engine: Presto
   device:
     type:
@@ -219,7 +219,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -237,7 +237,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -255,7 +255,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -273,7 +273,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -291,7 +291,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -309,7 +309,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -327,7 +327,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -345,7 +345,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -363,7 +363,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -381,7 +381,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -399,7 +399,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.6
+    version: "2.3.6"
   client:
     type: browser
     name: Android Browser
@@ -417,7 +417,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -435,7 +435,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -453,7 +453,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -471,7 +471,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -489,7 +489,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -507,7 +507,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -525,7 +525,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -543,7 +543,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -561,7 +561,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -579,7 +579,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -597,7 +597,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -615,7 +615,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -633,7 +633,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3.7
+    version: "2.3.7"
   client:
     type: browser
     name: Android Browser
@@ -651,7 +651,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3
+    version: "2.3"
   client:
     type: browser
     name: Android Browser
@@ -669,7 +669,7 @@
   os:
     name: Android
     short_name: AND
-    version: 2.3
+    version: "2.3"
   client:
     type: browser
     name: Android Browser
@@ -687,7 +687,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -705,7 +705,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -723,7 +723,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -741,7 +741,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -759,7 +759,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -777,7 +777,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -795,7 +795,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -813,7 +813,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -831,7 +831,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -849,7 +849,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -867,7 +867,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -885,7 +885,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -903,7 +903,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -921,7 +921,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -939,7 +939,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -957,7 +957,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -975,7 +975,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -993,7 +993,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1011,7 +1011,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1029,7 +1029,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1047,7 +1047,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1065,7 +1065,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1083,7 +1083,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1101,7 +1101,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1119,7 +1119,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1137,7 +1137,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1155,7 +1155,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1173,7 +1173,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1191,7 +1191,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1209,7 +1209,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1227,7 +1227,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1245,7 +1245,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1263,7 +1263,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1281,7 +1281,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1299,7 +1299,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1317,7 +1317,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1335,7 +1335,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1353,7 +1353,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1371,7 +1371,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.3
+    version: "4.0.3"
   client:
     type: browser
     name: Android Browser
@@ -1389,7 +1389,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1407,7 +1407,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1425,7 +1425,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1443,7 +1443,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1461,7 +1461,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1479,7 +1479,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1497,7 +1497,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1515,7 +1515,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1533,7 +1533,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1551,7 +1551,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1569,7 +1569,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1587,7 +1587,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1605,7 +1605,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1623,7 +1623,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1641,7 +1641,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1659,7 +1659,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1677,7 +1677,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1695,7 +1695,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1713,7 +1713,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1731,7 +1731,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1749,7 +1749,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1767,7 +1767,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1785,7 +1785,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1803,7 +1803,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1821,7 +1821,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1839,7 +1839,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1857,7 +1857,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1875,7 +1875,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1893,7 +1893,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1911,7 +1911,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1929,7 +1929,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1947,7 +1947,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1965,7 +1965,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -1983,7 +1983,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2001,7 +2001,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2019,7 +2019,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2037,7 +2037,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2055,7 +2055,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2073,7 +2073,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2091,7 +2091,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2109,7 +2109,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2127,7 +2127,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2145,7 +2145,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2163,7 +2163,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2181,7 +2181,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2199,7 +2199,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2217,7 +2217,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2235,7 +2235,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2253,7 +2253,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2271,7 +2271,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2289,7 +2289,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2307,7 +2307,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2325,7 +2325,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2343,7 +2343,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2361,7 +2361,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2379,7 +2379,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2397,7 +2397,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2415,7 +2415,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2433,7 +2433,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2451,7 +2451,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2469,7 +2469,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2487,7 +2487,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2505,7 +2505,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2523,7 +2523,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2541,7 +2541,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2559,7 +2559,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2577,7 +2577,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2595,7 +2595,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2613,7 +2613,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2631,7 +2631,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2649,7 +2649,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2667,7 +2667,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2685,7 +2685,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2703,7 +2703,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2721,7 +2721,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2739,7 +2739,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2757,7 +2757,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2775,7 +2775,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2793,7 +2793,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2811,7 +2811,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2829,7 +2829,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2847,7 +2847,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2865,7 +2865,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2883,7 +2883,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2901,7 +2901,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2919,7 +2919,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Android Browser
@@ -2937,7 +2937,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Maxthon
@@ -2955,12 +2955,12 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.4
+    version: "4.0.4"
   client:
     type: browser
     name: Puffin
     short_name: PU
-    version: 2.10990
+    version: "2.10990"
     engine: WebKit
   device:
     type:
@@ -2973,7 +2973,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.0.9
+    version: "4.0.9"
   client:
     type: browser
     name: Android Browser
@@ -2991,7 +2991,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.0
+    version: "4.1.0"
   client:
     type: browser
     name: Android Browser
@@ -3009,7 +3009,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3027,7 +3027,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3045,7 +3045,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3063,7 +3063,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3081,7 +3081,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3099,7 +3099,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3117,7 +3117,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3135,7 +3135,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3153,7 +3153,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3171,7 +3171,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3189,7 +3189,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3207,7 +3207,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3225,7 +3225,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3243,7 +3243,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
   client:
     type: browser
     name: Android Browser
@@ -3261,7 +3261,7 @@
   os:
     name: Android
     short_name: AND
-    version: 4.1
+    version: "4.1"
   client:
     type: browser
     name: Android Browser
@@ -3279,7 +3279,7 @@
   os:
     name: Brew
     short_name: BMP
-    version: 3.1.5.20
+    version: "3.1.5.20"
   client:
     type: browser
     name: UC Browser
@@ -3315,7 +3315,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -3333,7 +3333,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -3351,7 +3351,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 7.2.0
+    version: "7.2.0"
   client:
     type: browser
     name: Android Browser
@@ -3369,7 +3369,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -3387,7 +3387,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9
+    version: "9"
   client:
     type: browser
     name: Android Browser
@@ -3405,7 +3405,7 @@
   os:
     name: CyanogenMod
     short_name: CYN
-    version: 9.0.0
+    version: "9.0.0"
   client:
     type: browser
     name: Android Browser
@@ -3423,7 +3423,7 @@
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
   client:
     type: browser
     name: Android Browser
@@ -3441,12 +3441,12 @@
   os:
     name: RISC OS
     short_name: ROS
-    version: 3.70
+    version: "3.70"
   client:
     type: browser
     name: Oregano
     short_name: OR
-    version: 1.10
+    version: "1.10"
     engine:
   device:
     type:
@@ -3459,7 +3459,7 @@
   os:
     name: RISC OS
     short_name: ROS
-    version: 4.39
+    version: "4.39"
   client: null
   device:
     type:
@@ -3472,7 +3472,7 @@
   os:
     name: RISC OS
     short_name: ROS
-    version: 5.13
+    version: "5.13"
   client: null
   device:
     type:
@@ -3490,7 +3490,7 @@
     type: browser
     name: Tizen Browser
     short_name: TZ
-    version: 1.0
+    version: "1.0"
     engine: WebKit
   device:
     type:
@@ -3508,7 +3508,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: 4.01
+    version: "4.01"
     engine: Trident
   device:
     type:
@@ -3526,7 +3526,7 @@
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 10.00
+    version: "10.00"
     engine: Presto
   device:
     type:
@@ -3544,7 +3544,7 @@
     type: browser
     name: IE Mobile
     short_name: IM
-    version: 9.0
+    version: "9.0"
     engine: Trident
   device:
     type:


### PR DESCRIPTION
When using the test fixtures in more type-safe languages some versions get interpreted as floats or integers. For example the Opera versions get incorrectly parsed as "9.3" instead of "9.30" while the regex still grab the proper string version.

This patch changes all versions in the fixtures to be strings. The only change is GoogleTV version "92754" now being saved as "092754" (as matched by the regex).

Used command to convert fixtures:

``` shell
sed -i -e 's/version: \([^"].*\)/version: "\1"/g' *.yml
```
