### PR TITLE
add more detections for bots

### DIFF
--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -157,6 +157,10 @@
     name: ''
     url: ''
 
+- regex: 'Blogtrottr'
+  name: 'Blogtrottr'
+  url: 'https://blogtrottr.com/'
+
 - regex: 'BountiiBot'
   name: 'Bountii Bot'
   category: 'Search bot'
@@ -172,6 +176,11 @@
   producer:
     name: 'Browsershots.org'
     url: 'http://browsershots.org'
+
+- regex: 'BUbiNG'
+  name: 'BUbiNG'
+  category: 'crawler'
+  url: 'http://law.di.unimi.it/BUbiNG.html'
 
 - regex: '(?<!HTC)[ _]Butterfly'
   name: 'Butterfly Robot'
@@ -236,6 +245,10 @@
   producer:
     name: 'Discovery Engine'
     url: 'http://discoveryengine.com'
+
+- regex: 'Domain Re-Animator Bot'
+  name: 'Domain Re-Animator Bot'
+  url: 'http://domainreanimator.com'
 
 - regex: 'DotBot'
   name: 'DotBot'
@@ -349,6 +362,14 @@
     name: 'Genieo'
     url: 'http://www.genieo.com'
 
+- regex: 'Gluten Free Crawler'
+  name: 'Gluten Free Crawler'
+  category: 'crawler'
+  url: 'http://glutenfreepleasure.com/'
+
+- regex: 'Guzzle'
+  url: 'https://github.com/guzzle/guzzle'
+
 - regex: 'ichiro/mobile goo'
   name: 'Goo'
   category: 'Search bot'
@@ -397,6 +418,11 @@
     name: 'towards GmbH'
     url: 'http://www.towards.ch/'
 
+- regex: 'ICC-Crawler'
+  name: 'ICC-Crawler'
+  category: 'crawler'
+  url: 'http://www.nict.go.jp/en/univ-com/plan/crawl.html'
+
 - regex: 'iisbot'
   name: 'IIS Site Analysis'
   category: 'crawler'
@@ -413,6 +439,11 @@
     name: ''
     url: ''
 
+- regex: 'larbin'
+  name: 'Larbin web crawler'
+  category: 'crawler'
+  url: 'http://larbin.sourceforge.net'
+
 - regex: 'linkdexbot(-mobile)?|linkdex.com'
   name: 'Linkdex Bot'
   category: 'Search bot'
@@ -428,6 +459,10 @@
   producer:
     name: 'LinkedIn'
     url: 'http://www.linkedin.com'
+
+- regex: 'ltx71'
+  name: 'ltx71 - (http://ltx71.com/)'
+  url: 'http://ltx71.com/'
 
 - regex: 'Mail.RU(_Bot)?'
   name: 'Mail.Ru Bot'
@@ -621,6 +656,14 @@
     name: 'SEOmoz, Inc.'
     url: 'http://moz.com/'
 
+- regex: 'ROI Hunter'
+  name: 'ROI Hunter (an advanced Facebook Ads platform)'
+  url: 'http://roihunter.com/'
+
+- regex: 'Scrapy'
+  name: 'Scrapy'
+  url: 'http://scrapy.org'
+
 - regex: 'Screaming Frog SEO Spider'
   name: 'Screaming Frog SEO Spider'
   category: 'Crawler'
@@ -748,6 +791,10 @@
   producer:
     name: 'Domain Tools'
     url: 'http://www.domaintools.com'
+
+- regex: 'TelegramBot'
+  name: 'TelgramBot (like TwitterBot)'
+  url: 'https://telegram.org/blog/bot-revolution'
 
 - regex: 'TinEye-bot'
   name: 'TinEye Crawler'


### PR DESCRIPTION
While setting up a piwik instance I came across several bots in our access log.

In this case the bots had their "origin" url written in USER_AGENT. I have another dozen without proper naming or url. If interested I can create a pull request even with these.
