### PR TITLE
Added detection for Firefox iOS

### DIFF
--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -365,7 +365,7 @@
     type: browser
     name: Firefox
     short_name: FF
-    version: "Firefox iOS 1.0"
+    version: "iOS 1.0"
     engine: WebKit
 -
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; pl; rv:1.9.0.16) Gecko/2010021013 Firefox/3.0.16 Flock/2.5.6

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -360,6 +360,14 @@
     version: "Namoroka (3.6.13)"
     engine: Gecko
 -
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4
+  client:
+    type: browser
+    name: Firefox
+    short_name: FF
+    version: "Firefox iOS 1.0"
+    engine: WebKit
+-
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; pl; rv:1.9.0.16) Gecko/2010021013 Firefox/3.0.16 Flock/2.5.6
   client:
     type: browser

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -139,6 +139,11 @@
   version: '$1 ($2)'
   engine:
     default: 'Gecko'
+- regex: 'FxiOS/(\d+[\.\d]+)'
+  name: 'Firefox'
+  version: 'Firefox iOS $1'
+  engine:
+    default: 'WebKit'
 
 #ANTGalio
 - regex: 'ANTGalio(?:/(\d+[\.\d]+))?'

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -141,7 +141,7 @@
     default: 'Gecko'
 - regex: 'FxiOS/(\d+[\.\d]+)'
   name: 'Firefox'
-  version: 'Firefox iOS $1'
+  version: 'iOS $1'
   engine:
     default: 'WebKit'
 


### PR DESCRIPTION
Hi!

Mozilla chose the UA for Firefox iOS:
https://bugzilla.mozilla.org/show_bug.cgi?id=1147658

Warning, this Firefox is running over WebKit! :)

Cheers,
Thomas.
