### PR TITLE
update Blackberry Priv fixture quoting

### DIFF
--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -717,15 +717,15 @@
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
-    platform: ""
+    version: "6.0.1"
+    platform:
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 56.0.2924.87
+    version: "56.0.2924.87"
     engine: Blink
-    engine_version: ""
+    engine_version:
   device:
     type: smartphone
     brand: RM


### PR DESCRIPTION
The recently added Blackberry Priv fixture entry had some quotes placed inconsistently compared to the other entries (`platform` and `engine_version` being empty strings instead of `null`).