### PR TITLE
fix duplicated range in mobiles.yml regex string

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -375,7 +375,7 @@ Acer:
 
 # Airness
 Airness:
-  regex: 'AIRNESS-([\w0-9]+)'
+  regex: 'AIRNESS-([\w]+)'
   device: 'feature phone'
   model: '$1'
 


### PR DESCRIPTION
This fixes a duplicate range in the regex for detecting Airness devices. `\w` already includes `0-9`.
