### PR TITLE
Added detection for LG models like 49UJ6307

### DIFF
--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -1056,6 +1056,46 @@
   os_family: GNU/Linux
   browser_family: Safari
 - 
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 49UH664V-ZC; WEBOS3.0 05.30.02; W3_M16;)
+  os:
+    name: webOS
+    short_name: WOS
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Chrome
+    short_name: CH
+    version: "38.0.2125.122"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: LG
+    model: 49UH664V
+  os_family: Other Mobile
+  browser_family: Chrome
+- 
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 55UJ6307-ZA; WEBOS3.5 04.70.45; W3_K3LP;)
+  os:
+    name: webOS
+    short_name: WOS
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Chrome
+    short_name: CH
+    version: 38.0.2125.122
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: LG
+    model: 55UJ6307
+  os_family: Other Mobile
+  browser_family: Chrome
+- 
   user_agent: LOEWE/TV HbbTV/1.1.1 (+PVR; Loewe; SL121; LOH;;) CE-HTML/1.0 SL121/16.16.0
   os: [ ]
   client: null

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -99,7 +99,7 @@ LG:
   regex: 'LGE'
   device: 'tv'
   models:
-    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
+    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3|[0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
       model: '$1'
 
 # Loewe

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -99,7 +99,9 @@ LG:
   regex: 'LGE'
   device: 'tv'
   models:
-    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3|[0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
+    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
+      model: '$1'
+    - regex: 'LGE;? ?([0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
       model: '$1'
 
 # Loewe


### PR DESCRIPTION
```Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 43UJ6307-ZA; WEBOS3.5 04.70.45; W3_K3LP;)
Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 49UH664V-ZC; WEBOS3.0 05.30.02; W3_M16;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 55UJ670V-ZD; WEBOS3.5 04.70.45; W3_K3LP;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 55UJ6307-ZA; WEBOS3.5 04.70.45; W3_K3LP;)
```