### PR TITLE
move 'UC Browser' to the front of 'Chrome'

### DIFF
--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -9337,17 +9337,17 @@
     platform:
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
-    version: "30.0.0.0"
-    engine: Blink
-    engine_version:
+    name: UC Browser
+    short_name: UC
+    version: "3.4.1.483"
+    engine: WebKit
+    engine_version: "537.36"
   device:
     type: smartphone
     brand: SO
     model: Xperia E3 Dual
   os_family: Android
-  browser_family: Chrome
+  browser_family: Unknown
 - 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2105 Build/24.0.A.5.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -451,6 +451,14 @@
   engine:
     default: 'WebKit'
 
+#UC Browser
+- regex: 'UC[ ]?Browser(?:[ /]?(\d+[\.\d]+))?'
+  name: 'UC Browser'
+  version: '$1'
+- regex: 'UCWEB(?:[ /]?(\d+[\.\d]+))?'
+  name: 'UC Browser'
+  version: '$1'
+
 #Chrome
 - regex: 'CrMo(?:/(\d+[\.\d]+))?'
   name: 'Chrome Mobile'
@@ -490,14 +498,6 @@
     default: 'WebKit'
     versions:
       28: 'Blink'
-
-#UC Browser
-- regex: 'UC[ ]?Browser(?:[ /]?(\d+[\.\d]+))?'
-  name: 'UC Browser'
-  version: '$1'
-- regex: 'UCWEB(?:[ /]?(\d+[\.\d]+))?'
-  name: 'UC Browser'
-  version: '$1'
 
 #Tizen Browser
 - regex: '(?:Tizen|SLP) Browser(?:/(\d+[\.\d]+))?'


### PR DESCRIPTION
Hi sgiehl  :)

New version of 'UC Browser' user agent like this:

```
Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; HUAWEI ALE-CL00 Build/HuaweiALE-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.3.0.907 Mobile Safari/537.36
```

detection result:
client (browser): Chrome 40.0

'UC Browser' is the most popular mobile browser in China, and it has 100+ million active users.

More user agent of 'UC Browser':
https://www.handsetdetection.com/properties/browsers/UC%20Browser/11.3