### PR TITLE
Detection of short Sony models

### DIFF
--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -2306,6 +2306,26 @@
   os_family: GNU/Linux
   browser_family: Opera
 - 
+  user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 OPR/29.0.1803.0 OMI/4.5.23.37.ALSAN5.131 HbbTV/1.2.1 (; Sony; KD-65ZD9; v1.602671100; 2016;) sony.hbbtv.tv.2016HE
+  os:
+    name: GNU/Linux
+    short_name: LIN
+    version: ""
+    platform: ARM
+  client:
+    type: browser
+    name: Opera
+    short_name: OP
+    version: 29.0.1803.0
+    engine: Blink
+    engine_version: ""
+  device:
+    type: tv
+    brand: SO
+    model: KD-65ZD9
+  os_family: GNU/Linux
+  browser_family: Opera
+- 
   user_agent: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL32CX525; PKG4.008EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
   os:
     name: GNU/Linux

--- a/regexes/device/televisions.yml
+++ b/regexes/device/televisions.yml
@@ -215,7 +215,7 @@ Sony:
   regex: 'Sony'
   device: 'tv'
   models:
-    - regex: '(KDL?-?[0-9]{2}[A-Z]{1,2}[0-9]{3,5})'
+    - regex: '(KDL?-?[0-9]{2}[A-Z]{1,2}[0-9]{1,5})'
       model: '$1'
 
 # TechniSat


### PR DESCRIPTION
Short model numbers are now ignored such as `KD-65ZD9`

```
Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 OPR/29.0.1803.0 OMI/4.5.23.37.ALSAN5.131 HbbTV/1.2.1 (; Sony; KD-65ZD9; v1.602671100; 2016;) sony.hbbtv.tv.2016HE
```