### PR TITLE
Fixed README and removed debugging statement from Symfony YAML integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ $dd->setCache(new Doctrine\Common\Cache\PhpFileCache('./tmp/'));
 // OPTIONAL: Set custom yaml parser
 // By default Spyc will be used for parsing yaml files. You can also use another yaml parser.
 // You may need to implement the Yaml Parser facade if you want to use another parser than Spyc or [Symfony](https://github.com/symfony/yaml)
-$dd->setYamlParser(new DeviceDetector\Yaml\Parser\Symfony());
+$dd->setYamlParser(new DeviceDetector\Yaml\Symfony());
 
 // OPTIONAL: If called, getBot() will only return true if a bot was detected  (speeds up detection a bit)
 $dd->discardBotInformation();

--- a/Yaml/Symfony.php
+++ b/Yaml/Symfony.php
@@ -15,7 +15,6 @@ class Symfony implements Parser
     public function parseFile($file)
     {
         $parser = new SymfonyParser();
-        echo 'test';
         return $parser->parse(file_get_contents($file));
     }
 }


### PR DESCRIPTION
I wanted to use the Symfony YAML integration but found a debugging statement there. Is the integration unstable, or was the output "test" simply a mistake?
