### PR TITLE
Add Wechat browser

### DIFF
--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -24,6 +24,13 @@
   engine:
     default: 'WebKit'
 
+# Wechat Phone Browser
+- regex: 'MicroMessenger(?:/(\d+[\.\d]+))?'
+  name: 'Wechat Browser'
+  version: '$1'
+  engine:
+    default: 'WebKit'
+
 #SailfishBrowser
 - regex: 'SailfishBrowser(?:/(\d+[\.\d]+))?'
   name: 'Sailfish Browser'


### PR DESCRIPTION
As Wechat used more frequently in China, we should include this browser in, otherwise it will show as Unknown Browser.
