### PR TITLE
Added isParsed() method & code clean-up for improved readability

### DIFF
--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -89,6 +89,14 @@ class DeviceDetectorTest extends \PHPUnit_Framework_TestCase
         $dd->parse();
     }
 
+    public function testIsParsed()
+    {
+        $dd = new DeviceDetector('Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 101 PLATINUM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36');
+        $this->assertFalse($dd->isParsed());
+        $dd->parse();
+        $this->assertTrue($dd->isParsed());
+    }
+
     /**
      * @dataProvider getFixtures
      */


### PR DESCRIPTION
I noticed this library could use a little bit of code clean-up for improved readability (for example, declaring all class properties at the top). Also `$this->parsed` was used internally, but there was no chance to access it from outside the class - always calling `parse()` just-in-case is no reasonable alternative, so I added a public method `isParsed()`.
