### PR TITLE
Add Kodi (XBMC after version 14)

### DIFF
--- a/regexes/client/mediaplayers.yml
+++ b/regexes/client/mediaplayers.yml
@@ -65,6 +65,10 @@
   name: 'XBMC'
   version: '$1'
 
+- regex: 'Kodi(?:/([\d\.]+))?'
+  name: 'Kodi'
+  version: '$1'
+
 - regex: 'stagefright(?:/([\d\.]+))?'
   name: 'Stagefright'
   version: '$1'


### PR DESCRIPTION
Added the Kodi mediaplayer to the list, which is XBMC that was renamed for version 14.0.
