### PR TITLE
rename Epiphany to GNOME Web

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -70,7 +70,7 @@ class Browser extends ClientParserAbstract
         'DI' => 'Dillo',
         'EL' => 'Elinks',
         'EB' => 'Element Browser',
-        'EP' => 'Epiphany',
+        'EP' => 'GNOME Web',
         'ES' => 'Espial TV Browser',
         'FB' => 'Firebird',
         'FD' => 'Fluid',

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -435,7 +435,7 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i586; en-US; rv:1.6) Gecko/20040413 Epiphany/1.2.6
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "1.2.6"
     engine: Gecko
@@ -444,7 +444,7 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; fr-fr) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+ Debian/squeeze (2.30.6-1) Epiphany/2.30.6
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "2.30.6"
     engine: WebKit

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -248,7 +248,7 @@
     platform: x86
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "2.30.6"
     engine: WebKit
@@ -268,7 +268,7 @@
     platform:
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "3.8.2"
     engine: WebKit
@@ -348,7 +348,7 @@
     platform: x86
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "3.4.2"
     engine: WebKit
@@ -368,7 +368,7 @@
     platform: x64
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "3.4.2"
     engine: WebKit
@@ -2111,7 +2111,7 @@
     platform: x64
   client:
     type: browser
-    name: Epiphany
+    name: GNOME Web
     short_name: EP
     version: "2.30.6"
     engine: WebKit

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -385,9 +385,9 @@
     versions:
       28: 'Blink'
 
-#Epiphany
+#GNOME Web
 - regex: 'Epiphany(?:/(\d+[\.\d]+))?'
-  name: 'Epiphany'
+  name: 'GNOME Web'
   version: '$1'
   engine:
     default: 'Gecko'


### PR DESCRIPTION
replaces https://github.com/piwik/device-detector/pull/5527, but with fixed tests