### PR TITLE
Improved detection of Sony TV models

### DIFF
--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -2150,6 +2150,46 @@
   os_family: GNU/Linux
   browser_family: Opera
 - 
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KD-55XD8577; v3.925; 2015;) sony.hbbtv.tv.2015HE
+  os:
+    name: GNU/Linux
+    short_name: LIN
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Opera
+    short_name: OP
+    version: "22.0.1481.0"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: SO
+    model: KD-55XD8577
+  os_family: GNU/Linux
+  browser_family: Opera
+- 
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KDL-65W859C; v3.925; 2015;) sony.hbbtv.tv.2015HE
+  os:
+    name: GNU/Linux
+    short_name: LIN
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Opera
+    short_name: OP
+    version: "22.0.1481.0"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: SO
+    model: KDL-65W859
+  os_family: GNU/Linux
+  browser_family: Opera
+- 
   user_agent: Opera/9.80 (Linux mips; Opera TV Store/4510; U; en) Presto/2.10.250 Version/11.60 Model/Sony-KDL-32EX550 SonyCEBrowser/1.0 (KDL-32EX550; CTV/PKG2.120GAA; IND)
   os:
     name: GNU/Linux

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -213,7 +213,7 @@ Sony:
   regex: 'Sony'
   device: 'tv'
   models:
-    - regex: '(KDL?-?[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
+    - regex: '(KDL?-?[0-9]{2}[A-Z]{1,2}[0-9]{3,5})'
       model: '$1'
 
 # TechniSat

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -213,7 +213,7 @@ Sony:
   regex: 'Sony'
   device: 'tv'
   models:
-    - regex: '(KDL[0-9]{2}[A-Z]{1,2}[0-9]{3})'
+    - regex: '(KD[L,-]{0,2}[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
       model: '$1'
 
 # TechniSat

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -213,7 +213,7 @@ Sony:
   regex: 'Sony'
   device: 'tv'
   models:
-    - regex: '(KD[L,-]{0,2}[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
+    - regex: '(KD[L\-]{0,2}[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
       model: '$1'
 
 # TechniSat

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -213,7 +213,7 @@ Sony:
   regex: 'Sony'
   device: 'tv'
   models:
-    - regex: '(KD[L\-]{0,2}[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
+    - regex: '(KDL?-?[0-9]{2}[A-Z]{1,2}[0-9]{3,4}[A-Z]{0,1})'
       model: '$1'
 
 # TechniSat


### PR DESCRIPTION
RegEx now detects 
SONY KDL-65W859C as `KDL-65W859`
`Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KDL-65W859C; v3.925; 2015;) sony.hbbtv.tv.2015HE`

SONY KD-55XD8577 as `KD-55XD8577`
`Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KD-55XD8577; v3.925; 2015;) sony.hbbtv.tv.2015HE`