### PR TITLE
recognize PritTorrent as bot

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2485,3 +2485,12 @@
     producer:
       name: reddit inc.
       url: http://www.reddit.com
+- 
+  user_agent: PritTorrent/1.0
+  bot:
+    name: PritTorrent
+    category: Crawler
+    url: https://github.com/astro/prittorrent
+    producer:
+      name: Bitlove
+      url: http://bitlove.org/

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -692,6 +692,14 @@
     name: 'PHP Server Monitor'
     url: 'http://www.phpservermonitor.org/'
 
+- regex: 'PritTorrent'
+  name: 'PritTorrent'
+  category: 'Crawler'
+  url: 'https://github.com/astro/prittorrent'
+  producer:
+    name: 'Bitlove'
+    url: 'http://bitlove.org/'
+
 - regex: 'psbot(-page)?'
   name: 'Picsearch bot'
   category: 'Search bot'


### PR DESCRIPTION
PritTorrent is a crawler by http://bitlove.org/. It is already a known UserAgent but should be categorised as bot.