### PR TITLE
add RPM package manager detection

### DIFF
--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -136,3 +136,21 @@
     type: library
     name: Go-http-client
     version: 1.1
+-
+  user_agent: urlgrabber/3.9.1 yum/3.2.29
+  client:
+    type: library
+    name: urlgrabber (yum)
+    version: "3.9.1"
+-
+  user_agent: urlgrabber/3.10 yum/3.4.3
+  client:
+    type: library
+    name: urlgrabber (yum)
+    version: "3.10"
+-
+  user_agent: libdnf/0.11.1
+  client:
+    type: library
+    name: libdnf
+    version: "0.11.1"

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -70,3 +70,11 @@
 - regex: '(?:Go-http-client|Go )/?(?:(\d+[\.\d]+))?(?: package http)?'
   name: 'Go-http-client'
   version: '$1'
+
+- regex: 'urlgrabber(?:/(\d+[\.\d]+))?'
+  name: 'urlgrabber (yum)'
+  version: '$1'
+
+- regex: 'libdnf(?:/(\d+[\.\d]+))?'
+  name: 'libdnf'
+  version: '$1'


### PR DESCRIPTION
This PR adds detection of urlgrabber and libdnf used by yum and dnf  package managers respectively.