### PR TITLE
adds quotes to database entries

### DIFF
--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -3215,7 +3215,7 @@
     name: BashPodder
     version:
   device:
-    type: 
+    type:
     brand:
     model:
   os_family: Unknown

--- a/regexes/client/feed_readers.yml
+++ b/regexes/client/feed_readers.yml
@@ -18,13 +18,13 @@
   type: 'Feed Reader'
 
 - regex: 'BashPodder'
-  name: BashPodder
-  version: 
+  name: 'BashPodder'
+  version: ''
   url: 'http://lincgeek.org/bashpodder/'
   type: 'Feed Reader'
 
 - regex: 'Downcast/([\d\.]+)'
-  name: Downcast
+  name: 'Downcast'
   version: '$1'
   url: 'http://downcastapp.com/'
   type: 'Feed Reader App'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -79,8 +79,8 @@
   version: '$1'
 -
   regex: 'Podcat/([\d\.]+)'
-  name: Podcat
-  version: $1
+  name: 'Podcat'
+  version: '$1'
 
 -
   regex: 'BeyondPod'
@@ -112,5 +112,5 @@
   version: '$1'
 -
   regex: 'i[cC]atcher[^\d]+([\d\.]+)'
-  name: iCatcher
-  version: $1
+  name: 'iCatcher'
+  version: '$1'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -90,9 +90,9 @@
   name: 'Android'
   version: ''
 
-- regex: BeyondPod|AntennaPod|Podkicker|DoggCatcher
-  name: Android
-  version:
+- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher'
+  name: 'Android'
+  version: ''
   
   
 ##########
@@ -351,11 +351,11 @@
 
 - regex: 'Podcasts/(?:[\d\.]+)|Instacast(?:HD)?/(?:\d\.[\d\.abc]+)|Pocket Casts, iOS|Overcast|Castro|Podcat|i[cC]atcher'
   name: 'iOS'
-  version:
+  version: ''
 
 - regex: 'iTunes-(iPod|iPad|iPhone)/(?:[\d\.]+)'
   name: 'iOS'
-  version:
+  version: ''
 
 
 ##########


### PR DESCRIPTION
Some database entries were quoted inconsistently, potentially leading to some `null` type version values instead of empty strings. Other quotes added for pure consistency.
