### PR TITLE
Skip bot detection

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -110,11 +110,16 @@ class DeviceDetector
      * If $discardBotInformation is set to true, this property will be set to
      * true if parsed UA is identified as bot, additional information will be not available
      *
+     * If $skipBotDetection is set to true, bot detection will not be performed and isBot will
+     * always be false
+     *
      * @var array|boolean
      */
     protected $bot = null;
 
     protected $discardBotInformation = false;
+
+    protected $skipBotDetection = false;
 
     /**
      * Holds the cache class used for caching the parsed yml-Files
@@ -258,6 +263,18 @@ class DeviceDetector
     public function discardBotInformation($discard=true)
     {
         $this->discardBotInformation = $discard;
+    }
+
+    /**
+     * Sets whether to skip bot detection.
+     * It is needed if we want bots to be processed as a simple clients. So we can detect if it is mobile client,
+     * or desktop, or enything else. By default all this information is not retrieved for the bots.
+     *
+     * @param bool $skip
+     */
+    public function skipBotDetection($skip=true)
+    {
+        $this->skipBotDetection = $skip;
     }
 
     /**
@@ -514,6 +531,11 @@ class DeviceDetector
      */
     protected function parseBot()
     {
+        if ($this->skipBotDetection) {
+            $this->bot = false;
+            return false;
+        }
+
         $botParser = new Bot();
         $botParser->setUserAgent($this->getUserAgent());
         $botParser->setCache($this->getCache());

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -270,4 +270,18 @@ class DeviceDetectorTest extends \PHPUnit_Framework_TestCase
         $dd->parse();
         $this->assertEquals('Google', $dd->getBrandName());
     }
+
+    public function testSkipBotDetection()
+    {
+        $ua = 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5376e Safari/8536.25 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)';
+        $dd = new DeviceDetector($ua);
+        $dd->parse();
+        $this->assertFalse($dd->isMobile());
+        $this->assertTrue($dd->isBot());
+        $dd = new DeviceDetector($ua);
+        $dd->skipBotDetection();
+        $dd->parse();
+        $this->assertTrue($dd->isMobile());
+        $this->assertFalse($dd->isBot());
+    }
 }


### PR DESCRIPTION
I use device-detector to switch between mobile and desktop version of my website based on visitor's user-agent. Google bot also visits my website using different user agents - mobile and desktop. So I need somehow to switch off the bot detection to show a valid page to Google Bot (otherwise the bot is ever detected as "not mobile" client).
