### PR TITLE
Detect the other two OnePlus Two models

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -5130,12 +5130,12 @@ ZTE:
 
 # OnePlus
 OnePlus:
-  regex: '(?:A0001|A2005|E1003) Build'
+  regex: '(?:A0001|A2001|A2003|A2005|E1003) Build'
   device: 'smartphone'
   models:
     - regex: 'A0001'
       model: 'One'
-    - regex: 'A2005'
+    - regex: 'A2001|A2003|A2005'
       model: 'Two'
     - regex: 'E1003'
       model: 'X'


### PR DESCRIPTION
As per https://forums.oneplus.net/threads/three-oneplus-2-versions-spotted-a2001-a2003-a2005.319368/ there's three models of OnePlus Two