### PR TITLE
BrowserParser - BrowserFamily improvements

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -150,6 +150,8 @@ class Browser extends ClientParserAbstract
     protected static $browserFamilies = array(
         'Android Browser'    => array('AN', 'MU'),
         'BlackBerry Browser' => array('BB'),
+        'Baidu'              => array('BD', 'BS'),
+        'Amiga'              => array('AV', 'AW'),
         'Chrome'             => array('CH', 'CD', 'CM', 'CI', 'CF', 'CN', 'CR', 'CP', 'IR', 'RM', 'AO', 'VI'),
         'Firefox'            => array('FF', 'FE', 'SX', 'FB', 'PX', 'MB'),
         'Internet Explorer'  => array('IE', 'IM', 'PS'),

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -16,7 +16,7 @@
     brand:
     model:
   os_family: AmigaOS
-  browser_family: Unknown
+  browser_family: Amiga
 - 
   user_agent: AmigaVoyager/3.2 (AmigaOS/MC680x0)
   os:
@@ -34,7 +34,7 @@
     brand:
     model:
   os_family: AmigaOS
-  browser_family: Unknown
+  browser_family: Amiga
 - 
   user_agent: Mozilla/5.0 (AmigaOS; U; AmigaOS 1.3; en-US; rv:1.8.1.21) Gecko/20090303 SeaMonkey/1.1.15
   os:
@@ -2037,7 +2037,7 @@
     brand:
     model:
   os_family: Windows
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.30 (KHTML, like Gecko) Chrome/26.0.1403.0 Safari/537.30
   os:
@@ -2587,7 +2587,7 @@
     brand:
     model:
   os_family: Windows
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.57 Safari/537.17
   os:
@@ -3239,7 +3239,7 @@
     brand:
     model:
   os_family: Windows
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; BIDUBrowser 2.6)
   os:
@@ -3257,7 +3257,7 @@
     brand:
     model:
   os_family: Windows
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11
   os:

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -394,7 +394,7 @@
     brand: SA
     model: GALAXY Note 3
   os_family: Android
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-ca; SM-N900W8 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -2598,7 +2598,7 @@
     brand: CO
     model: 5950
   os_family: Android
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; YL-Coolpad_7230-B Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
@@ -8899,7 +8899,7 @@
     brand: II
     model: E86
   os_family: Android
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; th-th; i-mobile i-STYLE 4 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
@@ -17509,7 +17509,7 @@
     brand: SA
     model: GALAXY S4
   os_family: Android
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-gb; SAMSUNG GT-I9505X Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
@@ -28454,7 +28454,7 @@
     brand: ZT
     model: U817
   os_family: Android
-  browser_family: Unknown
+  browser_family: Baidu
 - 
   user_agent: ZTE U930_TD/1.0 Linux/2.6.39 Android/4.0 Release/3.5.2012 Browser/AppleWebKit534.30
   os:


### PR DESCRIPTION
Grouped Amiga and Baidu browsers into a single browser family.
Also, updated the relevant test fixtures and verified that tests are
passing.
