### PR TITLE
Added support for Edge/Android and Edge/iOS ...

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -151,6 +151,8 @@ class Browser extends ClientParserAbstract
         'PO' => 'Polaris',
         'PT' => 'Polarity',
         'PS' => 'Microsoft Edge',
+        'PB' => 'Microsoft Edge for Android',
+        'PI' => 'Microsoft Edge for iOS',
         'QQ' => 'QQ Browser',
         'QT' => 'Qutebrowser',
         'QZ' => 'QupZilla',

--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -151,8 +151,6 @@ class Browser extends ClientParserAbstract
         'PO' => 'Polaris',
         'PT' => 'Polarity',
         'PS' => 'Microsoft Edge',
-        'PB' => 'Microsoft Edge for Android',
-        'PI' => 'Microsoft Edge for iOS',
         'QQ' => 'QQ Browser',
         'QT' => 'Qutebrowser',
         'QZ' => 'QupZilla',

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -729,6 +729,24 @@
     engine: Edge
     engine_version: "13.10547"
 -
+  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1
+  client:
+    type: browser
+    name: Microsoft Edge for iOS
+    short_name: PI
+    version: "41.1"
+    engine: WebKit
+    engine_version: "603.2.4"
+-
+  user_agent: Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1
+  client:
+    type: browser
+    name: Microsoft Edge for Android
+    short_name: PB
+    version: "41.1"
+    engine: Blink
+    engine_version: ""
+-
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
   client:
     type: browser

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -734,7 +734,7 @@
     type: browser
     name: Microsoft Edge for iOS
     short_name: PI
-    version: "41.1"
+    version: "41.1.35.1"
     engine: WebKit
     engine_version: "603.2.4"
 -
@@ -743,7 +743,7 @@
     type: browser
     name: Microsoft Edge for Android
     short_name: PB
-    version: "41.1"
+    version: "41.1.35.1"
     engine: Blink
     engine_version: ""
 -

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -732,8 +732,8 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1
   client:
     type: browser
-    name: Microsoft Edge for iOS
-    short_name: PI
+    name: Microsoft Edge
+    short_name: PS
     version: "41.1.35.1"
     engine: WebKit
     engine_version: "603.2.4"
@@ -741,8 +741,8 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1
   client:
     type: browser
-    name: Microsoft Edge for Android
-    short_name: PB
+    name: Microsoft Edge
+    short_name: PS
     version: "41.1.35.1"
     engine: Blink
     engine_version: ""

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -14,14 +14,14 @@
 
 # Microsoft Edge for iOS
 - regex: 'EdgiOS[ /](\d+[\.\d]+)'
-  name: 'Microsoft Edge for iOS'
+  name: 'Microsoft Edge'
   version: '$1'
   engine:
     default: 'WebKit'
 
 # Microsoft Edge for Android
 - regex: 'EdgA[ /](\d+[\.\d]+)'
-  name: 'Microsoft Edge for Android'
+  name: 'Microsoft Edge'
   version: '$1'
   engine:
     default: 'Blink'

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -12,6 +12,20 @@
   engine:
     default: 'Edge'
 
+# Microsoft Edge for iOS
+- regex: 'EdgiOS[ /](\d+[\.\d]+)'
+  name: 'Microsoft Edge for iOS'
+  version: '$1'
+  engine:
+    default: 'WebKit'
+
+# Microsoft Edge for Android
+- regex: 'EdgA[ /](\d+[\.\d]+)'
+  name: 'Microsoft Edge for Android'
+  version: '$1'
+  engine:
+    default: 'Blink'
+
 # 360 Browser
 - regex: 'QIHU 360[ES]E'
   name: '360 Browser'


### PR DESCRIPTION
I used the following shortcodes to referring to Edge on a mobile-device
```
'PB' => 'Microsoft Edge for Android'  // Project Spartan on Blink-engine
'PI' => 'Microsoft Edge for iOS' // Project Spartan on iOS
```
https://blogs.windows.com/msedgedev/2017/10/05/microsoft-edge-ios-android-developer/