### PR TITLE
Added Symfony 4 YAML parser compatibility.

### DIFF
--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -347,7 +347,7 @@
   engine:
     default: ''
     versions:
-      3.5: 'Elektra'
+      '3.5': 'Elektra'
       7: 'Presto'
       15: 'Blink'
 
@@ -476,8 +476,8 @@
   engine:
     default: 'Gecko'
     versions:
-      2.9.16: '' # multi engine
-      2.28: 'WebKit'
+      '2.9.16': '' # multi engine
+      '2.28': 'WebKit'
 
 # Liebao
 - regex: 'LBBrowser(?:[ /](\d+[\.\d]+))?'


### PR DESCRIPTION
Symfony 4 YAML parser does not support numerical keys. This PR fixes compatibility with SF4.