### PR TITLE
Added Breaker to client regular expressions.

### DIFF
--- a/Tests/fixtures/feed_reader.yml
+++ b/Tests/fixtures/feed_reader.yml
@@ -242,6 +242,19 @@
   os_family: Mac
   browser_family: Unknown
 -
+  user_agent: Breaker/v315 (subscribers=9999; feed-id=123456; url=https://www.breaker.audio/url-slug-to-podcast)
+  os: [ ]
+  client:
+    type: feed reader
+    name: Breaker
+    version: "315"
+  device:
+    type: ""
+    brand: ""
+    model: ""
+  os_family: Unknown
+  browser_family: Unknown
+-
   user_agent: NetNewsWire/4.0.0 (Mac OS X; http://netnewswireapp.com/mac/; gzip-happy)
   os:
     name: Mac

--- a/regexes/client/feed_readers.yml
+++ b/regexes/client/feed_readers.yml
@@ -22,6 +22,12 @@
   version: ''
   url: 'http://lincgeek.org/bashpodder/'
   type: 'Feed Reader'
+  
+- regex: 'Breaker/v([\d\.]+)'
+  name: 'Breaker'
+  version: '$1'
+  url: 'https://www.breaker.audio/'
+  type: 'Feed Reader App'
 
 - regex: 'Downcast/([\d\.]+)'
   name: 'Downcast'


### PR DESCRIPTION
Breaker is a social podcasting application, it is known to scrape RSS files to update their own internal records. Their full user agent is actually:
Breaker/v315 (subscribers=9999; feed-id=123456; url=https://www.breaker.audio/url-slug-to-podcast)

However, there are no concessions at the moment to parse out the additional information in DeviceDetector (yet?).