### PR TITLE
Adds detection for Nokia branded phones by HMD Global

### DIFF
--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -1497,3 +1497,103 @@
     model: Pro
   os_family: Android
   browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1035 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "7.1.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "60.0.3112.116"
+    engine: Blink
+    engine_version:
+  device:
+    type: smartphone
+    brand: NK
+    model: 2
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1032 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "7.1.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "60.0.3112.116"
+    engine: Blink
+    engine_version:
+  device:
+    type: smartphone
+    brand: NK
+    model: 3
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1024 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "7.1.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "60.0.3112.116"
+    engine: Blink
+    engine_version:
+  device:
+    type: smartphone
+    brand: NK
+    model: 5
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1003 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "7.1.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "60.0.3112.116"
+    engine: Blink
+    engine_version:
+  device:
+    type: smartphone
+    brand: NK
+    model: 6
+  os_family: Android
+  browser_family: Chrome
+-
+  user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1004 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "7.1.1"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "60.0.3112.116"
+    engine: Blink
+    engine_version:
+  device:
+    type: smartphone
+    brand: NK
+    model: 8
+  os_family: Android
+  browser_family: Chrome

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -154,7 +154,7 @@ Microsoft:
 
 # NOKIA
 Nokia:
-  regex: 'Nokia|Lumia|Maemo RX|portalmmm/2\.0 N7|portalmmm/2\.0 NK|nok[0-9]+|Symbian.*\s([a-z0-9]+)$|RX-51 N900'
+  regex: 'Nokia|Lumia|Maemo RX|portalmmm/2\.0 N7|portalmmm/2\.0 NK|nok[0-9]+|Symbian.*\s([a-z0-9]+)$|RX-51 N900|TA-[0-9]{4} Build'
   device: 'smartphone'
   models:
     - regex: 'RX-51 N900'
@@ -187,6 +187,18 @@ Nokia:
     - regex: 'Symbian.*\s([a-z0-9]+)$'
       device: 'feature phone'
       model: '$1'
+
+    # Nokia branded phones by HMD Global
+    - regex: 'TA-10(07|23|29|35)'
+      model: '2'
+    - regex: 'TA-10(20|28|32|38)'
+      model: '3'
+    - regex: 'TA-10(24|27|44|53)'
+      model: '5'
+    - regex: 'TA-10(00|03|21|25|33|39)'
+      model: '6'
+    - regex: 'TA-10(04|12)'
+      model: '8'
 
 # CnM
 CnM:


### PR DESCRIPTION
Created detection for the following models:
- Nokia 2: TA-1007 TA-1023 TA-1029 TA-1035
- Nokia 3: TA-1020 TA-1028 TA-1032 TA-1038
- Nokia 5: TA-1024 TA-1027 TA-1044 TA-1053
- Nokia 6: TA-1000 TA-1003 TA-1021 TA-1025 TA-1033 TA-1039
- Nokia 8: TA-1004 TA-1012
