### PR TITLE
Add detection for podcast clients/libraries

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2476,3 +2476,12 @@
     producer:
       name: reddit inc.
       url: http://www.reddit.com
+- 
+  user_agent: Castro 2, Episode Duration Lookup
+  bot:
+    name: Castro 2
+    category: Service Agent
+    url: http://supertop.co/castro/
+    producer: 
+      name: 'Supertop'
+      url: 'http://supertop.co'

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -216,3 +216,38 @@
     model: 
   os_family: iOS
   browser_family: Unknown
+
+-
+  user_agent: Castro 2 Episode Download
+  os:
+    name: iOS
+    short_name: IOS
+    version: 
+    platform:
+  client:
+    type: mobile app
+    name: Castro 2
+    version: ""
+  device:
+    type:
+    brand:
+    model:
+  os_family: iOS
+  browser_family: Unknown
+-
+  user_agent: Castro 2 2.1.2/646 Like iTunes
+  os:
+    name: iOS
+    short_name: IOS
+    version: 
+    platform:
+  client:
+    type: mobile app
+    name: Castro 2
+    version: "2.1.2"
+  device:
+    type:
+    brand:
+    model:
+  os_family: iOS
+  browser_family: Unknown

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -268,3 +268,20 @@
     model:
   os_family: Android
   browser_family: Unknown
+-
+  user_agent: okhttp/2.7.5
+  os:
+    name: Android
+    short_name: AND
+    version: 
+    platform:
+  client:
+    type: library
+    name: OkHttp
+    version: "2.7.5"
+  device:
+    type:
+    brand:
+    model:
+  os_family: Android
+  browser_family: Unknown

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -251,3 +251,20 @@
     model:
   os_family: iOS
   browser_family: Unknown
+-
+  user_agent: Player FM
+  os:
+    name: Android
+    short_name: AND
+    version: 
+    platform:
+  client:
+    type: mobile app
+    name: Player FM
+    version: ""
+  device:
+    type:
+    brand:
+    model:
+  os_family: Android
+  browser_family: Unknown

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -181,6 +181,23 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
+-
+  user_agent: Podcatcher Deluxe
+  os:
+    name: Android
+    short_name: AND
+    version: ""
+    platform:
+  client:
+    type: mobile app
+    name: Podcatcher Deluxe
+    version: ""
+  device:
+    type: 
+    brand: 
+    model: 
+  os_family: Android
+  browser_family: Unknown
 
 -
   user_agent: iCatcher! Podcast Player/2.6.2

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -9170,6 +9170,23 @@
   os_family: Android
   browser_family: Chrome
 - 
+  user_agent: bPod
+  os:
+    name: BlackBerry OS
+    short_name: BLB
+    version:
+    platform:
+  client:
+    type: mobile app
+    name: bPod
+    version: ""
+  device:
+    type: 
+    brand: 
+    model: 
+  os_family: BlackBerry
+  browser_family: Unknown
+- 
   user_agent: FlyCast/1.34 (BlackBerry; 8330/4.5.0.131 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/-1)
   os:
     name: BlackBerry OS

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -69,6 +69,14 @@
     name: 'Apple Inc'
     url: 'http://www.apple.com'
 
+- regex: 'Castro 2, Episode Duration Lookup'
+  name: 'Castro 2'
+  category: 'Service Agent'
+  url: 'http://supertop.co/castro/'
+  producer: 
+    name: 'Supertop'
+    url: 'http://supertop.co'
+
 - regex: 'Curious George'
   name: 'Analytics SEO Crawler'
   category: 'Crawler'

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -32,3 +32,7 @@
 - regex: '(?:perlclient|libwww-perl)(?:/?(\d+[\.\d]+))?'
   name: 'Perl'
   version: '$1'
+
+- regex: 'okhttp/([\d\.]+)'
+  name: 'OkHttp'
+  version: '$1'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -10,6 +10,10 @@
   name: 'AndroidDownloadManager'
   version: '$1'
 
+- regex: 'bPod'
+  name: 'bPod'
+  version: ''
+
 # Facebook
 - regex: '(?:FBAV|com.facebook.katana)(?:[ /]([\d\.]+))?'
   name: 'Facebook'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -95,6 +95,10 @@
   name: 'Overcast'
   version: '$1'
 -
+  regex: 'Player FM'
+  name: 'Player FM'
+  version: ''
+-
   regex: 'Podkicker(?: Pro)?/([\d\.]+)'
   name: 'Podkicker'
   version: '$1'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -103,6 +103,14 @@
   name: 'Castro'
   version: '$1'
 -
+  regex: 'Castro 2 ([\d\.]+)/[\d]+ Like iTunes'
+  name: 'Castro 2'
+  version: '$1'
+-
+  regex: 'Castro 2'
+  name: 'Castro 2'
+  version: ''
+-
   regex: 'DoggCatcher'
   name: 'DoggCatcher'
   version:

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -49,6 +49,11 @@
   name: 'Pinterest'
   version: '$1'
 
+# Podcatcher Deluxe
+- regex: 'Podcatcher Deluxe'
+  name: 'Podcatcher Deluxe'
+  version: ''
+
 # YouTube
 - regex: 'com.google.android.youtube(?:/([\d\.]+))?'
   name: 'YouTube'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -446,6 +446,10 @@
 - regex: 'BlackBerry'
   name: 'BlackBerry OS'
   version: ''
+  
+- regex: 'bPod'
+  name: 'BlackBerry OS'
+  version: ''
 
 
 ##########

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -90,7 +90,7 @@
   name: 'Android'
   version: ''
 
-- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM'
+- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM|okhttp'
   name: 'Android'
   version: ''
   

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -90,7 +90,7 @@
   name: 'Android'
   version: ''
 
-- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM|okhttp'
+- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM|okhttp|Podcatcher Deluxe'
   name: 'Android'
   version: ''
   

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -90,7 +90,7 @@
   name: 'Android'
   version: ''
 
-- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher'
+- regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM'
   name: 'Android'
   version: ''
   


### PR DESCRIPTION
Add detection for the following clients:

- Castro 2 (supertop.co/castro/)
- Player FM (https://player.fm/)
- okhttp (https://square.github.io/okhttp/)
- bPod (https://appworld.blackberry.com/webstore/content/27375300/?lang=en)
- Podcatcher Deluxe (http://www.podcatcher-deluxe.com/)