### PR TITLE
updates "MultiPhone 8500 Duo" client fixture

### DIFF
--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -6786,7 +6786,7 @@
     type: browser
     name: Internet Explorer
     short_name: IE
-    version: "11"
+    version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:


### PR DESCRIPTION
Client is actually "11.0". PHP unstrict comparison is just fine with treating "11.0" the same as "11".
