### PR TITLE
Detection of Samsung SmartTV models from 2016-17

### DIFF
--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -1836,6 +1836,22 @@
   os_family: Unknown
   browser_family: Unknown
 - 
+  user_agent: HbbTV/1.2.1 (+DRM;Samsung;SmartTV2017;T-KTMDEUC-1151.1;;)+TVPLUS+SmartHubLink Chrome
+  os: [ ]
+  client:
+    type: browser
+    name: Chrome
+    short_name: CH
+    version: ""
+    engine: WebKit
+    engine_version: ""
+  device:
+    type: tv
+    brand: SA
+    model: Smart TV 2017
+  os_family: Unknown
+  browser_family: Chrome
+- 
   user_agent: SmartTV/1.0.0 (SAMSUNG;OTV-SMT-E5015;0x01;BAC.2012.05.12)
   os: [ ]
   client: null

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -167,7 +167,7 @@ Samsung:
   regex: 'Samsung|Maple_2011'
   device: 'tv'
   models:
-    - regex: 'SmartTV(2012|2013|2014|2015|2016|2017)'
+    - regex: 'SmartTV(201[2-9])'
       model: 'Smart TV $1'
     - regex: 'Maple_2011'
       model: 'Smart TV 2011'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -167,7 +167,7 @@ Samsung:
   regex: 'Samsung|Maple_2011'
   device: 'tv'
   models:
-    - regex: 'SmartTV(2012|2013|2014|2015)'
+    - regex: 'SmartTV(2012|2013|2014|2015|2016|2017)'
       model: 'Smart TV $1'
     - regex: 'Maple_2011'
       model: 'Smart TV 2011'


### PR DESCRIPTION
```
HbbTV/1.2.1 (+DRM;Samsung;SmartTV2016;T-HKMFKDEUC-1201.6;;) WebKit
HbbTV/1.2.1 (+DRM;Samsung;SmartTV2016;T-JZMDEUC-1160.6;;) WebKit
HbbTV/1.1.1 (;Samsung;SmartTV2017;T-KTSDEUC-1151.1;;)+SmartHubLink Chrome
HbbTV/1.2.1 (+DRM;Samsung;SmartTV2017;T-KTMDEUC-1151.1;;)+TVPLUS+SmartHubLink Chrome
etc.
```