### PR TITLE
Enhanced replacement options for generic regexes

### DIFF
--- a/Parser/ParserAbstract.php
+++ b/Parser/ParserAbstract.php
@@ -194,13 +194,14 @@ abstract class ParserAbstract
     protected function buildByMatch($item, $matches)
     {
         for ($nb=1;$nb<=3;$nb++) {
-            if (strpos($item, '$' . $nb) === false) {
+            if (strpos($item, '$' . $nb) === false && strpos($item, '$u' . $nb) === false && strpos($item, '$l' . $nb) === false && strpos($item, '$uf' . $nb) === false) {
                 continue;
             }
 
             $replace = isset($matches[$nb]) ? $matches[$nb] : '';
-            $item = trim(str_replace('$' . $nb, $replace, $item));
+            $item = trim(str_replace(array('$' . $nb, '$u' . $nb, '$l' . $nb, '$uf' . $nb), array($replace, strtoupper($replace), strtolower($replace), ucfirst($replace)), $item));
         }
+
         return $item;
     }
 
@@ -225,6 +226,7 @@ abstract class ParserAbstract
             $versionParts = array_slice($versionParts, 0, 1+self::$maxMinorParts);
             $versionString = implode('.', $versionParts);
         }
+
         return trim($versionString, ' .');
     }
 

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -7859,6 +7859,26 @@
   os_family: Android
   browser_family: Chrome
 - 
+  user_agent: Mozilla/5.0 (Linux; Android 9; moto g(6) plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
+  os:
+    name: Android
+    short_name: AND
+    version: "9"
+    platform: ""
+  client:
+    type: browser
+    name: Chrome Mobile
+    short_name: CM
+    version: "73.0.3683.90"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: smartphone
+    brand: MR
+    model: Moto G
+  os_family: Android
+  browser_family: Chrome
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; MotoG3 Build/MPIS24.107-55-2-17) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -6022,11 +6022,11 @@ Motorola:
       model: 'Moto M'
 
     - regex: 'Moto ([CGEZ]) \(([a-z0-9]+)\)( Plus| Play)?'
-      model: 'Moto $1$2$3'
+      model: 'Moto $u1$2$3'
     - regex: 'Moto ?([CGEZ])([0-9]+)( Plus| Play)?'
-      model: 'Moto $1$2$3'
+      model: 'Moto $u1$2$3'
     - regex: 'Moto ?([CGEZ])( Plus| Play)?'
-      model: 'Moto $1$2'
+      model: 'Moto $u1$2'
 
     - regex: 'Motorola[ _\-]([a-z0-9]+)'
       model: '$1'


### PR DESCRIPTION
As a followup for #5959, I've tried an idea and would like to suggest this change to have enhanced replacement options for generic regexes.

The idea is that in addition to $1 $2 $3 remplacements, we could also have modifiers like $u1 $l2 $uf3 to replace by an uppercase lowercase or uppercase-first value.

This would allow to keep the current generic non-case-sensitive regexes, while also supporting some user-agents where parts are in a wrong/outrageous case, like the example in the fixture with "Moto G" being provided as "g" in the user-agent.

This is backwards compatible and doesn't slow down the detection.