### PR TITLE
Move NetCast regex from mobiles to televisions

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -1504,9 +1504,6 @@ LG:
   regex: 'LG|portalmmm/2\.0 (?:KE|KG|KP|L3)|VX[0-9]+'
   device: 'smartphone'
   models:
-    - regex: 'LGE_DLNA_SDK|NetCast'
-      device: 'tv'
-      model: 'NetCast'
     - regex: 'LGE(?: |-LG| LG-AX|-)([a-z0-9]+)'
       model: '$1'
     - regex: 'LGE;([a-z0-9\-]+)'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -73,6 +73,8 @@ LG:
   models:
     - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
       model: '$1'
+    - regex: 'LGE_DLNA_SDK|NetCast'
+      model: 'NetCast'
 
 # Loewe
 Loewe:


### PR DESCRIPTION
I have discovered, that NetCast detection is partially done through the `mobiles` regexes, instead of `televisions`. I have merged both regexes in `televisions.yml`
