### PR TITLE
Add support for Android webview.

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -187,6 +187,7 @@ class Browser extends ClientParserAbstract
         'WF' => 'Waterfox',
         'WO' => 'wOSBrowser',
         'WT' => 'WeTab Browser',
+        'WV' => 'Android WebView',
         'YA' => 'Yandex Browser',
         'XI' => 'Xiino'
     );
@@ -201,7 +202,7 @@ class Browser extends ClientParserAbstract
         'BlackBerry Browser' => array('BB'),
         'Baidu'              => array('BD', 'BS'),
         'Amiga'              => array('AV', 'AW'),
-        'Chrome'             => array('CH', 'BR', 'CC', 'CD', 'CM', 'CI', 'CF', 'CN', 'CR', 'CP', 'IR', 'RM', 'AO', 'TS', 'VI', 'PT', 'AS'),
+        'Chrome'             => array('CH', 'BR', 'CC', 'CD', 'CM', 'CI', 'CF', 'CN', 'CR', 'CP', 'IR', 'RM', 'AO', 'TS', 'VI', 'PT', 'AS', 'WV'),
         'Firefox'            => array('FF', 'FE', 'FM', 'SX', 'FB', 'PX', 'MB', 'EI', 'WF', 'CU'),
         'Internet Explorer'  => array('IE', 'IM', 'PS'),
         'Konqueror'          => array('KO'),

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -185,8 +185,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -2193,8 +2193,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-1.yml
+++ b/Tests/fixtures/smartphone-1.yml
@@ -585,8 +585,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -605,8 +605,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -2205,8 +2205,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -3462,8 +3462,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -3482,8 +3482,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -3622,8 +3622,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
@@ -3742,8 +3742,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
@@ -3762,8 +3762,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -3802,8 +3802,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "59.0.3071.92"
     engine: Blink
     engine_version: ""
@@ -3842,8 +3842,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -3862,8 +3862,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
@@ -3882,8 +3882,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -3942,8 +3942,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -3982,8 +3982,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -4062,8 +4062,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -4122,8 +4122,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
@@ -4142,8 +4142,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
@@ -4182,8 +4182,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
@@ -5555,8 +5555,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -5575,8 +5575,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -5615,8 +5615,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -6483,8 +6483,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
@@ -8690,8 +8690,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -7304,8 +7304,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -7521,8 +7521,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -7541,8 +7541,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
@@ -7892,8 +7892,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
@@ -9593,8 +9593,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -2422,8 +2422,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
@@ -2996,8 +2996,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -3056,8 +3056,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -3776,8 +3776,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
@@ -4893,8 +4893,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
@@ -4913,8 +4913,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -6646,8 +6646,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -6706,8 +6706,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -6826,8 +6826,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
@@ -6946,8 +6946,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -6966,8 +6966,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
@@ -6986,8 +6986,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -7026,8 +7026,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -7046,8 +7046,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
@@ -7126,8 +7126,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -7166,8 +7166,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
@@ -7246,8 +7246,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
@@ -8233,8 +8233,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -8484,8 +8484,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
@@ -9761,8 +9761,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -4487,8 +4487,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
@@ -4667,8 +4667,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -6232,8 +6232,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -7492,8 +7492,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -9475,8 +9475,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -1096,8 +1096,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
@@ -2356,8 +2356,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
@@ -2436,8 +2436,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
@@ -2556,8 +2556,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-6.yml
+++ b/Tests/fixtures/smartphone-6.yml
@@ -125,8 +125,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
@@ -1482,8 +1482,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -2876,8 +2876,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -3216,8 +3216,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -3336,8 +3336,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
@@ -3396,8 +3396,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -4356,8 +4356,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
@@ -7240,8 +7240,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
@@ -7540,8 +7540,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -7837,8 +7837,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -7857,8 +7857,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
@@ -7957,8 +7957,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -9114,8 +9114,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -9291,8 +9291,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -1167,8 +1167,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -2655,8 +2655,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -2695,8 +2695,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
@@ -3015,8 +3015,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -3575,8 +3575,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -3655,8 +3655,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "42.0.2311.137"
     engine: Blink
     engine_version: ""
@@ -3675,8 +3675,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "42.0.2311.137"
     engine: Blink
     engine_version: ""
@@ -3695,8 +3695,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -3715,8 +3715,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -3735,8 +3735,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -3995,8 +3995,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -4015,8 +4015,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -4115,8 +4115,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -4491,8 +4491,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -5590,8 +5590,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -5630,8 +5630,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
@@ -5650,8 +5650,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -268,8 +268,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -845,8 +845,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -1485,8 +1485,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
@@ -1945,8 +1945,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
@@ -5078,8 +5078,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -5198,8 +5198,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
@@ -7934,8 +7934,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
@@ -8869,8 +8869,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
@@ -8986,8 +8986,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -9591,8 +9591,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -3902,8 +3902,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
@@ -4142,8 +4142,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -4162,8 +4162,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -7690,8 +7690,8 @@
     platform: ""
   client:
     type: browser
-    name: Chrome Mobile
-    short_name: CM
+    name: Web View
+    short_name: WV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -561,6 +561,15 @@
   name: 'UC Browser'
   version: '$1'
 
+#Android WebView
+- regex: 'Android (?:(?:\d+\.)+\d);.+?(?=wv)wv.+?(?=Chrome)Chrome/(\d+[\.\d]+)'
+  name: 'Android WebView'
+  version: $1
+  engine:
+    default: 'WebKit'
+    versions:
+      28: 'Blink'
+
 #Chrome
 - regex: 'CrMo(?:/(\d+[\.\d]+))?'
   name: 'Chrome Mobile'


### PR DESCRIPTION
Android WebView is the default engine which comes installed on all android devices. Its used by the Android for system level interfaces, and for displays within apps. The platform is similar but not the same as Chrome for Android (Chrome Mobile), and has limitations around the actions which a developer may perform (such as breaking out of the window, and executing other interfaces.)