### PR TITLE
Adjust Google-HTTP-Java-Client regex to be compatible with ruby

### DIFF
--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -55,7 +55,7 @@
   name: 'aiohttp'
   version: '$1'
 
-- regex: 'Google-HTTP-Java-Client(?:/(\d+[\.\d-\w]+))?'
+- regex: 'Google-HTTP-Java-Client(?:/(\d+[\.\d\w-]+))?'
   name: 'Google HTTP Java Client'
   version: '$1'
 


### PR DESCRIPTION

All tests still pass, this should just make the regexes more portable