### PR TITLE
Support for new bots

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -696,3 +696,6 @@
 -
   user_agent: 'Tiny Tiny RSS/1.11.4c63934 (http://tt-rss.org/)'
   name: 'Tiny Tiny RSS'
+-
+  user_agent: 'Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)'
+  name: 'Yahoo Gemini'

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -699,3 +699,6 @@
 -
   user_agent: 'Mozilla/5.0 (compatible; Yahoo Ad monitoring; https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html)'
   name: 'Yahoo Gemini'
+-
+  user_agent: 'Mozilla/5.0 (Java) outbrain'
+  name: 'Outbrain'

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -708,3 +708,6 @@
 -
   user_agent: 'ADmantX Platform Semantic Analyzer - ADmantX Inc. - www.admantx.com - support@admantx.com'
   name: 'ADMantX'
+-
+  user_agent: 'Pinterest/0.2 (+http://www.pinterest.com/)'
+  name: 'Pinterest'

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -711,3 +711,6 @@
 -
   user_agent: 'Pinterest/0.2 (+http://www.pinterest.com/)'
   name: 'Pinterest'
+-
+  user_agent: 'Server Density Service Monitoring v2'
+  name: 'Server Density'

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -705,3 +705,6 @@
 -
   user_agent: 'HubPages V0.2.2 (http://hubpages.com/help/crawlingpolicy)'
   name: 'HubPages'
+-
+  user_agent: 'ADmantX Platform Semantic Analyzer - ADmantX Inc. - www.admantx.com - support@admantx.com'
+  name: 'ADMantX'

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -702,3 +702,6 @@
 -
   user_agent: 'Mozilla/5.0 (Java) outbrain'
   name: 'Outbrain'
+-
+  user_agent: 'HubPages V0.2.2 (http://hubpages.com/help/crawlingpolicy)'
+  name: 'HubPages'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -941,6 +941,15 @@
     name: 'Yahoo! Inc.'
     url: 'http://www.yahoo.com'
 
+- regex: '.*Java.*outbrain'
+  name: 'Outbrain'
+  category: 'Crawler'
+  url: ''
+  producer:
+    name: 'Outbrain'
+    url: 'http://www.outbrain.com/'
+
+
 - regex: 'lycos'
   name: 'Lycos'
 

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1013,6 +1013,9 @@
 - regex: 'AdMantX.*admantx.com'
   name: 'ADMantX'
 
+- regex: 'Server Density Service Monitoring.*'
+  name: 'Server Density'
+
 - regex: '(nuhk|TsolCrawler|Yammybot|Openbot|Gulper Web Bot|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|teoma|blitzbot|oegp|furlbot|http%20client|polybot|htdig|mogimogi|larbin|scrubby|searchsight|seekbot|semanticdiscovery|snappy|vortex|zao|zeal|fast-webcrawler|converacrawler|dataparksearch|findlinks|BrowserMob|HttpMonitor|ThumbShotsBot|URL2PNG|ZooShot|GomezA|Catchpoint bot|Google SketchUp|Read%20Later|Minimo|RackspaceBot)'
   name: 'Bot'
 

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -949,6 +949,13 @@
     name: 'Outbrain'
     url: 'http://www.outbrain.com/'
 
+- regex: 'HubPages.*crawlingpolicy'
+  name: 'HubPages'
+  category: 'Crawler'
+  url: 'http://hubpages.com/help/crawlingpolicy'
+  producer:
+    name: 'HubPages'
+    url: 'http://hubpages.com/'
 
 - regex: 'lycos'
   name: 'Lycos'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1002,6 +1002,8 @@
 - regex: 'NetLyzer FastProbe'
   name: 'NetLyzer FastProbe'
 
+- regex: 'AdMantX.*admantx.com'
+  name: 'ADMantX'
 
 - regex: '(nuhk|TsolCrawler|Yammybot|Openbot|Gulper Web Bot|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|teoma|blitzbot|oegp|furlbot|http%20client|polybot|htdig|mogimogi|larbin|scrubby|searchsight|seekbot|semanticdiscovery|snappy|vortex|zao|zeal|fast-webcrawler|converacrawler|dataparksearch|findlinks|BrowserMob|HttpMonitor|ThumbShotsBot|URL2PNG|ZooShot|GomezA|Catchpoint bot|Google SketchUp|Read%20Later|Minimo|RackspaceBot)'
   name: 'Bot'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -933,7 +933,13 @@
     name: 'Yottaa'
     url: 'http://www.yottaa.com/'
 
