### PR TITLE
Adds OS detection for TwitterAndroid

### DIFF
--- a/Tests/Parser/fixtures/oss.yml
+++ b/Tests/Parser/fixtures/oss.yml
@@ -1008,3 +1008,19 @@
     short_name: IOS
     version:
     platform:
+
+-
+  user_agent: TwitterAndroid/7.73.0-release.17 (8900198-r-17) HUAWEI VNS-L53/7.0 (HUAWEI;HUAWEI VNS-L53;HUAWEI;VNS-L53;0;;1;2013)
+  os:
+    name: Android
+    short_name: AND
+    version: "7.0"
+    platform:
+
+-
+  user_agent: TwitterAndroid/7.71.1-release.15 (8900196-r-15) TA-1028/8.0.0 (HMD Global;TA-1028;Nokia;TA-1028_00WW;0;;1;2013)
+  os:
+    name: Android
+    short_name: AND
+    version: "8.0.0"
+    platform:

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -107,6 +107,10 @@
   name: 'Android'
   version: ''
 
+- regex: '(?:TwitterAndroid).*[ /](?:[a-z]+ )?(\d+[\.\d]*)'
+  name: 'Android'
+  version: '$1'
+
 - regex: 'BeyondPod|AntennaPod|Podkicker|DoggCatcher|Player FM|okhttp|Podcatcher Deluxe'
   name: 'Android'
   version: ''


### PR DESCRIPTION
Issue : https://github.com/matomo-org/device-detector/issues/5878

The following user agent is currently being detected as Symbian OS instead of Android OS.

`TwitterAndroid/7.71.1-release.15 (8900196-r-15) TA-1028/8.0.0 (HMD Global;TA-1028;Nokia;TA-1028_00WW;0;;1;2013)`

My PR should detect it as Android and also identify the Android Version.