### PR TITLE
Adds detection for Trendiction Bot

### DIFF
--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -2128,6 +2128,15 @@
     producer:
       name:
       url:
+-
+  user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-GB; rv:1.0; trendictionbot0.5.0; trendiction search; http://www.trendiction.de/bot; please let us know of any problems; web at trendiction.com) Gecko/20071127 Firefox/3.0.0.11
+  bot:
+    name: Trendiction Bot
+    category: Crawler
+    url: http://www.trendiction.de/bot
+    producer:
+      name: Talkwalker Inc.
+      url: http://www.talkwalker.com
 - 
   user_agent: TurnitinBot/3.0 (http://www.turnitin.com/robot/crawlerinfo.html)
   bot:

--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -1078,6 +1078,14 @@
     name: ''
     url: ''
 
+- regex: 'trendictionbot'
+  name: 'Trendiction Bot'
+  category: 'Crawler'
+  url: 'http://www.trendiction.de/bot'
+  producer:
+    name: 'Talkwalker Inc.'
+    url: 'http://www.talkwalker.com'
+
 - regex: 'TurnitinBot'
   name: 'TurnitinBot'
   category: 'Crawler'


### PR DESCRIPTION
Not 100% sure about the producer information.

The bot information page has a `Trendiction S.A.` in the footer but the contact link directs to `Talkwalker Inc.` at the same address in Luxembourg.