### PR TITLE
Fix Chrome OS version detection

### DIFF
--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -523,7 +523,7 @@
   os:
     name: Chrome OS
     short_name: COS
-    version: "4731.101.0"
+    version: "31.0.1650.67"
     platform: x64
 -
   user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Large Screen Safari/534.24 GoogleTV/092754

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -224,7 +224,7 @@
   os:
     name: Chrome OS
     short_name: COS
-    version: "4731.101.0"
+    version: "31.0.1650.67"
     platform: x64
   client:
     type: browser

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -419,7 +419,7 @@
 ##########
 # ChromeOS
 ##########
-- regex: 'CrOS [a-z0-9_]+ (\d+[\.\d]+)'
+- regex: 'CrOS [a-z0-9_]+ .* Chrome/(\d+[\.\d]+)'
   name: 'Chrome OS'
   version: '$1'
   


### PR DESCRIPTION
This switches to using the Chrome OS version that's commonly cited by Google and other sources, instead of the platform version.