### PR TITLE
Fix warnings with regexps that present in Ruby

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -1459,7 +1459,7 @@ Sony:
     - regex: '(?:Sony-)?(KDL?-?[0-9a-z]+)'
       model: '$1'
       device: 'tv'
-    - regex: 'Opera TV Store.*(?:Sony-)([0-9a-z-_]+)'
+    - regex: 'Opera TV Store.*(?:Sony-)([0-9a-z\-_]+)'
       model: '$1'
       device: 'tv'
     - regex: '((?:WT|SO|ST|SK|MK)[0-9]+[a-z]*[0-9]*)(?: Build|\))'
@@ -3045,14 +3045,14 @@ Ouki:
 
 # Overmax
 Overmax:
-  regex: 'OV-[a-z]+(?:[^;/]+)? Build'
+  regex: 'OV-[a-z]+(?:[^;/]*) Build'
   device: 'tablet'
   models:
     - regex: 'OV-Vertis-([^;/]+) Build'
       model: 'OV-Vertis-$1'
       device: 'smartphone'
 
-    - regex: '(OV-[a-z]+(?:[^;/]+)?) Build'
+    - regex: '(OV-[a-z]+(?:[^;/]*)) Build'
       model: '$1'
 
 # Oysters
@@ -4133,7 +4133,7 @@ Toplux:
 
 # Trevi
 Trevi:
-  regex: 'Trevi[ _]|TAB[ _]10[ _]3G[ _]V16|TAB[ _](7|8)[ _]3G[ _]V8|TAB9 3G|MINITAB 3GV|Phablet[ _](?:4|4\.5|5|5\,3|6)[ _]?[C|S|Q]|REVERSE[ _]5\.5[ _]?Q'
+  regex: 'Trevi[ _]|TAB[ _]10[ _]3G[ _]V16|TAB[ _](7|8)[ _]3G[ _]V8|TAB9 3G|MINITAB 3GV|Phablet[ _](?:4|4\.5|5|5\,3|6)[ _]?[CSQ]|REVERSE[ _]5\.5[ _]?Q'
   device: 'tablet'
   models:
     - regex: 'TAB[ _]?(7|8)[ _]3G[ _]V8'


### PR DESCRIPTION
This PR fixes some warnings about the regular expressions that present when using some patterns with Ruby via https://github.com/podigee/device_detector.

I believe this does not change the semantics of those patterns -- so even though the motivation for this PR is somewhat external, I am hoping it will be merge-able for the benefit of the `device_detetor` Rubygem.

Let me know if you have any questions or I am make further changes to help make this PR merg-eable.

Here is the related change in the PR for that Rubygem repo:
https://github.com/podigee/device_detector/pull/22/files#diff-e4f032e0894d753fbcba03794958c7f1L1444

Thanks!
