### PR TITLE
Update VoilaBot definition

### DIFF
--- a/Tests/Parser/fixtures/bots.yml
+++ b/Tests/Parser/fixtures/bots.yml
@@ -1178,6 +1178,42 @@
       name: 'OpenWebSpider Lab'
       url: 'http://lab.openwebspider.org'
 -
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1;fr;rv:1.8.1) VoilaBotCollector BETA 0.1 (http://www.voila.com/)
+  bot:
+    name: 'Orange Bot'
+    category: 'Search bot'
+    url: 'http://lemoteur.orange.fr'
+    producer:
+      name: 'Orange'
+      url: 'http://www.orange.fr'
+-
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
+  bot:
+    name: 'Orange Bot'
+    category: 'Search bot'
+    url: 'http://lemoteur.orange.fr'
+    producer:
+      name: 'Orange'
+      url: 'http://www.orange.fr'
+-
+  user_agent: Mozilla/5.0 (compatible; OrangeBot/2.0; support.orangebot@orange.com)
+  bot:
+    name: 'Orange Bot'
+    category: 'Search bot'
+    url: 'http://lemoteur.orange.fr'
+    producer:
+      name: 'Orange'
+      url: 'http://www.orange.fr'
+-
+  user_agent: Mozilla/5.0 (compatible; OrangeBot-Collector/2.0; support.orangebot@orange.com)
+  bot:
+    name: 'Orange Bot'
+    category: 'Search bot'
+    url: 'http://lemoteur.orange.fr'
+    producer:
+      name: 'Orange'
+      url: 'http://www.orange.fr'
+-
   user_agent: Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)
   bot:
     name: 'PaperLiBot'
@@ -1582,24 +1618,6 @@
     producer:
       name: 'Alentum Software Ltd.'
       url: 'http://www.alentum.com'
--
-  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1;fr;rv:1.8.1) VoilaBotCollector BETA 0.1 (http://www.voila.com/)
-  bot:
-    name: 'Voila Bot'
-    category: 'Search bot'
-    url: 'http://www.voila.fr'
-    producer:
-      name: ''
-      url: ''
--
-  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
-  bot:
-    name: 'Voila Bot'
-    category: 'Search bot'
-    url: 'http://www.voila.fr'
-    producer:
-      name: ''
-      url: ''
 -
   user_agent: Jigsaw/2.3.0 W3C_CSS_Validator_JFouffa/2.0 (See <http://validator.w3.org/services>)
   bot:

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -344,6 +344,18 @@
   user_agent: OpenWebSpider v0.1.4 (http://www.openwebspider.org/)
   name: 'OpenWebSpider'
 -
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1;fr;rv:1.8.1) VoilaBotCollector BETA 0.1 (http://www.voila.com/)
+  name: 'Orange Bot'
+-
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
+  name: 'Orange Bot'
+-
+  user_agent: Mozilla/5.0 (compatible; OrangeBot/2.0; support.orangebot@orange.com)
+  name: 'Orange Bot'
+-
+  user_agent: Mozilla/5.0 (compatible; OrangeBot-Collector/2.0; support.orangebot@orange.com)
+  name: 'Orange Bot'
+-
   user_agent: Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)
   name: 'PaperLiBot'
 -
@@ -460,12 +472,6 @@
 -
   user_agent: Mozilla/5.0 (compatible; VSMCrawler; http://www.visualsitemapper.com/crawler/)
   name: 'Visual Site Mapper Crawler'
--
-  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1;fr;rv:1.8.1) VoilaBotCollector BETA 0.1 (http://www.voila.com/)
-  name: 'Voila Bot'
--
-  user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; fr; rv:1.8.1) VoilaBot BETA 1.2 (support.voilabot@orange-ftgroup.com)
-  name: 'Voila Bot'
 -
   user_agent: Jigsaw/2.3.0 W3C_CSS_Validator_JFouffa/2.0 (See <http://validator.w3.org/services>)
   name: 'W3C CSS Validator'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -525,6 +525,14 @@
     name: 'Openindex B.V.'
     url: 'http://www.openindex.io'
 
+- regex: 'OrangeBot|VoilaBot'
+  name: 'Orange Bot'
+  category: 'Search bot'
+  url: 'http://lemoteur.orange.fr'
+  producer:
+    name: 'Orange'
+    url: 'http://www.orange.fr'
+
 - regex: 'spbot'
   name: 'OpenLinkProfiler'
   category: 'Crawler'
@@ -788,14 +796,6 @@
   producer:
     name: 'Alentum Software Ltd.'
     url: 'http://www.alentum.com'
-
-- regex: 'VoilaBot'
-  name: 'Voila Bot'
-  category: 'Search bot'
-  url: 'http://www.voila.fr'
-  producer:
-    name: ''
-    url: ''
 
 - regex: 'Jigsaw'
   name: 'W3C CSS Validator'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -525,14 +525,6 @@
     name: 'Openindex B.V.'
     url: 'http://www.openindex.io'
 
-- regex: 'OrangeBot|VoilaBot'
-  name: 'Orange Bot'
-  category: 'Search bot'
-  url: 'http://lemoteur.orange.fr'
-  producer:
-    name: 'Orange'
-    url: 'http://www.orange.fr'
-
 - regex: 'spbot'
   name: 'OpenLinkProfiler'
   category: 'Crawler'
@@ -548,6 +540,14 @@
   producer:
     name: 'OpenWebSpider Lab'
     url: 'http://lab.openwebspider.org'
+
+- regex: 'OrangeBot|VoilaBot'
+  name: 'Orange Bot'
+  category: 'Search bot'
+  url: 'http://lemoteur.orange.fr'
+  producer:
+    name: 'Orange'
+    url: 'http://www.orange.fr'
 
 - regex: 'PaperLiBot'
   name: 'PaperLiBot'


### PR DESCRIPTION
Orange build a new bot named OrangeBot : http://blog.lemoteur.fr/orangebot/

This bot replace VoilaBot which going to be removed very soon...
