### PR TITLE
Use configured cache for vendor fragment parsing

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -617,6 +617,7 @@ class DeviceDetector
          */
         if (empty($this->brand)) {
             $vendorParser = new VendorFragment($this->getUserAgent());
+            $vendorParser->setCache($this->getCache());
             $this->brand = $vendorParser->parse();
         }
 


### PR DESCRIPTION
The configured cache implementation is injected into each used parser instance but this injection is missing when parsing vendor fragments.
