### PR TITLE
Detection of LG OLED models

### DIFF
--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -1056,6 +1056,46 @@
   os_family: GNU/Linux
   browser_family: Safari
 - 
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED55B6J-Z; WEBOS3.0 04.30.65; W3_K2L;)
+  os:
+    name: webOS
+    short_name: WOS
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Chrome
+    short_name: CH
+    version: "38.0.2125.122"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: LG
+    model: OLED55B6J
+  os_family: Other Mobile
+  browser_family: Chrome
+- 
+  user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED65C7V-Z; WEBOS3.5 04.70.30; W3_M16P;)
+  os:
+    name: webOS
+    short_name: WOS
+    version: ""
+    platform: ""
+  client:
+    type: browser
+    name: Chrome
+    short_name: CH
+    version: 38.0.2125.122
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: LG
+    model: OLED65C7V
+  os_family: Other Mobile
+  browser_family: Chrome
+- 
   user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 49UH664V-ZC; WEBOS3.0 05.30.02; W3_M16;)
   os:
     name: webOS

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -99,7 +99,7 @@ LG:
   regex: 'LGE'
   device: 'tv'
   models:
-    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
+    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3|OLED[0-9]{2}[A-Z]{1}[0-9]{1}[A-Z]{1})'
       model: '$1'
     - regex: 'LGE;? ?([0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
       model: '$1'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -101,7 +101,7 @@ LG:
   models:
     - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
       model: '$1'
-    - regex: 'OLED[0-9]{2}[A-Z][0-9][A-Z]'
+    - regex: '(OLED[0-9]{2}[A-Z][0-9][A-Z])'
       model: '$1'
     - regex: 'LGE;? ?([0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
       model: '$1'

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -99,7 +99,9 @@ LG:
   regex: 'LGE'
   device: 'tv'
   models:
-    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3|OLED[0-9]{2}[A-Z]{1}[0-9]{1}[A-Z]{1})'
+    - regex: '(NetCast [0-9]{1}.[0-9]{1}|GLOBAL_PLAT3)'
+      model: '$1'
+    - regex: 'OLED[0-9]{2}[A-Z][0-9][A-Z]'
       model: '$1'
     - regex: 'LGE;? ?([0-9]{2}[A-Z]{2}[0-9]{2,4}[A-Z]?)'
       model: '$1'


### PR DESCRIPTION
Added detection of LG OLED models. Structure is described here: http://en.tab-tv.com/?page_id=7111
```
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED55B6J-Z; WEBOS3.0 04.30.65; W3_K2L;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED55B7V-Z; WEBOS3.5 04.70.30; W3_M16P;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED65B7V-Z; WEBOS3.5 04.70.30; W3_M16P;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED65C7V-Z; WEBOS3.5 04.70.30; W3_M16P;)
Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED65B6J-Z; WEBOS3.0 05.30.03; W3_K2L;)
etc.
```