### PR TITLE
Added support for Windows IoT 10.0 devices

### DIFF
--- a/Parser/OperatingSystem.php
+++ b/Parser/OperatingSystem.php
@@ -96,6 +96,7 @@ class OperatingSystem extends ParserAbstract
         'WTV' => 'WebTV',
         'WIN' => 'Windows',
         'WCE' => 'Windows CE',
+        'WIO' => 'Windows IoT',
         'WMO' => 'Windows Mobile',
         'WPH' => 'Windows Phone',
         'WRT' => 'Windows RT',
@@ -135,7 +136,7 @@ class OperatingSystem extends ParserAbstract
         'Unix'                  => array('SOS', 'AIX', 'HPX', 'BSD', 'NBS', 'OBS', 'DFB', 'SYL', 'IRI', 'T64', 'INF'),
         'WebTV'                 => array('WTV'),
         'Windows'               => array('WIN'),
-        'Windows Mobile'        => array('WPH', 'WMO', 'WCE', 'WRT')
+        'Windows Mobile'        => array('WPH', 'WMO', 'WCE', 'WRT', 'WIO')
     );
 
     /**

--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -330,6 +330,13 @@
     version: "10"
     platform: x64
 -
+  user_agent: Mozilla/5.0 (Windows IoT 10.0; Android 6.0.1; WebView/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/17.17083
+  os:
+    name: Windows IoT
+    short_name: WIO
+    version: "10"
+    platform:
+-
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; de; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20
   os:
     name: Windows

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -58,6 +58,12 @@
   name: 'Windows RT'
   version: '8.1'
 
+##########
+# Windows IoT
+##########
+- regex: 'Windows IoT 10.0'
+  name: 'Windows IoT'
+  version: '10'
 
 ##########
 # Custom Android Roms


### PR DESCRIPTION
The UserAgent for Windows IoT 10.0 devices recently changed from 

> Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; WebView/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/16.16299

to

> Mozilla/5.0 (Windows IoT 10.0; Android 6.0.1; WebView/3.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Mobile Safari/537.36 Edge/17.17083
