### PR TITLE
A few more Bots: DuckDuckGo Bot, "checker", Guzzle, PocketParser 

### DIFF
--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -82,3 +82,39 @@
     type: library
     name: Guzzle (PHP HTTP Client)
     version: "3.9.3"
+-
+  user_agent: HTTP_Request2/2.3.0 (http://pear.php.net/package/http_request2) PHP/5.3.3
+  client:
+    type: library
+    name: HTTP_Request2
+    version: 2.3.0
+-
+  user_agent: Mechanize/2.7.3 Ruby/1.9.3p551 (http://github.com/sparklemotion/mechanize/)
+  client:
+    type: library
+    name: Mechanize
+    version: 2.7.3
+-
+  user_agent: Python/3.5 aiohttp/1.0.5
+  client:
+    type: library
+    name: aiohttp
+    version: 1.0.5
+-
+  user_agent: Google-HTTP-Java-Client/1.17.0-rc (gzip)
+  client:
+    type: library
+    name: Google HTTP Java Client
+    version: 1.17.0-rc
+-
+  user_agent: WWW-Mechanize/1.73
+  client:
+    type: library
+    name: WWW-Mechanize
+    version: 1.73
+-
+  user_agent: Faraday v0.9.1
+  client:
+    type: library
+    name: Faraday
+    version: 0.9.1

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -507,7 +507,16 @@
     producer:
       name: SEOmoz, Inc.
       url: http://moz.com/
-- 
+-
+  user_agent: Mozilla/5.0 (compatible; DuckDuckGo-Favicons-Bot/1.0; +http://duckduckgo.com)
+  bot:
+    name: DuckDuckGo Bot
+    category: Search bot
+    url: https://duckduckgo.com/duckduckbot
+    producer:
+      name: DuckDuckGo
+      url: https://duckduckgo.com/
+-
   user_agent: EMail Exractor
   bot:
     name: EMail Exractor
@@ -2648,5 +2657,9 @@
    name: Generic Bot
 -
   user_agent: PHPCrawl
+  bot:
+    name: Generic Bot
+-
+  user_agent: COMODO SSL Checker
   bot:
     name: Generic Bot

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -1618,7 +1618,16 @@
     producer:
       name: PHP Server Monitor
       url: http://www.phpservermonitor.org/
-- 
+-
+  user_agent: PocketParser/2.0 (+https://getpocket.com/pocketparser_ua)
+  bot:
+    name: 'PocketParser'
+    category: 'Read-it-later Service'
+    url: 'https://getpocket.com/pocketparser_ua'
+    producer:
+      name: 'Pocket'
+      url: 'https://getpocket.com/'
+-
   user_agent: Mozilla/5.0 (compatible; PaperLiBot/2.1; http://support.paper.li/entries/20023257-what-is-paper-li)
   bot:
     name: PaperLiBot
@@ -2654,7 +2663,11 @@
 -
   user_agent: Faraday v0.9.1
   bot:
-   name: Generic Bot
+    name: Generic Bot
+-
+  user_agent: Guzzle/5.3.1 curl/7.52.1 PHP/7.0.15-1
+  bot:
+    name: Generic Bot
 -
   user_agent: PHPCrawl
   bot:

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2641,34 +2641,6 @@
       name: reddit inc.
       url: http://www.reddit.com
 -
-  user_agent: Python/3.5 aiohttp/1.0.5
-  bot:
-    name: Generic Bot
--
-  user_agent: Google-HTTP-Java-Client/1.17.0-rc (gzip)
-  bot:
-    name: Generic Bot
--
-  user_agent: HTTP_Request2/2.3.0 (http://pear.php.net/package/http_request2) PHP/5.3.3
-  bot:
-    name: Generic Bot
--
-  user_agent: Mechanize/2.7.3 Ruby/1.9.3p551 (http://github.com/sparklemotion/mechanize/)
-  bot:
-    name: Generic Bot
--
-  user_agent: WWW-Mechanize/1.73
-  bot:
-    name: Generic Bot
--
-  user_agent: Faraday v0.9.1
-  bot:
-    name: Generic Bot
--
-  user_agent: Guzzle/5.3.1 curl/7.52.1 PHP/7.0.15-1
-  bot:
-    name: Generic Bot
--
   user_agent: PHPCrawl
   bot:
     name: Generic Bot

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1392,10 +1392,6 @@
 - regex: '(A6-Indexer|nuhk|TsolCrawler|Yammybot|Openbot|Gulper Web Bot|grub-client|Download Demon|SearchExpress|Microsoft URL Control|borg|altavista|teoma|blitzbot|oegp|furlbot|http%20client|polybot|htdig|mogimogi|larbin|scrubby|searchsight|seekbot|semanticdiscovery|snappy|vortex(?! Build)|zeal|fast-webcrawler|converacrawler|dataparksearch|findlinks|BrowserMob|HttpMonitor|ThumbShotsBot|URL2PNG|ZooShot|GomezA|Google SketchUp|Read%20Later|Minimo|RackspaceBot)'
   name: 'Generic Bot'
 
-# Some libraries used for bots
-- regex: '(HTTP_Request2|Mechanize|aiohttp|Google-HTTP-Java-Client|WWW-Mechanize|faraday|Guzzle)'
-  name: 'Generic Bot'
-
 # Generic detections
 
 - regex: 'Nutch'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -317,6 +317,14 @@
     name: 'SEOmoz, Inc.'
     url: 'http://moz.com/'
 
+- regex: 'DuckDuck'
+  name: 'DuckDuckGo Bot'
+  category: 'Search bot'
+  url: 'https://duckduckgo.com/duckduckbot'
+  producer:
+    name: 'DuckDuckGo'
+    url: 'https://duckduckgo.com/'
+
 - regex: 'EasouSpider'
   name: 'Easou Spider'
   category: 'Search bot'
@@ -1390,5 +1398,5 @@
     name: 'The Apache Software Foundation'
     url: 'http://www.apache.org/foundation/'
 
-- regex: '[a-z0-9\-_]*((?<!cu)bot|crawler|crawl|archiver|transcoder|spider)([^a-z]|$)'
+- regex: '[a-z0-9\-_]*((?<!cu)bot|crawler|crawl|checker|archiver|transcoder|spider)([^a-z]|$)'
   name: 'Generic Bot'

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -755,6 +755,14 @@
     name: 'PHP Server Monitor'
     url: 'http://www.phpservermonitor.org/'
 
+- regex: 'PocketParser'
+  name: 'PocketParser'
+  category: 'Read-it-later Service'
+  url: 'https://getpocket.com/pocketparser_ua'
+  producer:
+    name: 'Pocket'
+    url: 'https://getpocket.com/'
+
 - regex: 'PritTorrent'
   name: 'PritTorrent'
   category: 'Crawler'
@@ -1385,7 +1393,7 @@
   name: 'Generic Bot'
 
 # Some libraries used for bots
-- regex: '(HTTP_Request2|Mechanize|aiohttp|Google-HTTP-Java-Client|WWW-Mechanize|faraday)'
+- regex: '(HTTP_Request2|Mechanize|aiohttp|Google-HTTP-Java-Client|WWW-Mechanize|faraday|Guzzle)'
   name: 'Generic Bot'
 
 # Generic detections

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -36,3 +36,32 @@
 - regex: 'okhttp/([\d\.]+)'
   name: 'OkHttp'
   version: '$1'
+
+- regex: 'HTTP_Request2(?:/(\d+[\.\d]+))?'
+  name: 'HTTP_Request2'
+  version: '$1'
+
+- regex: 'HTTP_Request2(?:/(\d+[\.\d]+))?'
+  name: 'HTTP_Request2'
+  version: '$1'
+  url: 'http://pear.php.net/package/http_request2'
+
+- regex: 'Mechanize(?:/(\d+[\.\d]+))?'
+  name: 'Mechanize'
+  version: '$1'
+  url: 'http://github.com/sparklemotion/mechanize/'
+
+- regex: 'aiohttp(?:/(\d+[\.\d]+))?'
+  name: 'aiohttp'
+  version: '$1'
+
+- regex: 'Google-HTTP-Java-Client(?:/(\d+[\.\d-\w]+))?'
+  name: 'Google HTTP Java Client'
+  version: '$1'
+
+- regex: 'WWW-Mechanize(?:/(\d+[\.\d]+))?'
+  name: 'WWW-Mechanize'
+  version: '$1'
+- regex: 'Faraday(?: v(\d+[\.\d]+))?'
+  name: 'Faraday'
+  version: '$1'


### PR DESCRIPTION
Sorry for the multiple pull requests, but I keep finding new bots.
 - DuckDuckGo Bot
 - "checker" as generic bot suffix
 - Guzzle (PHP HTTP client)
 - PocketParser (I added the new category 'Read-it-later Service')
I also wanted to add Instapaper, but they seem to use a not helpful user-agent: 
`Mozilla/5.0 (Macintosh; Intel Mac OS X 10_7_3) AppleWebKit/534.55.3 (KHTML, like Gecko) Version/5.1.3 Safari/534.53.10`