### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/Tests/Cache/PSR16CacheTest.php
+++ b/Tests/Cache/PSR16CacheTest.php
@@ -10,12 +10,13 @@ namespace DeviceDetector\Tests\Cache;
 use DeviceDetector\Cache\PSR16Bridge;
 use MatthiasMullie\Scrapbook\Adapters\MemoryStore;
 use MatthiasMullie\Scrapbook\Psr16\SimpleCache;
+use PHPUnit\Framework\TestCase;
 
 if (!class_exists('\MatthiasMullie\Scrapbook\Adapters\MemoryStore')) {
     return;
 }
 
-class PSR16CacheTest extends \PHPUnit_Framework_TestCase
+class PSR16CacheTest extends TestCase
 {
     protected function setUp()
     {

--- a/Tests/Cache/PSR6CacheTest.php
+++ b/Tests/Cache/PSR6CacheTest.php
@@ -10,12 +10,13 @@ namespace DeviceDetector\Tests\Cache;
 use DeviceDetector\Cache\PSR6Bridge;
 use MatthiasMullie\Scrapbook\Adapters\MemoryStore;
 use MatthiasMullie\Scrapbook\Psr6\Pool;
+use PHPUnit\Framework\TestCase;
 
 if (!class_exists('\MatthiasMullie\Scrapbook\Adapters\MemoryStore')) {
     return;
 }
 
-class PSR6CacheTest extends \PHPUnit_Framework_TestCase
+class PSR6CacheTest extends TestCase
 {
     protected function setUp()
     {

--- a/Tests/Cache/StaticCacheTest.php
+++ b/Tests/Cache/StaticCacheTest.php
@@ -8,8 +8,9 @@
 namespace DeviceDetector\Tests\Cache;
 
 use DeviceDetector\Cache\StaticCache;
+use PHPUnit\Framework\TestCase;
 
-class StaticCacheTests extends \PHPUnit_Framework_TestCase
+class StaticCacheTests extends TestCase
 {
     protected function setUp()
     {

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -11,8 +11,9 @@ use DeviceDetector\DeviceDetector;
 use DeviceDetector\Parser\Device\DeviceParserAbstract;
 use DeviceDetector\Parser\ParserAbstract;
 use DeviceDetector\Yaml\Symfony;
+use PHPUnit\Framework\TestCase;
 
-class DeviceDetectorTest extends \PHPUnit_Framework_TestCase
+class DeviceDetectorTest extends TestCase
 {
     /**
      * @expectedException \Exception

--- a/Tests/Parser/BotTest.php
+++ b/Tests/Parser/BotTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser;
 
 use DeviceDetector\Parser\Bot;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class BotTest extends \PHPUnit_Framework_TestCase
+class BotTest extends TestCase
 {
     public function testGetInfoFromUABot()
     {

--- a/Tests/Parser/Client/BrowserTest.php
+++ b/Tests/Parser/Client/BrowserTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\Browser;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class BrowserTest extends \PHPUnit_Framework_TestCase
+class BrowserTest extends TestCase
 {
     static $browsersTested = array();
 

--- a/Tests/Parser/Client/FeedReaderTest.php
+++ b/Tests/Parser/Client/FeedReaderTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\FeedReader;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class FeedReaderTest extends \PHPUnit_Framework_TestCase
+class FeedReaderTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Client/LibraryTest.php
+++ b/Tests/Parser/Client/LibraryTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\Library;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class ToolTest extends \PHPUnit_Framework_TestCase
+class ToolTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Client/MediaPlayerTest.php
+++ b/Tests/Parser/Client/MediaPlayerTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\MediaPlayer;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class MediaPlayerTest extends \PHPUnit_Framework_TestCase
+class MediaPlayerTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Client/MobileAppTest.php
+++ b/Tests/Parser/Client/MobileAppTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\MobileApp;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class MobileAppTest extends \PHPUnit_Framework_TestCase
+class MobileAppTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Client/PIMTest.php
+++ b/Tests/Parser/Client/PIMTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Client;
 
 use DeviceDetector\Parser\Client\PIM;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class PIMTest extends \PHPUnit_Framework_TestCase
+class PIMTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Devices/CameraTest.php
+++ b/Tests/Parser/Devices/CameraTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Device;
 
 use DeviceDetector\Parser\Device\Camera;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class CameraTest extends \PHPUnit_Framework_TestCase
+class CameraTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Devices/CarBrowserTest.php
+++ b/Tests/Parser/Devices/CarBrowserTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Device;
 
 use DeviceDetector\Parser\Device\CarBrowser;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class CarBrowserTest extends \PHPUnit_Framework_TestCase
+class CarBrowserTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Devices/ConsoleTest.php
+++ b/Tests/Parser/Devices/ConsoleTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser\Device;
 
 use DeviceDetector\Parser\Device\Console;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class ConsoleTest extends \PHPUnit_Framework_TestCase
+class ConsoleTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Devices/DeviceParserAbstractTest.php
+++ b/Tests/Parser/Devices/DeviceParserAbstractTest.php
@@ -8,8 +8,9 @@
 namespace DeviceDetector\Tests\Parser\Device;
 
 use DeviceDetector\Parser\Device\DeviceParserAbstract;
+use PHPUnit\Framework\TestCase;
 
-class DeviceParserAbstractTest extends \PHPUnit_Framework_TestCase
+class DeviceParserAbstractTest extends TestCase
 {
     public function testGetAvailableDeviceTypes()
     {

--- a/Tests/Parser/Devices/HbbTvTest.php
+++ b/Tests/Parser/Devices/HbbTvTest.php
@@ -8,8 +8,9 @@
 namespace DeviceDetector\Tests\Parser\Device;
 
 use DeviceDetector\Parser\Device\HbbTv;
+use PHPUnit\Framework\TestCase;
 
-class HbbTvTest extends \PHPUnit_Framework_TestCase
+class HbbTvTest extends TestCase
 {
     public function testIsHbbTv()
     {

--- a/Tests/Parser/OperatingSystemTest.php
+++ b/Tests/Parser/OperatingSystemTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser;
 
 use DeviceDetector\Parser\OperatingSystem;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class OperatingSystemTest extends \PHPUnit_Framework_TestCase
+class OperatingSystemTest extends TestCase
 {
     static $osTested = array();
 

--- a/Tests/Parser/VendorFragmentTest.php
+++ b/Tests/Parser/VendorFragmentTest.php
@@ -9,8 +9,9 @@ namespace DeviceDetector\Tests\Parser;
 
 use DeviceDetector\Parser\VendorFragment;
 use \Spyc;
+use PHPUnit\Framework\TestCase;
 
-class VendorFragmentTest extends \PHPUnit_Framework_TestCase
+class VendorFragmentTest extends TestCase
 {
     static $regexesTested = array();
 

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "mustangostang/spyc": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "4.1.*",
+        "phpunit/phpunit": "^4.8.36",
         "fabpot/php-cs-fixer": "~1.7",
         "psr/cache": "^1.0",
         "psr/simple-cache": "^1.0",


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.36`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4836---2017-06-21), that support this namespace.