### PR TITLE
Optimized Catchpoint lookup

### DIFF
--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1207,6 +1207,14 @@
     name: 'Monitor.Us'
     url: 'http://www.monitor.us'
 
+- regex: 'Catchpoint( bot)?'
+  name: 'Catchpoint'
+  category: 'Site Monitor'
+  url: ''
+  producer:
+    name: 'Catchpoint Systems'
+    url: 'http://www.catchpoint.com/'
+
 - regex: 'Zao/'
   name: 'Zao'
   category: 'Crawler'
@@ -1262,7 +1270,7 @@
 - regex: 'Server Density Service Monitoring.*'
   name: 'Server Density'
 
-- regex: '(A6-Indexer|nuhk|TsolCrawler|Yammybot|Openbot|Gulper Web Bot|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|teoma|blitzbot|oegp|furlbot|http%20client|polybot|htdig|mogimogi|larbin|scrubby|searchsight|seekbot|semanticdiscovery|snappy|vortex(?! Build)|zeal|fast-webcrawler|converacrawler|dataparksearch|findlinks|BrowserMob|HttpMonitor|ThumbShotsBot|URL2PNG|ZooShot|GomezA|Catchpoint bot|Google SketchUp|Read%20Later|Minimo|RackspaceBot)'
+- regex: '(A6-Indexer|nuhk|TsolCrawler|Yammybot|Openbot|Gulper Web Bot|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|teoma|blitzbot|oegp|furlbot|http%20client|polybot|htdig|mogimogi|larbin|scrubby|searchsight|seekbot|semanticdiscovery|snappy|vortex(?! Build)|zeal|fast-webcrawler|converacrawler|dataparksearch|findlinks|BrowserMob|HttpMonitor|ThumbShotsBot|URL2PNG|ZooShot|GomezA|Google SketchUp|Read%20Later|Minimo|RackspaceBot)'
   name: 'Generic Bot'
 
 # Generic detections


### PR DESCRIPTION
In our access logs I figured out that Catchpoint has not "bot" included. Therefore made it optional to have a correct detection. Further added the information about Catchpoint.