-
+- regex: 'Yahoo Ad monitoring.*yahoo-ad-monitoring-SLN24857.*'
+  name: 'Yahoo Gemini'
+  category: 'Crawler'
+  url: 'https://help.yahoo.com/kb/yahoo-ad-monitoring-SLN24857.html'
+  producer:
+    name: 'Yahoo! Inc.'
+    url: 'http://www.yahoo.com'
 
 - regex: 'lycos'
   name: 'Lycos'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -957,6 +957,14 @@
     name: 'HubPages'
     url: 'http://hubpages.com/'
 
+- regex: 'Pinterest/\d\.\d.*www.pinterest.com.*'
+  name: 'Pinterest'
+  url: ''
+  category: 'Crawler'
+  producer:
+    name: 'Pinterest'
+    url: 'http://www.pinterest.com/'
+
 - regex: 'lycos'
   name: 'Lycos'
 


### PR DESCRIPTION
I've been using this piwik component alongside an ad-related infrastructure in order to determine in real time, user-agent information. 

Because this is done in on request, they might never be seen via Piwik, but I think it's important to keep a list of bots here, so others can use it and identify them as bots. Right now, in our system they are seen as "unknown", so I need them to be here so we can track them as bots :smile: 

Yahoo Gemini's bot does behave like an actual user and appear on Piwik though. It's used as part of Yahoo Gemini's campaign monitoring (they request your site with every possible device out there).

New bots:
- Yahoo Gemini: http://gemini.yahoo.com
- Outbrain: http://outbrain.com
- HubPages
- Server Density Service Monitoring
- Pinterest's Bot
- ADManTX (No idea what they do, but they hit our systems way too much).

Few things:

I noticed these user agents weren't detected at all, and look like real devices:
- `SAMSUNG-GT-S5260/1.0 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B`
- `SAMSUNG-GT-S5620/S5620XEJE1 SHP/VPP/R5 Dolfin/1.5 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1`
- `UCWEB/2.0 (Java; U; MIDP-2.0; en-US; generic) U2/1.0.0 UCBrowser/9.5.0.449 U2/1.0.0 Mobile`
- `Mozilla/5.0 (LG-T395 AppleWebkit/531 Browser/Phantom/V2.0 Widget/LGMW/3.0 MMS/LG-MMS-V1.0/1.2 Java/ASVM/1.1 Profile/MIDP-2.1 Configuration/CLDC-1.1)` 
- `Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.1.16 AQUOSBrowser/2.0 (US01DTV;V;0001;0001)`
- `Mozilla/5.0 (compatible; Google Desktop/5.9.1005.12335; http://desktop.google.com/)`
- `LG-LGMS450 Obigo/Q7.3 Profile/MIDP-2.1 Configuration/CLDC-1.1`
- `LG-C395/V10i Obigo/Q7.3 Profile/MIDP-2.1 Configuration/CLDC-1.1`
- `LG-B450 Obigo/Q7.3 Profile/MIDP-2.1 Configuration/CLDC-1.1`
- `KKT27/MIDP-2.0 Configuration/CLDC-1.1/Screen-240x320`

And last, because my need to detect bots and crawlers, I noticed user agents like these, should be identified as bots:
- `WordPress/4.x http://site.com`
- `Apache-HttpClient/4.3.4 (java 1.5)`
- `urllib2 (Python 2.6)`
- `Ruby`
- `Mozilla/5.0 (compatible; Pagespeed/1.1 Fetcher; +http://www.pagespeed.de)`
- `curl/7.32.0`
- `curl/7.18.2 (x86_64-pc-linux-gnu) libcurl/7.18.2 OpenSSL/0.9.8g zlib/1.2.3.3 libidn/1.8 libssh2/0.18`
- `HTTPClient/1.0 (2.4.0, ruby 2.0.0 (2013-11-22))`
- `Jakarta Commons-HttpClient/3.1`
- `libwww-perl/5.813`
- `Mozilla/5.0 (compatible; Google-Apps-Script)`
- `okhttp/2.2.0`

I have many others (We've seen over 50k unique user agents, and only 250 or so weren't detected by this library!), so should I try to integrate as many of them that I see as bots in here? I can do more PRs later...

Thanks.
