### PR TITLE
Add Stringer user-agent regex

### DIFF
--- a/Tests/Parser/Client/fixtures/feed_reader.yml
+++ b/Tests/Parser/Client/fixtures/feed_reader.yml
@@ -178,3 +178,10 @@
     type: feed reader
     name: RSSOwl
     version: "2.2.1.201312301316"
+
+-
+  user_agent: Stringer (https://github.com/swanson/stringer)
+  client:
+    type: feed reader
+    name: Stringer
+    version: ""

--- a/regexes/client/feed_readers.yml
+++ b/regexes/client/feed_readers.yml
@@ -100,3 +100,9 @@
   version: '$1'
   url: 'http://www.rssowl.org/'
   type: 'Feed Reader'
+
+- regex: 'Stringer'
+  name: 'Stringer'
+  version: ''
+  url: 'https://github.com/swanson/stringer'
+  type: 'Feed Reader'


### PR DESCRIPTION
The full user agent for [Stringer](https://github.com/swanson/stringer) (a self-hosted RSS reader) is:

``` ruby
USER_AGENT = "Stringer (https://github.com/swanson/stringer)"
```

We don't report a version - is it alright to omit it from the yml file here?
