### PR TITLE
Update blink detection

### DIFF
--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -1,50 +1,50 @@
 ---
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) BeakerBrowser/0.8.2 Chrome/66.0.3359.181 Electron/3.0.9 Safari/537.36
   client:
     type: browser
     name: Beaker Browser
-    short_name: "BA"
+    short_name: BA
     version: "0.8.2"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GT-N7100 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360 Aphone Browser (6.8.7beta)
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: "36"
+    short_name: 36
     version: "6.8.7"
     engine: WebKit
     engine_version: "534.30"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 QIHU 360SE
   client:
     type: browser
     name: 360 Browser
     short_name: 3B
-    version:
-    engine: WebKit
-    engine_version: "537.36"
--
+    version: ""
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 QIHU 360EE
   client:
     type: browser
     name: 360 Browser
     short_name: 3B
-    version:
-    engine: WebKit
-    engine_version: "537.36"
--
+    version: ""
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; Avant Browser; InfoPath.1)
   client:
     type: browser
     name: Avant Browser
     short_name: AA
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (compatible; U; ABrowse 0.6; Syllable) AppleWebKit/420+ (KHTML, like Gecko)
   client:
     type: browser
@@ -53,34 +53,34 @@
     version: "0.6"
     engine: WebKit
     engine_version: "420"
--
+- 
   user_agent: Mozilla/3.04 (compatible; NCBrowser/2.35; ANTFresco/2.17; RISC OS-NC 5.13 Laz1UK1309)
   client:
     type: browser
     name: ANT Fresco
     short_name: AF
     version: "2.17"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: HbbTV/1.1.1 (+PVR;Humax;HD FOX+;1.00.12;1.0)CE-HTML/1.0 ANTGalio/3.1.1.23.04.09
   client:
     type: browser
     name: ANTGalio
     short_name: AG
     version: "3.1.1.23.04.09"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: amaya/9.51 libwww/5.4.0
   client:
     type: browser
     name: Amaya
     short_name: AM
     version: "9.51"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.74 Safari/537.36 MRCHROME
   client:
     type: browser
@@ -89,25 +89,25 @@
     version: "28.0.1500.74"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 0.5; en-us) AppleWebKit/522+ (KHTML, like Gecko) Safari/419.3
   client:
     type: browser
     name: Android Browser
     short_name: AN
-    version:
+    version: ""
     engine: WebKit
     engine_version: "522"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; IQ270 Firebird Build/GRJ22; LeWa_IQ270_ROM_12.12.14) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   client:
     type: browser
     name: Android Browser
     short_name: AN
-    version:
+    version: ""
     engine: WebKit
     engine_version: "533.1"
--
+- 
   user_agent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US) AppleWebKit/532.1 (KHTML, like Gecko) Arora/0.10.1 (Git: 1329 e5385f3) Safari/532.1'
   client:
     type: browser
@@ -116,43 +116,43 @@
     version: "0.10.1"
     engine: WebKit
     engine_version: "532.1"
--
+- 
   user_agent: AmigaVoyager/3.2 (AmigaOS/MC680x0)
   client:
     type: browser
     name: Amiga Voyager
     short_name: AV
     version: "3.2"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/6.0 (Macintosh; U; Amiga-AWeb) Safari 3.1
   client:
     type: browser
     name: Amiga Aweb
     short_name: AW
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: AtomicBrowser/7.0.1 CFNetwork/672.1.15 Darwin/14.0.0
   client:
     type: browser
     name: Atomic Web Browser
     short_name: AT
     version: "7.0.1"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: BlackBerry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/134
   client:
     type: browser
     name: BlackBerry Browser
     short_name: BB
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Coolpad 5950 Build/JZO54K) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/4.5.20.0 (Baidu; P1 4.1.2)
   client:
     type: browser
@@ -161,16 +161,16 @@
     version: "4.5.20.0"
     engine: WebKit
     engine_version: "534.24"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.4.9999.1900 Safari/537.31 BDSpark/26.4
   client:
     type: browser
     name: Baidu Spark
     short_name: BS
     version: "26.4"
-    engine: WebKit
-    engine_version: "537.31"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows; U; Win9x; en; Stable) Gecko/20020911 Beonex/0.8.1-stable
   client:
     type: browser
@@ -179,25 +179,25 @@
     version: "0.8.1"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Bunjalloo/0.7.6(Nintendo DS;U;en)
   client:
     type: browser
     name: Bunjalloo
     short_name: BJ
     version: "0.7.6"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: BriskBard/1.0 (Windows 10) BriskBard/1.0
   client:
     type: browser
     name: BriskBard
     short_name: BK
-    version: 1.0
-    engine:
+    version: "1.0"
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.9 Chrome/47.0.2526.73 Electron/0.36.2 Safari/537.36
   client:
     type: browser
@@ -206,16 +206,16 @@
     version: "0.7.9"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: 'Mozilla/4.61 [en] (X11; U; ) - BrowseX (2.0.0 Windows)'
   client:
     type: browser
     name: BrowseX
     short_name: BX
     version: "2.0.0"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en; rv:1.9.2.28) Gecko/20120308 Camino/2.1.2 (like Firefox/3.6.28)
   client:
     type: browser
@@ -224,7 +224,7 @@
     version: "2.1.2"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:27.0) Gecko/20100101 Firefox/27.0 Cunaguaro/27.0
   client:
     type: browser
@@ -233,7 +233,7 @@
     version: "27.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) coc_coc_browser/45.0 Chrome/39.0.2171.74 Safari/537.36
   client:
     type: browser
@@ -242,7 +242,7 @@
     version: "45.0"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.11 (KHTML, like Gecko) Comodo_Dragon/17.1.0.0 Chrome/17.0.963.38 Safari/535.11
   client:
     type: browser
@@ -251,16 +251,16 @@
     version: "17.1.0.0"
     engine: WebKit
     engine_version: "535.11"
--
+- 
   user_agent: Mozilla/4.08 (Charon; Inferno)
   client:
     type: browser
     name: Charon
     short_name: CX
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; chromeframe/19.0.1084.52)
   client:
     type: browser
@@ -269,7 +269,7 @@
     version: "19.0.1084.52"
     engine: WebKit
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_0) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/63.0.3205.0 Safari/537.36
   client:
     type: browser
@@ -278,7 +278,7 @@
     version: "63.0.3205.0"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/60.0.3112.78 Safari/537.36
   client:
     type: browser
@@ -287,7 +287,7 @@
     version: "60.0.3112.78"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 ArchLinux (X11; U; Linux x86_64; en-US) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30
   client:
     type: browser
@@ -296,7 +296,7 @@
     version: "12.0.742.100"
     engine: WebKit
     engine_version: "534.30"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Pixel Build/OPR3.170623.008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   client:
     type: browser
@@ -305,7 +305,7 @@
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.125 Safari/537.36
   client:
     type: browser
@@ -314,7 +314,7 @@
     version: "36.0.1985.125"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/31.0.1650.18 Mobile/10A523 Safari/8536.25
   client:
     type: browser
@@ -323,7 +323,7 @@
     version: "31.0.1650.18"
     engine: WebKit
     engine_version: "536.26"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20131030 conkeror/1.0pre (Debian-1.0~~pre+git131116-1)
   client:
     type: browser
@@ -332,7 +332,7 @@
     version: "1.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL ONE TOUCH 6033X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   client:
     type: browser
@@ -341,7 +341,7 @@
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7 CoolNovo/1.6.5.28
   client:
     type: browser
@@ -350,7 +350,7 @@
     version: "1.6.5.28"
     engine: WebKit
     engine_version: "535.7"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:11.0) Gecko/20100101 Firefox/11.0 CometBird/11.0
   client:
     type: browser
@@ -359,7 +359,7 @@
     version: "11.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Chrome/9.0.597.98 Safari/534.13 ChromePlus/1.6.0.0
   client:
     type: browser
@@ -368,7 +368,7 @@
     version: "1.6.0.0"
     engine: WebKit
     engine_version: "534.13"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/31.0.1650.63 Chrome/31.0.1650.63 Safari/537.36
   client:
     type: browser
@@ -377,7 +377,7 @@
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/418.9 (KHTML, like Gecko, Safari) Safari/419.3 Cheshire/1.0.ALPHA
   client:
     type: browser
@@ -386,17 +386,17 @@
     version: "1.0"
     engine: WebKit
     engine_version: "418.9"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D167 bline/7 (iPhone OS 7.1, iPhone)
   client:
     type: browser
     name: B-Line
     short_name: BL
-    version:
+    version: ""
     engine: WebKit
     engine_version: "537.51.2"
--
-  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46  (KHTML, like Gecko) Mobile/13F69 bline/1.04 (iPhone OS 9.3.2, iPhone)
+- 
+  user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46  (KHTML, like Gecko) Mobile/13F69 bline/1.04 (iPhone OS 9.3.2, iPhone)'
   client:
     type: browser
     name: B-Line
@@ -404,34 +404,34 @@
     version: "1.04"
     engine: WebKit
     engine_version: "601.1.46"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU ,iPhone OS 7_0_6 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/dbrowser Safari/8536.25
   client:
     type: browser
     name: dbrowser
     short_name: DB
-    version:
+    version: ""
     engine: WebKit
     engine_version: "536.26"
--
+- 
   user_agent: Mozilla/5.0 (iPod touch; CPU ,iPod touch OS 7_1_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/dbrowser Safari/8536.25
   client:
     type: browser
     name: dbrowser
     short_name: DB
-    version:
+    version: ""
     engine: WebKit
     engine_version: "536.26"
--
+- 
   user_agent: Deepnet Explorer 1.5.3; Smart 2x2; Avant Browser; .NET CLR 2.0.50727; InfoPath.1)
   client:
     type: browser
     name: Deepnet Explorer
     short_name: DE
     version: "1.5.3"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5380D/S5380DNVKL1; U; Bada/2.0; fr-fr) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
   client:
     type: browser
@@ -440,7 +440,7 @@
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
--
+- 
   user_agent: Dillo/0.8.5-i18n-misc
   client:
     type: browser
@@ -449,16 +449,16 @@
     version: "0.8.5"
     engine: Dillo
     engine_version: "0.8.5"
--
+- 
   user_agent: Dorado WAP-Browser/1.0
   client:
     type: browser
     name: Dorado
     short_name: DO
     version: "1.0"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533+ (KHTML, like Gecko) Element Browser 5.0
   client:
     type: browser
@@ -467,7 +467,7 @@
     version: "5.0"
     engine: WebKit
     engine_version: "533"
--
+- 
   user_agent: ELinks/0.12~pre6-1ubuntu1 (textmode; Ubuntu; Linux 3.11.0-13-generic i686; 100x25-2)
   client:
     type: browser
@@ -476,7 +476,7 @@
     version: "0.12"
     engine: Text-based
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i586; en-US; rv:1.6) Gecko/20040413 Epiphany/1.2.6
   client:
     type: browser
@@ -485,7 +485,7 @@
     version: "1.2.6"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; fr-fr) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+ Debian/squeeze (2.30.6-1) Epiphany/2.30.6
   client:
     type: browser
@@ -494,7 +494,7 @@
     version: "2.30.6"
     engine: WebKit
     engine_version: "531.2"
--
+- 
   user_agent: Mozilla/5.0 (DTV) AppleWebKit/531.2+ (KHTML, like Gecko) Espial/6.1.5 AQUOSBrowser/2.0 (US01DTV;V;0001;0001)
   client:
     type: browser
@@ -503,7 +503,7 @@
     version: "6.1.5"
     engine: WebKit
     engine_version: "531.2"
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Win95; en-US; rv:1.5) Gecko/20031007 Firebird/0.7
   client:
     type: browser
@@ -512,7 +512,7 @@
     version: "0.7"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) AppleWebKit/528.16 (KHTML, like Gecko) Fluid/0.9.6 Safari/528.16
   client:
     type: browser
@@ -521,7 +521,7 @@
     version: "0.9.6"
     engine: WebKit
     engine_version: "528.16"
--
+- 
   user_agent: Mozilla/5.0 (Android; Linux armv7l; rv:10.0) Gecko/20120118 Firefox/10.0 Fennec/10.0
   client:
     type: browser
@@ -530,7 +530,7 @@
     version: "10.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Arch Linux i686; rv:2.0) Gecko/20110321 Firefox/4.0
   client:
     type: browser
@@ -539,7 +539,7 @@
     version: "4.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (BeOS; U; Haiku BePC; en-US; rv:1.8.1.21pre) Gecko/20090218 BonEcho/2.0.0.21pre
   client:
     type: browser
@@ -548,7 +548,7 @@
     version: "BonEcho (2.0.0.21)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.11) Gecko GranParadiso/3.0.11
   client:
     type: browser
@@ -557,7 +557,7 @@
     version: "GranParadiso (3.0.11)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9a3pre) Gecko/20070301 Minefield/3.0a3pre
   client:
     type: browser
@@ -566,7 +566,7 @@
     version: "Minefield (3.0)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.1b5pre) Gecko/20090424 Shiretoko/3.5b5pre
   client:
     type: browser
@@ -575,7 +575,7 @@
     version: "Shiretoko (3.5)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3pre) Gecko/20100403 Lorentz/3.6.3plugin2pre (.NET CLR 4.0.20506)
   client:
     type: browser
@@ -584,7 +584,7 @@
     version: "Lorentz (3.6.3)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.13) Gecko/20110504 Namoroka/3.6.13
   client:
     type: browser
@@ -593,7 +593,7 @@
     version: "Namoroka (3.6.13)"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4
   client:
     type: browser
@@ -602,25 +602,25 @@
     version: "iOS 1.0"
     engine: WebKit
     engine_version: "600.1.4"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Klar/1.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   client:
     type: browser
     name: Firefox Focus
     short_name: FK
     version: "1.0"
-    engine: WebKit
-    engine_version: "537.36"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Focus/1.1 Chrome/49.0.2623.91 Mobile Safari/537.36
   client:
     type: browser
     name: Firefox Focus
     short_name: FK
-    version: 1.1
-    engine: WebKit
-    engine_version: "537.36"
--
+    version: "1.1"
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; pl; rv:1.9.0.16) Gecko/2010021013 Firefox/3.0.16 Flock/2.5.6
   client:
     type: browser
@@ -629,16 +629,16 @@
     version: "2.5.6"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:2.0) Treco/20110515 Fireweb Navigator/2.4
   client:
     type: browser
     name: Fireweb Navigator
     short_name: FN
     version: "2.4"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/534+ (KHTML, like Gecko) FireWeb/1.0.0.0
   client:
     type: browser
@@ -647,7 +647,7 @@
     version: "1.0.0.0"
     engine: WebKit
     engine_version: "534"
--
+- 
   user_agent: Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.7.12) Gecko/20051105 Galeon/1.3.21
   client:
     type: browser
@@ -656,7 +656,7 @@
     version: "1.3.21"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; cs-CZ) AppleWebKit/532.4 (KHTML, like Gecko) Google Earth/5.2.1.1329 Safari/532.4
   client:
     type: browser
@@ -665,16 +665,16 @@
     version: "5.2.1.1329"
     engine: WebKit
     engine_version: "532.4"
--
+- 
   user_agent: HotJava/1.1.2 FCS
   client:
     type: browser
     name: HotJava
     short_name: HJ
     version: "1.1.2"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:10.0.12) Gecko/20130823 Firefox/10.0.11esrpre Iceape/2.7.12
   client:
     type: browser
@@ -683,16 +683,16 @@
     version: "2.7.12"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: IBrowse/2.4 (AmigaOS 3.9; 68K)
   client:
     type: browser
     name: IBrowse
     short_name: IB
     version: "2.4"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.5 (compatible; iCab 2.9.9; Macintosh; U; 68K)
   client:
     type: browser
@@ -701,7 +701,7 @@
     version: "2.9.9"
     engine: iCab
     engine_version: "2.9.9"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_8; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) iCab/4.8 Safari/533.16
   client:
     type: browser
@@ -710,7 +710,7 @@
     version: "4.8"
     engine: WebKit
     engine_version: "533.19.4"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; rv:26.0) Gecko/20100101 Firefox/26.0 IceDragon/26.0.0.2
   client:
     type: browser
@@ -719,7 +719,7 @@
     version: "26.0.0.2"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.0.15) Gecko/2009102815 Iceweasel/3.0.6 (Debian-3.0.6-3)
   client:
     type: browser
@@ -728,7 +728,7 @@
     version: "3.0.6"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Mac_PowerPC)
   client:
     type: browser
@@ -737,7 +737,7 @@
     version: "4.01"
     engine: Trident
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Safari/537.36 Edge/12.0
   client:
     type: browser
@@ -746,7 +746,7 @@
     version: "12.0"
     engine: Edge
     engine_version: "12.0"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10240
   client:
     type: browser
@@ -755,7 +755,7 @@
     version: "12.10240"
     engine: Edge
     engine_version: "12.10240"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10537
   client:
     type: browser
@@ -764,7 +764,7 @@
     version: "13.10537"
     engine: Edge
     engine_version: "13.10537"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10547
   client:
     type: browser
@@ -773,7 +773,7 @@
     version: "13.10547"
     engine: Edge
     engine_version: "13.10547"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_2 like Mac OS X) AppleWebKit/603.2.4 (KHTML, like Gecko) Mobile/14F89 Safari/603.2.4 EdgiOS/41.1.35.1
   client:
     type: browser
@@ -782,7 +782,7 @@
     version: "41.1.35.1"
     engine: WebKit
     engine_version: "603.2.4"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0; Pixel XL Build/OPP3.170518.006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.0 Mobile Safari/537.36 EdgA/41.1.35.1
   client:
     type: browser
@@ -791,7 +791,7 @@
     version: "41.1.35.1"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3738.0 Safari/537.36 Edg/75.0.107.0
   client:
     type: browser
@@ -800,7 +800,7 @@
     version: "75.0.107.0"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
   client:
     type: browser
@@ -809,7 +809,7 @@
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Iron/26.0.1450.0 Chrome/26.0.1450.0 Safari/537.36
   client:
     type: browser
@@ -818,70 +818,70 @@
     version: "26.0.1450.0"
     engine: WebKit
     engine_version: "537.36"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) Mobile/isivioo
   client:
     type: browser
     name: Isivioo
     short_name: IV
-    version:
+    version: ""
     engine: WebKit
     engine_version: "538.34.9"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.0; LG-D855 Build/LRX21R.A1445306351; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36/isivioo
   client:
     type: browser
     name: Isivioo
     short_name: IV
-    version:
+    version: ""
     engine: WebKit
     engine_version: "537.36"
--
+- 
   user_agent: SAMSUNG-GT-S5230-ORANGE/S5230BVIF1 SHP/VPP/R5 Jasmine/0.8 Nextreaming SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
   client:
     type: browser
     name: Jasmine
     short_name: JS
     version: "0.8"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (jig browser 5.0.1; F900iT)
   client:
     type: browser
     name: Jig Browser
     short_name: JI
     version: "5.0.1"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (jig browser web; 1.0.4; V702NK)
   client:
     type: browser
     name: Jig Browser
     short_name: JI
     version: "1.0.4"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (jig browser9i 1.5.0; F10B; 2004)
   client:
     type: browser
     name: Jig Browser
     short_name: JI
     version: "1.5.0"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (jig browser9 1.4.9; D905i; 2043)
   client:
     type: browser
     name: Jig Browser
     short_name: JI
     version: "1.4.9"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.0 (screen 600x800)
   client:
     type: browser
@@ -890,7 +890,7 @@
     version: "2.0"
     engine: NetFront
     engine_version: "3.4"
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.24pre) Gecko/20100228 K-Meleon/1.5.4
   client:
     type: browser
@@ -899,7 +899,7 @@
     version: "1.5.4"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (compatible; Konqueror/3.5; Linux; de) KHTML/3.5.8 (like Gecko) (Debian)
   client:
     type: browser
@@ -908,7 +908,7 @@
     version: "3.5"
     engine: KHTML
     engine_version: "3.5.8"
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.9) Gecko/20080705 Firefox/3.0 Kapiko/3.0
   client:
     type: browser
@@ -917,7 +917,7 @@
     version: "3.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.8) Gecko Fedora/1.9.0.8-1.fc10 Kazehakase/0.5.6
   client:
     type: browser
@@ -926,7 +926,7 @@
     version: "0.5.6"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2) Gecko/20100222 Firefox/3.6 Kylo/0.6.1.70394
   client:
     type: browser
@@ -935,16 +935,16 @@
     version: "0.6.1.70394"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/537.36 LBBROWSER
   client:
     type: browser
     name: Liebao
     short_name: LB
-    version:
-    engine: WebKit
-    engine_version: "537.36"
--
+    version: ""
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Links (2.1pre23; Linux 3.5.0 i686; 237x63)
   client:
     type: browser
@@ -953,25 +953,25 @@
     version: "2.1"
     engine: Text-based
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (OpenBSD i386) AppleWebKit/538.1+ (KHTML, like Gecko) WebKitGTK+/2.2.3 luakit/0d5f4
   client:
     type: browser
     name: LuaKit
     short_name: LU
-    version:
+    version: ""
     engine: WebKit
     engine_version: "538.1"
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; .NET CLR 1.1.4322; Lunascape 2.1.3)
   client:
     type: browser
     name: Lunascape
     short_name: LS
     version: "2.1.3"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Lynx/2.8.8pre.3 libwww-FM/2.14 SSL-MM/1.4.1 OpenSSL/1.0.1e
   client:
     type: browser
@@ -980,7 +980,7 @@
     version: "2.8.8"
     engine: Text-based
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux armv7l; en-GB; rv:1.9.2a1pre) Gecko/20090514 Firefox/3.0 Tablet browser 0.9.7 RX-34
   client:
     type: browser
@@ -989,25 +989,25 @@
     version: "0.9.7"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.181 Safari/537.36 Avast/66.2.567.182
   client:
     type: browser
     name: Avast Secure Browser
     short_name: AS
     version: "66.2.567.182"
-    engine: WebKit
-    engine_version: "537.36"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Maemo Browser
   client:
     type: browser
     name: MicroB
     short_name: MB
-    version:
+    version: ""
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux armv7l; pt-PT; rv:1.9.2.3pre) Gecko/20100723 Firefox/3.5 Maemo Browser 1.7.4.8 RX-51 N900
   client:
     type: browser
@@ -1016,16 +1016,16 @@
     version: "1.7.4.8"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: NCSA_Mosaic/2.7b5 (X11;Linux 2.6.7 i686) libwww/2.12 modified
   client:
     type: browser
     name: NCSA Mosaic
     short_name: MC
     version: "2.7"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mercury/8.0.1 Mobile/10A523 Safari/8536.25
   client:
     type: browser
@@ -1034,7 +1034,7 @@
     version: "8.0.1"
     engine: WebKit
     engine_version: "536.26"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; MI 3W Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   client:
     type: browser
@@ -1043,16 +1043,16 @@
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8C148
   client:
     type: browser
     name: Mobile Safari
     short_name: MF
-    version:
+    version: ""
     engine: WebKit
     engine_version: "533.17.9"
--
+- 
   user_agent: MobileSafari/9537.53 CFNetwork/672.1.13 Darwin/13.1.0
   client:
     type: browser
@@ -1061,7 +1061,7 @@
     version: "9537.53"
     engine: WebKit
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux) AppleWebKit/535.22 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.22 Midori/0.5
   client:
     type: browser
@@ -1070,7 +1070,7 @@
     version: "0.5"
     engine: WebKit
     engine_version: "535.22"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; en-gb; KFSOWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.12 Safari/535.19 Silk-Accelerated=true
   client:
     type: browser
@@ -1079,7 +1079,7 @@
     version: "3.12"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.22 (KHTML, like Gecko) Maxthon/4.1.2.2000 Chrome/25.0.1364.99 Safari/537.22
   client:
     type: browser
@@ -1088,7 +1088,7 @@
     version: "4.1.2.2000"
     engine: WebKit
     engine_version: "537.22"
--
+- 
   user_agent: Mozilla/5.0 (Symbian/3; Series60/5.3 NokiaE7-00/111.040.1511; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/535.1 (KHTML, like Gecko) NokiaBrowser/8.3.1.4 Mobile Safari/535.1
   client:
     type: browser
@@ -1097,16 +1097,16 @@
     version: "8.3.1.4"
     engine: WebKit
     engine_version: "535.1"
--
+- 
   user_agent: NokiaN73-2/3.0-630.0.2 Series60/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
   client:
     type: browser
     name: Nokia OSS Browser
     short_name: 'NO'
     version: "3.0"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; cs_cz; MT11i Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
   client:
     type: browser
@@ -1115,7 +1115,7 @@
     version: "2.3"
     engine: NetFront
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Series40; Nokia306/03.63; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/3.9.0.0.22
   client:
     type: browser
@@ -1124,7 +1124,7 @@
     version: "3.9.0.0.22"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: SAMSUNG-SGH-A737/UCHD2 SHP/VPP/R5 NetFront/3.4 SMM-MMS/1.2.0 profile/MIDP-2.0 configuration/CLDC-1.1
   client:
     type: browser
@@ -1133,16 +1133,16 @@
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
--
+- 
   user_agent: Mozilla/3.0 (compatible; NetPositive/2.2.1; BeOS)
   client:
     type: browser
     name: NetPositive
     short_name: NP
     version: "2.2.1"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux 2.4.2-2 i586; en-US; m18) Gecko/20010131 Netscape6/6.01
   client:
     type: browser
@@ -1151,7 +1151,7 @@
     version: "6.01"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; en-US; rv:1.7.5) Gecko/20070321 Netscape/8.1.3
   client:
     type: browser
@@ -1160,7 +1160,7 @@
     version: "8.1.3"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Android 5.1; U613 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) NTENTBrowser/1.0.0.547 (CellularOne-US) Mobile Safari/537.36
   client:
     type: browser
@@ -1169,7 +1169,7 @@
     version: "1.0.0.547"
     engine: WebKit
     engine_version: "537.36"
--
+- 
   user_agent: Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM9600-NA; 06.00.00; 0x00000001;); LG NetCast.TV-2012 0
   client:
     type: browser
@@ -1178,16 +1178,16 @@
     version: "5.00.00"
     engine: WebKit
     engine_version: "534.26"
--
+- 
   user_agent: Huawei/1.0/0HuaweiG2800/WAP2.0/Obigo-Browser/Q03C MMS/Obigo-MMS/1.2
   client:
     type: browser
     name: Obigo
     short_name: OB
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; PowerPC MorphOS 3.7; Odyssey Web Browser; rv:1.23) AppleWebKit/538.1 (KHTML, like Gecko) OWB/1.23 Safari/538.1
   client:
     type: browser
@@ -1196,16 +1196,16 @@
     version: "1.23"
     engine: WebKit
     engine_version: "538.1"
--
+- 
   user_agent: Mozilla/4.7 (compatible; OffByOne; Windows 2000) Webster Pro V3.4
   client:
     type: browser
     name: Off By One
     short_name: OF
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: OneBrowser/4.2.0/Adr(Linux; U; Android 2.3.4; en-us; ADR6325 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Mobile Safari/533.1
   client:
     type: browser
@@ -1214,7 +1214,7 @@
     version: "4.2.0"
     engine: WebKit
     engine_version: "533.1"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 11_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) OPT/1.10.36 Mobile/15G77
   client:
     type: browser
@@ -1223,7 +1223,7 @@
     version: "1.10.36"
     engine: WebKit
     engine_version: "605.1.15"
--
+- 
   user_agent: Opera/9.80 (J2ME/MIDP; Opera Mini; U; en) Presto/2.12.423 Version/12.16
   client:
     type: browser
@@ -1232,7 +1232,7 @@
     version: "12.16"
     engine: Presto
     engine_version: "2.12.423"
--
+- 
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; GT-S6812) U2/1.0.0 UCBrowser/9.0.0.366 Mobile
   client:
     type: browser
@@ -1241,7 +1241,7 @@
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC EVO 3D X515m Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.61541
   client:
     type: browser
@@ -1250,7 +1250,7 @@
     version: "15.0.1162.61541"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230-VODAFONE/1.0; U; Bada/1.0; en-us) OperaMini/5.0.21073 Mobile WVGA SMM-MMS/1.2.0 NexPla
   client:
     type: browser
@@ -1259,7 +1259,7 @@
     version: "5.0.21073"
     engine: Presto
     engine_version: ""
--
+- 
   user_agent: Opera/9.80 (X11; Linux zbov) Presto/2.11.355 Version/12.10
   client:
     type: browser
@@ -1268,16 +1268,16 @@
     version: "12.10"
     engine: Presto
     engine_version: "2.11.355"
--
+- 
   user_agent: Opera/3.2 (Windows 2000 3.8; )
   client:
     type: browser
     name: Opera
     short_name: OP
     version: "3.2"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: 'Opera/6.04 (Windows 2000; U) [en]'
   client:
     type: browser
@@ -1286,7 +1286,7 @@
     version: "6.04"
     engine: Elektra
     engine_version: ""
--
+- 
   user_agent: MOT-A1600/1.0 LinuxOS/2.4.20 Release/8.22.2006 Browser/Opera8.00 Profile/MIDP-2.0 Configuration/CLDC-1.1 Software/R542_G_11.61.33R
   client:
     type: browser
@@ -1295,7 +1295,7 @@
     version: "8.00"
     engine: Presto
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 1091) AppleWebKit/537.36 (KHTML like Gecko) Chrome/33.0.1750.91 Safari/537.36 OPR/20.0.1387.37 (Edition Next)
   client:
     type: browser
@@ -1304,34 +1304,34 @@
     version: "20.0.1387.37"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: 'Mozilla/1.10 [en] (Compatible; RISC OS 3.70; Oregano 1.10)'
   client:
     type: browser
     name: Oregano
     short_name: OR
     version: "1.10"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: pcdc751/1.0 UP.Browser/6.2.3.2 (GUI) MMP/2.0
   client:
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
     version: "6.2.3.2"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: SonyEricssonW395c/R1DA Browser/OpenWave/1.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
   client:
     type: browser
     name: Openwave Mobile Browser
     short_name: OV
     version: "1.0"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: 'Mozilla/5.0 (Macintosh; Intel  Mac OS X 10_9_1; en-US) AppleWebKit/9537.73.11 (KHTML, like Gecko) Version/7.0 Safari/537.71 OmniWeb/v624.0'
   client:
     type: browser
@@ -1340,16 +1340,16 @@
     version: "624.0"
     engine: WebKit
     engine_version: "9537.73.11"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-us; CPH1729 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.134 Mobile Safari/537.36 OppoBrowser/1.0.0
   client:
     type: browser
     name: Oppo Browser
     short_name: PP
     version: "1.0.0"
-    engine: WebKit
-    engine_version: "537.36"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/538.1 (KHTML, like Gecko) Otter/0.9.04
   client:
     type: browser
@@ -1358,16 +1358,16 @@
     version: "0.9.04"
     engine: WebKit
     engine_version: "538.1"
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource/Palm-D050; Blazer/4.3) 16;320x320
   client:
     type: browser
     name: Palm Blazer
     short_name: PL
     version: "4.3"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.2; Win64; x64; rv:24.0) Gecko/20140129 Firefox/24.0 PaleMoon/24.3.1
   client:
     type: browser
@@ -1376,7 +1376,7 @@
     version: "24.3.1"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (webOS/1.0; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.0
   client:
     type: browser
@@ -1385,7 +1385,7 @@
     version: "1.0"
     engine: WebKit
     engine_version: "525.27.1"
--
+- 
   user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
   client:
     type: browser
@@ -1394,25 +1394,25 @@
     version: "2.10977"
     engine: WebKit
     engine_version: "534.35"
--
+- 
   user_agent: Mozilla/4.76 (compatible; MSIE 6.0; U; Windows 95; PalmSource; PalmOS; WebPro; Tungsten Proxyless 1.1 320x320x16)
   client:
     type: browser
     name: Palm WebPro
     short_name: PW
-    version:
-    engine:
+    version: ""
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: 'Palmscape/3.0J [ja] (v. 3.5.2H1.5; 153x130; c8)'
   client:
     type: browser
     name: Palmscape
     short_name: PA
-    version: 3.0
-    engine:
+    version: "3.0"
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.2b) Gecko/20021029 Phoenix/0.4
   client:
     type: browser
@@ -1421,16 +1421,16 @@
     version: "0.4"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/4.0 (compatible; Polaris 6.2; Brew 3.1.5; en)/240X320 Samsung sam-r631
   client:
     type: browser
     name: Polaris
     short_name: PO
     version: "6.2"
-    engine:
-    engine_version:
--
+    engine: ""
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) rekonq/2.3.2 Safari/537.21
   client:
     type: browser
@@ -1439,7 +1439,7 @@
     version: "2.3.2"
     engine: WebKit
     engine_version: "537.21"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/535.7 (KHTML, like Gecko) RockMelt/0.16.91.483 Chrome/16.0.912.77 Safari/535.7
   client:
     type: browser
@@ -1448,25 +1448,25 @@
     version: "0.16.91.483"
     engine: WebKit
     engine_version: "535.7"
--
+- 
   user_agent: Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1
   client:
     type: browser
     name: Samsung Browser
     short_name: SB
-    version: 1.0
+    version: "1.0"
     engine: WebKit
     engine_version: "538.1"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-A510F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   client:
     type: browser
     name: Samsung Browser
     short_name: SB
-    version: 4.0
-    engine: WebKit
-    engine_version: "537.36"
--
+    version: "4.0"
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0 SailfishBrowser/1.0 like Safari/538.1
   client:
     type: browser
@@ -1475,16 +1475,16 @@
     version: "1.0"
     engine: Gecko
     engine_version: "26.0"
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1; SV1; SE 2.x)
   client:
     type: browser
     name: Sogou Explorer
     short_name: SE
     version: "2"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux i686; U; en-US) Gecko/20081217 Vision-Browser/8.1 301x200 LG VN530
   client:
     type: browser
@@ -1493,16 +1493,16 @@
     version: "8.1"
     engine: Gecko
     engine_version: ""
--
-  user_agent: Safari/9537.73.11 CFNetwork/673.0.3 Darwin/13.0.0 (x86_64) (MacBookAir6%2C2)
+- 
+  user_agent: 'Safari/9537.73.11 CFNetwork/673.0.3 Darwin/13.0.0 (x86_64) (MacBookAir6%2C2)'
   client:
     type: browser
     name: Safari
     short_name: SF
-    version:
+    version: ""
     engine: WebKit
     engine_version: ""
--
+- 
   user_agent: Sraf/3.0 (Linux i686 ; U; HbbTV/1.1.1 (+PVR+DL;NEXUS; TV44; sw1.0) CE-HTML/1.0 Config(L:eng,CC:DEU); en/de)
   client:
     type: browser
@@ -1511,16 +1511,16 @@
     version: "3.0"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: CELKON.C64/R2AE SEMC-Browser/4.0.3 Profile/MIDP-2.0 Configuration/CLDC-1.1
   client:
     type: browser
     name: SEMC-Browser
     short_name: SC
     version: "4.0.3"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/419 (KHTML, like Gecko) Shiira/1.2.3 Safari/125
   client:
     type: browser
@@ -1529,16 +1529,16 @@
     version: "1.2.3"
     engine: WebKit
     engine_version: "419"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_7; xx) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Safari/530.17 Skyfire/6DE
   client:
     type: browser
     name: Skyfire
     short_name: SK
-    version:
+    version: ""
     engine: WebKit
     engine_version: "530.17"
--
+- 
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; Sleipnir/2.9.18)
   client:
     type: browser
@@ -1547,7 +1547,7 @@
     version: "2.9.18"
     engine: Trident
     engine_version: "6.0"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:29.0) Gecko/20100101 Firefox/29.0 SeaMonkey/2.26a1 Lightning/3.1a1
   client:
     type: browser
@@ -1556,7 +1556,7 @@
     version: "2.26"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) Snowshoe/1.0.0 Safari/537.21
   client:
     type: browser
@@ -1565,7 +1565,7 @@
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.21"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; U; CPU @2764110S 5_1_1 like Mac OS X; sv-SE) AppleWebKit/601.1.46 (KHTML, like Gecko) Streamy/1.1.11 Mobile/13B143 Safari/7534.48.3
   client:
     type: browser
@@ -1574,7 +1574,7 @@
     version: "1.1.11"
     engine: WebKit
     engine_version: "601.1.46"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; U; CPU @1064110S 5_1_1 like Mac OS X; en-US) AppleWebKit/601.1.46 (KHTML, like Gecko) Streamy/1.1.11 Mobile/13F69 Safari/7534.48.3
   client:
     type: browser
@@ -1583,7 +1583,7 @@
     version: "1.1.11"
     engine: WebKit
     engine_version: "601.1.46"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.116 Crosswalk/18.48.477.13 Mobile Safari/537.36 Streamy/1.1.193
   client:
     type: browser
@@ -1592,7 +1592,7 @@
     version: "1.1.193"
     engine: WebKit
     engine_version: "537.36"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/125.5.7 (KHTML, like Gecko) SunriseBrowser/0.833
   client:
     type: browser
@@ -1601,7 +1601,7 @@
     version: "0.833"
     engine: WebKit
     engine_version: "125.5.7"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) SuperBird/24.0
   client:
     type: browser
@@ -1610,7 +1610,7 @@
     version: "24.0"
     engine: WebKit
     engine_version: "537.17"
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Firefox/2.0 (Swiftfox)
   client:
     type: browser
@@ -1619,7 +1619,7 @@
     version: "2.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Tizen/1.0 like Android; en-us; AppleWebKit/534.46 (KHTML, like Gecko) Tizen Browser/1.0 Mobile
   client:
     type: browser
@@ -1628,16 +1628,16 @@
     version: "1.0"
     engine: WebKit
     engine_version: "534.46"
--
+- 
   user_agent: UCWEB/2.0 (Java; U; MIDP-2.0; fr-FR; ALCATEL_one_touch_585) U2/1.0.0 UCBrowser/9.4.1.377 U2/1.0.0 Mobile UNTRUSTED/1.0
   client:
     type: browser
     name: UC Browser
     short_name: UC
     version: "9.4.1.377"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.114 Safari/537.36 Vivaldi/1.0.105.7
   client:
     type: browser
@@ -1646,7 +1646,7 @@
     version: "1.0.105.7"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) TweakStyle/0.9.2 Chrome/49.0.2623.75 Electron/0.37.5 Safari/537.36 (Tab 1)
   client:
     type: browser
@@ -1655,25 +1655,25 @@
     version: "0.9.2"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (compatible; U; Webpositive/533.4; Haiku) AppleWebkit/533.4 (KHTML, like gecko) Chrome/5.0.375.55 Safari/533.4
   client:
     type: browser
     name: WebPositive
     short_name: WE
-    version:
+    version: ""
     engine: WebKit
     engine_version: "533.4"
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; de-DE) AppleWebKit/534.3 (KHML, like Gecko) WeTab-Browser Safari/534.3
   client:
     type: browser
     name: WeTab Browser
     short_name: WT
-    version:
+    version: ""
     engine: WebKit
     engine_version: "534.3"
--
+- 
   user_agent: Mozilla/5.0 (webOS/1.4.5; U; ru-RU) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pixi/1.0
   client:
     type: browser
@@ -1682,7 +1682,7 @@
     version: "1.4.5"
     engine: WebKit
     engine_version: "532.2"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 YaBrowser/13.10.1500.9323 Safari/537.36
   client:
     type: browser
@@ -1691,43 +1691,43 @@
     version: "13.10.1500.9323"
     engine: Blink
     engine_version: ""
--
+- 
   user_agent: 'Xiino/1.0.9E [en] (v. 4.1; 153x130; g4)'
   client:
     type: browser
     name: Xiino
     short_name: XI
     version: "1.0.9"
-    engine:
-    engine_version:
--
+    engine: ""
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36 QQBrowser/8.0.3197.400
   client:
     type: browser
     name: QQ Browser
     short_name: QQ
     version: "8.0.3197.400"
-    engine: WebKit
-    engine_version: "537.36"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: MQQBrowser/Mini2.6 (SAMSUNG-SGH-A777/A777UCIF2)
   client:
     type: browser
     name: QQ Browser
     short_name: QQ
     version: "2.6"
-    engine:
+    engine: ""
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; Nexus 4 Build/JOP24G) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Polarity/6.0.0 Safari/534.30
   client:
     type: browser
     name: Polarity
     short_name: PT
     version: "6.0.0"
-    engine: WebKit
-    engine_version: "534.30"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/533.3 (KHTML, like Gecko) QupZilla/1.1.5 Safari/533.3
   client:
     type: browser
@@ -1736,7 +1736,7 @@
     version: "1.1.5"
     engine: WebKit
     engine_version: "533.3"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/534.34 (KHTML, like Gecko) Dooble/1.41 Safari/534.34
   client:
     type: browser
@@ -1745,7 +1745,7 @@
     version: "1.41"
     engine: WebKit
     engine_version: "534.34"
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.10) Gecko/20101026 Epic/1.2 Firefox/3.6.10
   client:
     type: browser
@@ -1754,7 +1754,7 @@
     version: "1.2"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Coast/1.0.2.62956 Mobile/10B329 Safari/7534.48.3
   client:
     type: browser
@@ -1763,7 +1763,7 @@
     version: "1.0.2.62956"
     engine: WebKit
     engine_version: "536.26"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/538.1 (KHTML, like Gecko) qutebrowser/0.2.1 Safari/538.1
   client:
     type: browser
@@ -1772,7 +1772,7 @@
     version: "0.2.1"
     engine: WebKit
     engine_version: "538.1"
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_0_2 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14A456 Safari/602.1 AlohaBrowser/1.4
   client:
     type: browser
@@ -1781,7 +1781,7 @@
     version: "1.4"
     engine: WebKit
     engine_version: "602.1.50"
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:30.0) Gecko/20100101 Waterfox/30.0 Firefox/30.0
   client:
     type: browser
@@ -1790,16 +1790,16 @@
     version: "30.0"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_4) AppleWebKit/537.36 (KHTML, like Gecko) Iridium/41.2 Safari/537.36 Chrome/41.0.2272.118
   client:
     type: browser
     name: Iridium
     short_name: I1
     version: "41.2"
-    engine: WebKit
-    engine_version: "537.36"
--
+    engine: Blink
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:28.0) Gecko/20100101 Firefox/28.0 Cyberfox/28.0.1
   client:
     type: browser
@@ -1807,35 +1807,35 @@
     short_name: CY
     version: "28.0.1"
     engine: Gecko
-    engine_version:
--
+    engine_version: ""
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU OS 8_0 like Mac OS X) AppleWebKit/538.34.9 (KHTML, like Gecko) iCabMobile/1.1
   client:
     type: browser
-    name: "iCab Mobile"
+    name: iCab Mobile
     short_name: I2
-    version:  "1.1"
+    version: "1.1"
     engine: WebKit
     engine_version: "538.34.9"
--
+- 
   user_agent: NetSurf/3.7 (Linux; Arch Linux)
   client:
     type: browser
-    name: "NetSurf"
+    name: NetSurf
     short_name: NE
     version: "3.7"
     engine: NetSurf
     engine_version: "3.7"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en; SM-J530F) AppleWebKit/537.36 (KHTML, like Gecko) Tenta/2.10.3 Mobile Safari/537.36 Mobile
   client:
     type: browser
-    name: "Tenta Browser"
+    name: Tenta Browser
     short_name: TB
     version: "2.10.3"
     engine: Webkit
     engine_version: "537.36"
--
+- 
   user_agent: QwantMobile/2.5 (Android 8.1.0; Mobile; rv:63.0) Gecko/63.0 Firefox/63.0 QwantBrowser/63.0.1
   client:
     type: browser
@@ -1844,7 +1844,7 @@
     version: "2.5"
     engine: Gecko
     engine_version: "63.0"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; PPC Mac OS X 10.5; FPR10; rv:45.0) Gecko/20100101 Firefox/45.0 TenFourFox/G5
   client:
     type: browser
@@ -1853,7 +1853,7 @@
     version: ""
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 AOLShield/52.4.2
   client:
     type: browser
@@ -1862,21 +1862,21 @@
     version: "52.4.2"
     engine: Gecko
     engine_version: ""
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; ONEPLUS A3003 Build/PQ3A.190505.002; rv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Rocket/1.6.2(12322) Chrome/74.0.3729.157 Mobile Safari/537.36
   client:
     type: browser
     name: Firefox Rocket
     short_name: FR
-    version: 1.6.2
+    version: "1.6.2"
     engine: Webkit
     engine_version: "537.36"
--
+- 
   user_agent: Mozilla/5.0 Linux; Android 8.0.0 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Web Explorer/2.6.6 Chrome/75.0.3770.143 Mobile Safari/537.36
   client:
     type: browser
     name: Web Explorer
     short_name: WP
-    version: 2.6.6
+    version: "2.6.6"
     engine: Webkit
     engine_version: "537.36"

--- a/Tests/Parser/Client/fixtures/feed_reader.yml
+++ b/Tests/Parser/Client/fixtures/feed_reader.yml
@@ -1,205 +1,201 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) akregator/4.11.5 Safari/537.21
   client:
     type: feed reader
     name: Akregator
     version: "4.11.5"
--
+- 
   user_agent: Akregator/4.12.3; syndication SUSE
   client:
     type: feed reader
     name: Akregator
     version: "4.12.3"
--
+- 
   user_agent: Akregator/1.2.9; librss/remnants
   client:
     type: feed reader
     name: Akregator
     version: "1.2.9"
--
+- 
   user_agent: Apple-PubSub/65.28
   client:
     type: feed reader
     name: Apple PubSub
     version: "65.28"
--
+- 
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows)
   client:
     type: feed reader
     name: FeedDemon
     version: "4.5"
--
+- 
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows XP)
   client:
     type: feed reader
     name: FeedDemon
     version: "4.5"
--
+- 
   user_agent: FeeddlerPro/2.4 CFNetwork/672.0.8 Darwin/14.0.0
   client:
     type: feed reader
     name: Feeddler RSS Reader
     version: "2.4"
--
+- 
   user_agent: FeeddlerRSS/2.4 CFNetwork/548.1.4 Darwin/11.0.0
   client:
     type: feed reader
     name: Feeddler RSS Reader
     version: "2.4"
--
+- 
   user_agent: FeeddlerRSS 2.4 (iPad; iPhone OS 5.1.1; en_US)
   client:
     type: feed reader
     name: Feeddler RSS Reader
     version: "2.4"
--
+- 
   user_agent: JetBrains Omea Reader 2.2 (http://www.jetbrains.com/omea/reader/)
   client:
     type: feed reader
     name: JetBrains Omea Reader
     version: "2.2"
--
+- 
   user_agent: Liferea/1.6.4 (Linux; en_US.UTF-8; http://liferea.sf.net/)
   client:
     type: feed reader
     name: Liferea
     version: "1.6.4"
--
+- 
   user_agent: Liferea/1.10-RC1 (Linux; en_GB.UTF-8; http://liferea.sf.net/)
   client:
     type: feed reader
     name: Liferea
     version: "1.10"
--
+- 
   user_agent: Liferea/1.10.6 (Linux; en_US.UTF8; http://liferea.sf.net/) AppleWebKit (KHTML, like Gecko)
   client:
     type: feed reader
     name: Liferea
     version: "1.10.6"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) Version/6.0 NetNewsWire/4.0.0
   client:
     type: feed reader
     name: NetNewsWire
     version: "4.0.0"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) NetNewsWire/3.3.2
   client:
     type: feed reader
     name: NetNewsWire
     version: "3.3.2"
--
+- 
   user_agent: NetNewsWire/4.0.0 (Mac OS X; http://netnewswireapp.com/mac/; gzip-happy)
   client:
     type: feed reader
     name: NetNewsWire
     version: "4.0.0"
--
+- 
   user_agent: newsbeuter/2.7 (Linux x86_64)
   client:
     type: feed reader
     name: Newsbeuter
     version: "2.7"
--
+- 
   user_agent: NewsBlur iPhone App v3.6
   client:
     type: feed reader
     name: NewsBlur Mobile App
     version: "3.6"
--
+- 
   user_agent: NewsBlur iPad App v3.6
   client:
     type: feed reader
     name: NewsBlur Mobile App
     version: "3.6"
--
+- 
   user_agent: NewsBlur/4.0.1 CFNetwork/672.1.13 Darwin/14.0.0
   client:
     type: feed reader
     name: NewsBlur
     version: "4.0.1"
--
+- 
   user_agent: newsbeuter/2.4 (Linux 3.2.0-23-generic; i686; http://www.newsbeuter.org/) libcurl/7.22.0 GnuTLS/2.12.14 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
   client:
     type: feed reader
     name: Newsbeuter
     version: "2.4"
--
+- 
   user_agent: PritTorrent/1.0
-  client:
-    type: feed reader
-    name: PritTorrent
-    version: 1.0
--
+- 
   user_agent: Pulp/1.5.2 (iPad; http://www.acrylicapps.com/pulp/)
   client:
     type: feed reader
     name: Pulp
     version: "1.5.2"
--
+- 
   user_agent: ReadKit/2.4.0 (Mac OS X Version 10.9.2 (Build 13C64))
   client:
     type: feed reader
     name: ReadKit
     version: "2.4.0"
--
-  user_agent: ReadKit/7017 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (MacBookPro10%2C1)
+- 
+  user_agent: 'ReadKit/7017 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (MacBookPro10%2C1)'
   client:
     type: feed reader
     name: ReadKit
     version: "7017"
--
+- 
   user_agent: Reeder/3.2 CFNetwork/672.1.12 Darwin/14.0.0
   client:
     type: feed reader
     name: Reeder
     version: "3.2"
--
+- 
   user_agent: RssBandit/1.9.0.1002
   client:
     type: feed reader
     name: RSS Bandit
     version: "1.9.0.1002"
--
+- 
   user_agent: RssBandit/1.9.0.1002 (.NET CLR 2.0.50727.7512; WinNT 6.2.9200.0; http://www.rssbandit.org)
   client:
     type: feed reader
     name: RSS Bandit
     version: "1.9.0.1002"
--
+- 
   user_agent: RSS Junkie Daemon
   client:
     type: feed reader
     name: RSS Junkie
-    version:
--
+    version: ""
+- 
   user_agent: RSSOwl/2.2.1.201312301314 (Windows; U; en)
   client:
     type: feed reader
     name: RSSOwl
     version: "2.2.1.201312301314"
--
+- 
   user_agent: RSSOwl/2.2.1.201312301316 (X11; U; en)
   client:
     type: feed reader
     name: RSSOwl
     version: "2.2.1.201312301316"
-
--
+- 
   user_agent: Stringer (https://github.com/swanson/stringer)
   client:
     type: feed reader
     name: Stringer
     version: ""
--
-  user_agent: Downcast/1241 CFNetwork/673.4 Darwin/13.3.0 (x86_64) (MacBookAir4%2C2)
+- 
+  user_agent: 'Downcast/1241 CFNetwork/673.4 Darwin/13.3.0 (x86_64) (MacBookAir4%2C2)'
   client:
     type: feed reader
     name: Downcast
-    version: 1241
--
+    version: "1241"
+- 
   user_agent: iTunes/10.7 Downcast/2.8.24.1002
   client:
     type: feed reader
     name: Downcast
-    version: 2.8.24.1002
+    version: "2.8.24.1002"

--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -1,160 +1,161 @@
--
+---
+- 
   user_agent: Wget/1.10+devel
   client:
     type: library
     name: Wget
     version: "1.10"
--
+- 
   user_agent: Wget/1.11.4 Red Hat modified
   client:
     type: library
     name: Wget
     version: "1.11.4"
--
+- 
   user_agent: Wget/ (linux-gnu)
   client:
     type: library
     name: Wget
-    version:
--
+    version: ""
+- 
   user_agent: curl/7.21.0 (i386-redhat-linux-gnu) libcurl/7.21.0 NSS/3.12.10.0 zlib/1.2.5 libidn/1.18 libssh2/1.2.4
   client:
     type: library
     name: curl
     version: "7.21.0"
--
+- 
   user_agent: PycURL/7.19.3.1 libcurl/7.26.0 GnuTLS/2.12.20 zlib/1.2.7 libidn/1.25 libssh2/1.4.2 librtmp/2.3
   client:
     type: library
     name: curl
     version: "7.26.0"
--
+- 
   user_agent: python-requests/1.2.0 CPython/2.7.3 Linux/3.8.0-33-generic
   client:
     type: library
     name: Python Requests
     version: "1.2.0"
--
+- 
   user_agent: python-requests/1.2.0 CPython/2.7.5 Windows/7
   client:
     type: library
     name: Python Requests
     version: "1.2.0"
--
+- 
   user_agent: Python-urllib/2.6
   client:
     type: library
     name: Python urllib
     version: "2.6"
--
+- 
   user_agent: Mozilla/5.0 (Python-urllib2)
   client:
     type: library
     name: Python urllib
-    version:
--
+    version: ""
+- 
   user_agent: Java/1.7.0_51
   client:
     type: library
     name: Java
     version: "1.7.0"
--
+- 
   user_agent: Java1.1.4
   client:
     type: library
     name: Java
     version: "1.1.4"
--
+- 
   user_agent: libwww-perl/5.69
   client:
     type: library
     name: Perl
     version: "5.69"
--
+- 
   user_agent: perlclient/1.0
   client:
     type: library
     name: Perl
     version: "1.0"
--
+- 
   user_agent: Guzzle/3.9.3 curl/7.38.0 PHP/5.6.14-0+deb8u1
   client:
     type: library
     name: Guzzle (PHP HTTP Client)
     version: "3.9.3"
--
+- 
   user_agent: HTTP_Request2/2.3.0 (http://pear.php.net/package/http_request2) PHP/5.3.3
   client:
     type: library
     name: HTTP_Request2
-    version: 2.3.0
--
+    version: "2.3.0"
+- 
   user_agent: Mechanize/2.7.3 Ruby/1.9.3p551 (http://github.com/sparklemotion/mechanize/)
   client:
     type: library
     name: Mechanize
-    version: 2.7.3
--
+    version: "2.7.3"
+- 
   user_agent: Python/3.5 aiohttp/1.0.5
   client:
     type: library
     name: aiohttp
-    version: 1.0.5
--
+    version: "1.0.5"
+- 
   user_agent: Google-HTTP-Java-Client/1.17.0-rc (gzip)
   client:
     type: library
     name: Google HTTP Java Client
-    version: 1.17.0-rc
--
+    version: "1.17.0-rc"
+- 
   user_agent: WWW-Mechanize/1.73
   client:
     type: library
     name: WWW-Mechanize
-    version: 1.73
--
+    version: "1.73"
+- 
   user_agent: Faraday v0.9.1
   client:
     type: library
     name: Faraday
-    version: 0.9.1
--
+    version: "0.9.1"
+- 
   user_agent: Go-http-client/1.1
   client:
     type: library
     name: Go-http-client
-    version: 1.1
--
+    version: "1.1"
+- 
   user_agent: Go-http-client/2.0
   client:
     type: library
     name: Go-http-client
-    version: 2.0
--
+    version: "2.0"
+- 
   user_agent: Go 1.1 package http
   client:
     type: library
     name: Go-http-client
-    version: 1.1
--
+    version: "1.1"
+- 
   user_agent: urlgrabber/3.9.1 yum/3.2.29
   client:
     type: library
     name: urlgrabber (yum)
     version: "3.9.1"
--
+- 
   user_agent: urlgrabber/3.10 yum/3.4.3
   client:
     type: library
     name: urlgrabber (yum)
     version: "3.10"
--
+- 
   user_agent: libdnf/0.11.1
   client:
     type: library
     name: libdnf
     version: "0.11.1"
--
+- 
   user_agent: HTTPie/1.0.2
   client:
     type: library

--- a/Tests/Parser/Client/fixtures/mediaplayer.yml
+++ b/Tests/Parser/Client/fixtures/mediaplayer.yml
@@ -1,160 +1,161 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Songbird/1.12.1 (20140112193149)
   client:
     type: mediaplayer
     name: Songbird
     version: "1.12.1"
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Nightingale/1.12.2 (20140112193149)
   client:
     type: mediaplayer
     name: Nightingale
     version: "1.12.2"
--
+- 
   user_agent: iTunes/10.2.1 (Macintosh; Intel Mac OS X 10.7) AppleWebKit/534.20.8
   client:
     type: mediaplayer
     name: iTunes
     version: "10.2.1"
--
+- 
   user_agent: iTunes/10.2.1 (Windows; Microsoft Windows 7 Enterprise Edition Service Pack 1 (Build 7601)) AppleWebKit/533.20.25
   client:
     type: mediaplayer
     name: iTunes
     version: "10.2.1"
--
+- 
   user_agent: VLC/2.1.0 LibVLC/2.1.0
   client:
     type: mediaplayer
     name: VLC
     version: "2.1.0"
--
+- 
   user_agent: LibVLC/2.2.3 (LIVE555 Streaming Media v2015.10.12)
   client:
     type: mediaplayer
     name: VLC
     version: "2.2.3"
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; FunWebProducts; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.0.04506; Windows-Media-Player/10.00.00.3990)
   client:
     type: mediaplayer
     name: Windows Media Player
     version: "10.00.00.3990"
--
+- 
   user_agent: Windows-Media-Player/11.0.6001.7000
   client:
     type: mediaplayer
     name: Windows Media Player
     version: "11.0.6001.7000"
--
+- 
   user_agent: SAMSUNG-GT-S3850/S3850CXKD1 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   client:
     type: mediaplayer
     name: NexPlayer
     version: "3.0"
--
+- 
   user_agent: Banshee 1.5.1 (http://banshee-project.org/)
   client:
     type: mediaplayer
     name: Banshee
     version: "1.5.1"
--
+- 
   user_agent: Banshee/2.6.2 (http://banshee-project.org/)
   client:
     type: mediaplayer
     name: Banshee
     version: "2.6.2"
--
+- 
   user_agent: QuickTime/7.6.6 (qtver=7.6.6;cpu=IA32;os=Mac 10.6.8)
   client:
     type: mediaplayer
     name: QuickTime
     version: "7.6.6"
--
+- 
   user_agent: QuickTime.7.7.4 (qtver=7.7.4;os=Windows NT 6.0Service Pack 2)
   client:
     type: mediaplayer
     name: QuickTime
     version: "7.7.4"
--
+- 
   user_agent: QuickTime (qtver=7.0.2a26;os=Windows NT 6.0)
   client:
     type: mediaplayer
     name: QuickTime
     version: "7.0.2"
--
+- 
   user_agent: QuickTime E-/7.7.5 (qtver=7.7.5;os=Windows NT 6.1)
   client:
     type: mediaplayer
     name: QuickTime
     version: "7.7.5"
--
+- 
   user_agent: FlyCast/1.34 (BlackBerry; 8330/4.5.0.131 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/-1)
   client:
     type: mediaplayer
     name: FlyCast
     version: "1.34"
--
+- 
   user_agent: XBMC/9.04 r19840 (Mac OS X; Darwin 9.6.0; http://www.xbmc.org)
   client:
     type: mediaplayer
     name: XBMC
     version: "9.04"
--
+- 
   user_agent: XBMC/9.04-beta1 r19639 (Windows; Windows XP Professional Service Pack 2 build 2600; http://www.xbmc.org)
   client:
     type: mediaplayer
     name: XBMC
     version: "9.04"
--
+- 
   user_agent: SubStream/0.7 CFNetwork/485.12.30 Darwin/10.4.0
   client:
     type: mediaplayer
     name: SubStream
     version: "0.7"
--
+- 
   user_agent: MediaMonkey 4.1.1.1703
   client:
     type: mediaplayer
     name: MediaMonkey
     version: "4.1.1.1703"
--
+- 
   user_agent: Clementine 1.2.2
   client:
     type: mediaplayer
     name: Clementine
     version: "1.2.2"
--
+- 
   user_agent: WAFA/1.2.10 (Linux; Android 4.1; Winamp) Replicant/1.0
   client:
     type: mediaplayer
     name: Winamp
-    version:
--
+    version: ""
+- 
   user_agent: WinampMPEG/5.66, Ultravox/2.1
   client:
     type: mediaplayer
     name: Winamp
     version: "5.66"
--
+- 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9) Gecko Miro/2.0.4 (http://www.getmiro.com/)
   client:
     type: mediaplayer
     name: Miro
     version: "2.0.4"
--
+- 
   user_agent: Miro/3.0.1 (http://www.getmiro.com/; Darwin 8.11.1 i386)
   client:
     type: mediaplayer
     name: Miro
     version: "3.0.1"
--
+- 
   user_agent: Kodi/14.0 (Macintosh; Intel Mac OS X 10_10_3) App_Bitness/64 Version/14.0-Git:2014-12-23-ad747d9-dirty
   client:
     type: mediaplayer
     name: Kodi
     version: "14.0"
--
+- 
   user_agent: foobar2000/1.3.10
   client:
     type: mediaplayer

--- a/Tests/Parser/Client/fixtures/mobile_app.yml
+++ b/Tests/Parser/Client/fixtures/mobile_app.yml
@@ -1,134 +1,133 @@
--
+---
+- 
   user_agent: Pulse/4.0.5 (iPhone; iOS 7.0.6; Scale/2.00)
   client:
     type: mobile app
     name: Pulse
     version: "4.0.5"
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G7509 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 MicroMessenger/6.0.2.56_r958800.520 NetType/WIFI
   client:
     type: mobile app
     name: WeChat
     version: "6.0.2.56.r958800.520"
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ZTE U807N Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 Weibo (ZTE-ZTE U807N__weibo__5.0.0__android__android4.0.4)
   client:
     type: mobile app
     name: Sina Weibo
     version: "5.0.0"
--
+- 
   user_agent: FeedR/1.0 (Android)
   client:
     type: mobile app
     name: FeedR
     version: "1.0"
--
+- 
   user_agent: Pinterest/3.3.3 CFNetwork/609.1.4 Darwin/13.0.0
   client:
     type: mobile app
     name: Pinterest
     version: "3.3.3"
--
+- 
   user_agent: Instacast/5.0a8 CFNetwork/711.1.11 Darwin/13.4.0
   client:
     type: mobile app
     name: Instacast
-    version: 5.0a8
--
+    version: "5.0a8"
+- 
   user_agent: InstacastHD/1.1.2 CFNetwork/711.0.6 Darwin/14.0.0
   client:
     type: mobile app
     name: Instacast
-    version: 1.1.2
--
+    version: "1.1.2"
+- 
   user_agent: Podcasts/2.1.2
   client:
     type: mobile app
     name: Podcasts
-    version: 2.1.2
--
+    version: "2.1.2"
+- 
   user_agent: Shifty Jelly Pocket Casts, Android v4.4.3.1
   client:
     type: mobile app
     name: Pocket Casts
-    version: 4.4.3.1
--
+    version: "4.4.3.1"
+- 
   user_agent: Pocket Casts
   client:
     type: mobile app
     name: Pocket Casts
-    version:
-
--
+    version: ""
+- 
   user_agent: Mozilla/5.0 (Linux; U; en-us; BeyondPod)
   client:
     type: mobile app
     name: BeyondPod
-    version:
--
+    version: ""
+- 
   user_agent: AntennaPod/0.9.9.1
   client:
     type: mobile app
     name: AntennaPod
-    version: 0.9.9.1
--
+    version: "0.9.9.1"
+- 
   user_agent: AntennaPod/
   client:
     type: mobile app
     name: AntennaPod
-    version: 
-
--
+    version: ""
+- 
   user_agent: Overcast/1.0 (+http://overcast.fm/; iOS podcast app)
   client:
     type: mobile app
     name: Overcast
-    version: 1.0
--
+    version: "1.0"
+- 
   user_agent: Podkicker/1.9.4
   client:
     type: mobile app
     name: Podkicker
-    version: 1.9.4
--
+    version: "1.9.4"
+- 
   user_agent: Podkicker Pro/1.9.4
   client:
     type: mobile app
     name: Podkicker
-    version: 1.9.4
--
+    version: "1.9.4"
+- 
   user_agent: Castro/64 CFNetwork/672.1.15 Darwin/14.0.0
   client:
     type: mobile app
     name: Castro
-    version: 64
--
+    version: "64"
+- 
   user_agent: Mozilla/5.0 (Linux; U; Windows NT 6.1; en-us; dream) DoggCatcher
   client:
     type: mobile app
     name: DoggCatcher
-    version:
--
+    version: ""
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; SOL22 Build/10.3.1.D.0.257) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YJApp-ANDROID jp.co.yahoo.android.yjtop/3.15.1
   client:
     type: mobile app
     name: Yahoo! Japan
-    version: 3.15.1
--
+    version: "3.15.1"
+- 
   user_agent: RSSRadio/9220 (iPad;iOS;12.3.1)
   client:
     type: mobile app
     name: RSSRadio
-    version: 9220
--
+    version: "9220"
+- 
   user_agent: RSSRadio/9252
   client:
     type: mobile app
     name: RSSRadio
-    version: 9252
--
+    version: "9252"
+- 
   user_agent: RSSRadio/
   client:
     type: mobile app
     name: RSSRadio
-    version:
+    version: ""

--- a/Tests/Parser/Client/fixtures/pim.yml
+++ b/Tests/Parser/Client/fixtures/pim.yml
@@ -1,100 +1,101 @@
--
+---
+- 
   user_agent: Outlook-Express/7.0 (MSIE 7.0; Windows NT 6.1; WOW64; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; AskTbORJ/5.15.9.29495; .NET4.0E; TmstmpExt)
   client:
     type: pim
     name: Outlook Express
     version: "7.0"
--
+- 
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Win64; x64; Trident/7.0; .NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; InfoPath.3; .NET CLR 1.1.4322; FDM; Tablet PC 2.0; .NET4.0E; Microsoft Outlook 14.0.7113; ms-office; MSOffice 14)
   client:
     type: pim
     name: Microsoft Outlook
     version: "14.0.7113"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux i686; rv:17.0) Gecko/20130330 Thunderbird/17.0.5
   client:
     type: pim
     name: Thunderbird
     version: "17.0.5"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Thunderbird/24.4.0 Lightning/2.6.4
   client:
     type: pim
     name: Thunderbird
     version: "24.4.0"
--
+- 
   user_agent: Airmail 1.4 rv:238 (Macintosh; Mac OS X 10.9.2; hr_HR)
   client:
     type: pim
     name: Airmail
     version: "1.4"
--
+- 
   user_agent: Airmail 1.3.3 rv:237 (Macintosh; Mac OS X 10.9.2; en_US)
   client:
     type: pim
     name: Airmail
     version: "1.3.3"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Icedove/24.4.0
   client:
     type: pim
     name: Thunderbird
     version: "24.4.0"
--
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:24.0) Gecko/20100101 Icedove/24.4.0 Lightning/2.6.5
   client:
     type: pim
     name: Thunderbird
     version: "24.4.0"
--
+- 
   user_agent: Mozilla/4.0 (compatible; Lotus-Notes/6.0; Windows-NT)
   client:
     type: pim
     name: Lotus Notes
     version: "6.0"
--
+- 
   user_agent: Barca/2.8.4400
   client:
     type: pim
     name: Barca
     version: "2.8.4400"
--
+- 
   user_agent: BarcaPro/1.4 L.1001
   client:
     type: pim
     name: Barca
     version: "1.4"
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.8) Gecko/20100317 Postbox/1.1.3
   client:
     type: pim
     name: Postbox
     version: "1.1.3"
--
+- 
   user_agent: Postbox 1.0b14 (Windows/2009072715)
   client:
     type: pim
     name: Postbox
     version: "1.0"
--
+- 
   user_agent: MailBar/1.3.2 (Mac OS X Version 10.11.1 (Build 15B42))
   client:
     type: pim
     name: MailBar
-    version: 1.3.2
--
+    version: "1.3.2"
+- 
   user_agent: The Bat! 4.0.0.22
   client:
     type: pim
     name: The Bat!
     version: "4.0.0.22"
--
+- 
   user_agent: The Bat! Voyager 4.0.18.4
   client:
     type: pim
     name: The Bat!
     version: "4.0.18.4"
--
+- 
   user_agent: DAVdroid/1.6.2-ose (2017/06/23; dav4android; okhttp3) Android/7.0
   client:
     type: pim

--- a/Tests/Parser/Devices/fixtures/camera.yml
+++ b/Tests/Parser/Devices/fixtures/camera.yml
@@ -2,18 +2,18 @@
 - 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0; de-DE; EK-GC100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   device:
-    type: camera
+    type: 8
     brand: SA
     model: GALAXY Camera
 - 
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; EK-GC100 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.60140
   device:
-    type: camera
+    type: 8
     brand: SA
     model: GALAXY Camera
 - 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; COOLPIX S800c Build/CP01_WW) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   device:
-    type: camera
+    type: 8
     brand: NN
     model: Coolpix S800c

--- a/Tests/Parser/Devices/fixtures/camera.yml
+++ b/Tests/Parser/Devices/fixtures/camera.yml
@@ -1,18 +1,19 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0; de-DE; EK-GC100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   device:
-    type: 8
+    type: camera
     brand: SA
     model: GALAXY Camera
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; EK-GC100 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.60140
   device:
-    type: 8
+    type: camera
     brand: SA
     model: GALAXY Camera
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; COOLPIX S800c Build/CP01_WW) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   device:
-    type: 8
+    type: camera
     brand: NN
     model: Coolpix S800c

--- a/Tests/Parser/Devices/fixtures/car_browser.yml
+++ b/Tests/Parser/Devices/fixtures/car_browser.yml
@@ -2,6 +2,6 @@
 - 
   user_agent: Mozilla/5.0 (X11; u; Linux; C) AppleWebKit /533.3 (Khtml, like Gheko) QtCarBrowser Safari/533.3
   device:
-    type: car browser
+    type: 6
     brand: TA
     model: Model S

--- a/Tests/Parser/Devices/fixtures/car_browser.yml
+++ b/Tests/Parser/Devices/fixtures/car_browser.yml
@@ -1,6 +1,7 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (X11; u; Linux; C) AppleWebKit /533.3 (Khtml, like Gheko) QtCarBrowser Safari/533.3
   device:
-    type: 6
+    type: car browser
     brand: TA
     model: Model S

--- a/Tests/Parser/Devices/fixtures/console.yml
+++ b/Tests/Parser/Devices/fixtures/console.yml
@@ -2,78 +2,78 @@
 - 
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS GAMEPAD Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   device:
-    type: console
+    type: 4
     brand: AR
     model: Gamepad
 - 
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)
   device:
-    type: console
+    type: 4
     brand: MS
     model: Xbox 360
 - 
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)
   device:
-    type: console
+    type: 4
     brand: MS
     model: Xbox One
 - 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   device:
-    type: console
+    type: 4
     brand: MS
     model: Xbox One
 - 
   user_agent: Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.EU
   device:
-    type: console
+    type: 4
     brand: NI
     model: 3DS
 - 
   user_agent: Bunjalloo/0.7.6(Nintendo DS;U;en)
   device:
-    type: console
+    type: 4
     brand: NI
     model: DS
 - 
   user_agent: Opera/9.30 (Nintendo Wii; U; ; 3642; en)
   device:
-    type: console
+    type: 4
     brand: NI
     model: Wii
 - 
   user_agent: Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US
   device:
-    type: console
+    type: 4
     brand: NI
     model: WiiU
 - 
   user_agent: Mozilla/5.0 (Linux; U; Android OUYA 4.1.2; en-us; OUYA Build/JZO54L-OUYA) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   device:
-    type: console
+    type: 4
     brand: OU
     model: OUYA
 - 
   user_agent: Mozilla/5.0 (PLAYSTATION 3 4.46) AppleWebKit/531.22.8 (KHTML, like Gecko)
   device:
-    type: console
+    type: 4
     brand: SO
     model: PlayStation 3
 - 
   user_agent: Mozilla/5.0 (PlayStation 4 1.52) AppleWebKit/536.26 (KHTML, like Gecko)
   device:
-    type: console
+    type: 4
     brand: SO
     model: PlayStation 4
 - 
   user_agent: Mozilla/4.0 (PlayStation Portable); 2.00)
   device:
-    type: console
+    type: 4
     brand: SO
     model: PlayStation Portable
 - 
   user_agent: Mozilla/5.0 (PlayStation Vita 3.01) AppleWebKit/536.26 (KHTML, like Gecko) Silk/3.2
   device:
-    type: console
+    type: 4
     brand: SO
     model: PlayStation Vita

--- a/Tests/Parser/Devices/fixtures/console.yml
+++ b/Tests/Parser/Devices/fixtures/console.yml
@@ -1,78 +1,79 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS GAMEPAD Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   device:
-    type: 4
+    type: console
     brand: AR
     model: Gamepad
--
+- 
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)
   device:
-    type: 4
+    type: console
     brand: MS
     model: Xbox 360
--
+- 
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)
   device:
-    type: 4
+    type: console
     brand: MS
     model: Xbox One
--
+- 
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; Xbox; Xbox One) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   device:
-    type: 4
+    type: console
     brand: MS
     model: Xbox One
--
+- 
   user_agent: Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.EU
   device:
-    type: 4
+    type: console
     brand: NI
     model: 3DS
--
+- 
   user_agent: Bunjalloo/0.7.6(Nintendo DS;U;en)
   device:
-    type: 4
+    type: console
     brand: NI
     model: DS
--
+- 
   user_agent: Opera/9.30 (Nintendo Wii; U; ; 3642; en)
   device:
-    type: 4
+    type: console
     brand: NI
     model: Wii
--
+- 
   user_agent: Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US
   device:
-    type: 4
+    type: console
     brand: NI
     model: WiiU
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android OUYA 4.1.2; en-us; OUYA Build/JZO54L-OUYA) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   device:
-    type: 4
+    type: console
     brand: OU
     model: OUYA
--
+- 
   user_agent: Mozilla/5.0 (PLAYSTATION 3 4.46) AppleWebKit/531.22.8 (KHTML, like Gecko)
   device:
-    type: 4
+    type: console
     brand: SO
     model: PlayStation 3
--
+- 
   user_agent: Mozilla/5.0 (PlayStation 4 1.52) AppleWebKit/536.26 (KHTML, like Gecko)
   device:
-    type: 4
+    type: console
     brand: SO
     model: PlayStation 4
--
+- 
   user_agent: Mozilla/4.0 (PlayStation Portable); 2.00)
   device:
-    type: 4
+    type: console
     brand: SO
     model: PlayStation Portable
--
+- 
   user_agent: Mozilla/5.0 (PlayStation Vita 3.01) AppleWebKit/536.26 (KHTML, like Gecko) Silk/3.2
   device:
-    type: 4
+    type: console
     brand: SO
     model: PlayStation Vita

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -1740,8 +1740,8 @@
     name: Baidu Spark
     short_name: BS
     version: "26.4"
-    engine: WebKit
-    engine_version: "537.31"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -2368,8 +2368,8 @@
     name: Sogou Explorer
     short_name: SE
     version: "2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -2388,8 +2388,8 @@
     name: Baidu Spark
     short_name: BS
     version: "2"
-    engine: WebKit
-    engine_version: "537.31"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -3110,8 +3110,8 @@
     name: Baidu Spark
     short_name: BS
     version: "2"
-    engine: WebKit
-    engine_version: "537.31"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -3190,8 +3190,8 @@
     name: CoolNovo
     short_name: CN
     version: "2.0.9.20"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -3530,8 +3530,8 @@
     name: Liebao
     short_name: LB
     version: ""
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""
@@ -3690,8 +3690,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.0.3197.400"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: desktop
     brand: ""

--- a/Tests/fixtures/feed_reader.yml
+++ b/Tests/fixtures/feed_reader.yml
@@ -1,9 +1,10 @@
--
+---
+- 
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) akregator/4.11.5 Safari/537.21
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
+    version: ""
     platform: x64
   client:
     type: feed reader
@@ -11,28 +12,28 @@
     version: "4.11.5"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Akregator/4.12.3; syndication SUSE
   os:
     name: SUSE
     short_name: SSE
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: Akregator
     version: "4.12.3"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Akregator/1.2.9; librss/remnants
   os: [ ]
   client:
@@ -40,12 +41,12 @@
     name: Akregator
     version: "1.2.9"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: Apple-PubSub/65.28
   os: [ ]
   client:
@@ -53,86 +54,86 @@
     name: Apple PubSub
     version: "65.28"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows)
   os:
     name: Windows
     short_name: WIN
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: FeedDemon
     version: "4.5"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: Windows
   browser_family: Unknown
--
+- 
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows XP)
   os:
     name: Windows
     short_name: WIN
     version: "XP"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: FeedDemon
     version: "4.5"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: Windows
   browser_family: Unknown
--
+- 
   user_agent: FeeddlerPro/2.4 CFNetwork/672.0.8 Darwin/14.0.0
   os:
     name: iOS
     short_name: IOS
     version: "7.0"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Feeddler RSS Reader
     version: "2.4"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: FeeddlerRSS/2.4 CFNetwork/548.1.4 Darwin/11.0.0
   os:
     name: iOS
     short_name: IOS
     version: "5.1"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Feeddler RSS Reader
     version: "2.4"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: FeeddlerRSS 2.4 (iPad; iPhone OS 5.1.1; en_US)
   os:
     name: iOS
     short_name: IOS
     version: "5.1.1"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Feeddler RSS Reader
@@ -143,7 +144,7 @@
     model: iPad
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: JetBrains Omea Reader 2.2 (http://www.jetbrains.com/omea/reader/)
   os: [ ]
   client:
@@ -151,69 +152,69 @@
     name: JetBrains Omea Reader
     version: "2.2"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: Liferea/1.6.4 (Linux; en_US.UTF-8; http://liferea.sf.net/)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: Liferea
     version: "1.6.4"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Liferea/1.10-RC1 (Linux; en_GB.UTF-8; http://liferea.sf.net/)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: Liferea
     version: "1.10"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Liferea/1.10.6 (Linux; en_US.UTF8; http://liferea.sf.net/) AppleWebKit (KHTML, like Gecko)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: Liferea
     version: "1.10.6"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) Version/6.0 NetNewsWire/4.0.0
   os:
     name: Mac
     short_name: MAC
     version: "10.9.2"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: NetNewsWire
@@ -221,16 +222,16 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) NetNewsWire/3.3.2
   os:
     name: Mac
     short_name: MAC
     version: "10.9.2"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: NetNewsWire
@@ -238,10 +239,10 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
+- 
   user_agent: Breaker/v315 (subscribers=9999; feed-id=123456; url=https://www.breaker.audio/url-slug-to-podcast)
   os: [ ]
   client:
@@ -254,13 +255,13 @@
     model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: NetNewsWire/4.0.0 (Mac OS X; http://netnewswireapp.com/mac/; gzip-happy)
   os:
     name: Mac
     short_name: MAC
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: NetNewsWire
@@ -268,17 +269,16 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
-
--
+- 
   user_agent: Downcast/2.9.11 (Mac OS X Version 10.11.3 (Build 15D21))
   os:
     name: Mac
     short_name: MAC
     version: "10.11.3"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Downcast
@@ -286,17 +286,16 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
-
--
+- 
   user_agent: Downcast/2.9.11 (iPhone; iOS 9.2; Scale/2.00)
   os:
     name: iOS
     short_name: IOS
     version: "9.2"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Downcast
@@ -307,13 +306,12 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
-
--
+- 
   user_agent: newsbeuter/2.7 (Linux x86_64)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
+    version: ""
     platform: x64
   client:
     type: feed reader
@@ -321,17 +319,17 @@
     version: "2.7"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: NewsBlur iPhone App v3.6
   os:
     name: iOS
     short_name: IOS
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: NewsBlur Mobile App
@@ -342,13 +340,13 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: NewsBlur iPad App v3.6
   os:
     name: iOS
     short_name: IOS
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: NewsBlur Mobile App
@@ -359,29 +357,29 @@
     model: iPad
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: NewsBlur/4.0.1 CFNetwork/672.1.13 Darwin/14.0.0
   os:
     name: iOS
     short_name: IOS
     version: "7.1"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: NewsBlur
     version: "4.0.1"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: newsbeuter/2.4 (Linux 3.2.0-23-generic; i686; http://www.newsbeuter.org/) libcurl/7.22.0 GnuTLS/2.12.14 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
+    version: ""
     platform: x86
   client:
     type: feed reader
@@ -389,17 +387,17 @@
     version: "2.4"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Pulp/1.5.2 (iPad; http://www.acrylicapps.com/pulp/)
   os:
     name: iOS
     short_name: IOS
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: Pulp
@@ -410,13 +408,13 @@
     model: iPad
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: ReadKit/2.4.0 (Mac OS X Version 10.9.2 (Build 13C64))
   os:
     name: Mac
     short_name: MAC
     version: "10.9.2"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: ReadKit
@@ -424,11 +422,11 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
-  user_agent: ReadKit/7017 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (MacBookPro10%2C1)
+- 
+  user_agent: 'ReadKit/7017 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (MacBookPro10%2C1)'
   os:
     name: Mac
     short_name: MAC
@@ -441,27 +439,27 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
+- 
   user_agent: Reeder/3.2 CFNetwork/672.1.12 Darwin/14.0.0
   os:
     name: iOS
     short_name: IOS
     version: "7.1"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: Reeder
     version: "3.2"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: RssBandit/1.9.0.1002
   os: [ ]
   client:
@@ -469,59 +467,59 @@
     name: RSS Bandit
     version: "1.9.0.1002"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: RssBandit/1.9.0.1002 (.NET CLR 2.0.50727.7512; WinNT 6.2.9200.0; http://www.rssbandit.org)
   os:
     name: Windows
     short_name: WIN
     version: "NT"
-    platform:
+    platform: ""
   client:
     type: feed reader
     name: RSS Bandit
     version: "1.9.0.1002"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: Windows
   browser_family: Unknown
--
+- 
   user_agent: RSS Junkie Daemon
   os: [ ]
   client:
     type: feed reader
     name: RSS Junkie
-    version:
+    version: ""
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: RSSOwl/2.2.1.201312301314 (Windows; U; en)
   os:
     name: Windows
     short_name: WIN
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: feed reader
     name: RSSOwl
     version: "2.2.1.201312301314"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: Windows
   browser_family: Unknown
--
+- 
   user_agent: RSSOwl/2.2.1.201312301316 (X11; U; en)
   os: [ ]
   client:
@@ -529,8 +527,8 @@
     name: RSSOwl
     version: "2.2.1.201312301316"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown

--- a/Tests/fixtures/mediaplayer.yml
+++ b/Tests/fixtures/mediaplayer.yml
@@ -1,4 +1,5 @@
--
+---
+- 
   user_agent: Audacious/3.6.2 neon/0.30.1
   os: [ ]
   client:
@@ -11,12 +12,12 @@
     model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Songbird/1.12.1 (20140112193149)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
+    version: ""
     platform: x86
   client:
     type: mediaplayer
@@ -24,16 +25,16 @@
     version: "1.12.1"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Nightingale/1.12.2 (20140112193149)
   os:
     name: GNU/Linux
     short_name: LIN
-    version:
+    version: ""
     platform: x86
   client:
     type: mediaplayer
@@ -41,17 +42,17 @@
     version: "1.12.2"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
--
+- 
   user_agent: iTunes/10.2.1 (Macintosh; Intel Mac OS X 10.7) AppleWebKit/534.20.8
   os:
     name: Mac
     short_name: MAC
     version: "10.7"
-    platform:
+    platform: ""
   client:
     type: mediaplayer
     name: iTunes
@@ -59,27 +60,27 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
+- 
   user_agent: iTunes/10.2.1 (Windows; Microsoft Windows 7 Enterprise Edition Service Pack 1 (Build 7601)) AppleWebKit/533.20.25
   os:
     name: Windows
     short_name: WIN
     version: "7"
-    platform:
+    platform: ""
   client:
     type: mediaplayer
     name: iTunes
     version: "10.2.1"
   device:
     type: desktop
-    brand:
-    model:
+    brand: ""
+    model: ""
   os_family: Windows
   browser_family: Unknown
--
+- 
   user_agent: SAMSUNG-GT-S3850/S3850CXKD1 SHP/VPP/R5 Dolfin/2.0 NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os: [ ]
   client:
@@ -92,7 +93,7 @@
     model: GT-S3850
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: Deezer/5.4.21.97 (Android; 6.0; Mobile; fr) WIKO U FEEL
   os:
     name: Android
@@ -109,13 +110,13 @@
     model: U Feel
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: FlyCast/1.34 (BlackBerry; 8330/4.5.0.131 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/-1)
   os:
     name: BlackBerry OS
     short_name: BLB
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mediaplayer
     name: FlyCast
@@ -126,7 +127,7 @@
     model: BlackBerry
   os_family: BlackBerry
   browser_family: Unknown
--
+- 
   user_agent: NSPlayer/10.0.0.4072 WMFSDK/10.0
   os: [ ]
   client:
@@ -134,18 +135,18 @@
     name: Windows Media Player
     version: "10.0.0.4072"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: XBMC/9.04 r19840 (Mac OS X; Darwin 9.6.0; http://www.xbmc.org)
   os:
     name: Mac
     short_name: MAC
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mediaplayer
     name: XBMC
@@ -153,33 +154,33 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown
--
+- 
   user_agent: SubStream/0.7 CFNetwork/485.12.30 Darwin/10.4.0
   os:
     name: iOS
     short_name: IOS
     version: "4.2"
-    platform:
+    platform: ""
   client:
     type: mediaplayer
     name: SubStream
     version: "0.7"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Samsung GT-I9505 stagefright/1.2 (Linux;Android 4.4.2)
   os:
     name: Android
     short_name: AND
     version: "4.4.2"
-    platform:
+    platform: ""
   client:
     type: mediaplayer
     name: Stagefright
@@ -190,13 +191,13 @@
     model: GALAXY S4
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Kodi/14.0 (Macintosh; Intel Mac OS X 10_10_3) App_Bitness/64 Version/14.0-Git:2014-12-23-ad747d9-dirty
   os:
     name: Mac
     short_name: MAC
     version: "10.10.3"
-    platform:
+    platform: ""
   client:
     type: mediaplayer
     name: Kodi
@@ -204,6 +205,6 @@
   device:
     type: desktop
     brand: AP
-    model:
+    model: ""
   os_family: Mac
   browser_family: Unknown

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -1,10 +1,11 @@
--
+---
+- 
   user_agent: Pulse/4.0.5 (iPhone; iOS 7.0.6; Scale/2.00)
   os:
     name: iOS
     short_name: IOS
     version: "7.0.6"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Pulse
@@ -15,13 +16,13 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: WhatsApp/2.6.4 iPhone_OS/4.3.3 Device/iPhone_4
   os:
     name: iOS
     short_name: IOS
     version: "4.3.3"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: WhatsApp
@@ -32,13 +33,13 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; MB886 Build/9.8.0Q-97_MB886_FFW-20)
   os:
     name: Android
     short_name: AND
     version: "4.1.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: AndroidDownloadManager
@@ -49,13 +50,13 @@
     model: MB886
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: com.google.android.youtube/2.4.4(Linux; U; Android 2.3.5; en_US; SCH-I500 Build/GINGERBREAD) gzip
   os:
     name: Android
     short_name: AND
     version: "2.3.5"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: YouTube
@@ -66,47 +67,47 @@
     model: SCH-I500
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: NS/3.3.1 (Linux; U; Android 5.0.1; en-in; phone/Nexus 5 Build/LRX22C; Density/480; gzip) com.google.android.apps.magazines/2014102707
   os:
     name: Android
     short_name: AND
     version: "5.0.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Google Play Newsstand
-    version:
+    version: ""
   device:
     type: smartphone
     brand: GO
     model: Nexus 5
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (iPad3,6; iPad; U; CPU OS 7_1 like Mac OS X; en_US) com.google.GooglePlus/33839 (KHTML, like Gecko) Mobile/P103AP (gzip)
   os:
     name: iOS
     short_name: IOS
     version: "7.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Google Plus
-    version:
+    version: ""
   device:
     type: tablet
     brand: AP
     model: iPad 4
   os_family: iOS
   browser_family: Unknown
--
-  user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 [FBAN/MessengerForiOS;FBAV/132.0.0.41.90;FBBV/69171754;FBDV/iPhone8,4;FBMD/iPhone;FBSN/iOS;FBSV/10.3.3;FBSS/2;FBCR/Koodo;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]
+- 
+  user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 [FBAN/MessengerForiOS;FBAV/132.0.0.41.90;FBBV/69171754;FBDV/iPhone8,4;FBMD/iPhone;FBSN/iOS;FBSV/10.3.3;FBSS/2;FBCR/Koodo;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]'
   os:
     name: iOS
     short_name: IOS
     version: "10.3.3"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Facebook Messenger
@@ -117,13 +118,13 @@
     model: iPhone SE
   os_family: iOS
   browser_family: Unknown
--
-  user_agent: Mozilla/5.0 (iPad; CPU OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 [FBAN/MessengerForiOS;FBAV/122.0.0.40.69;FBBV/61279955;FBDV/iPad4,1;FBMD/iPad;FBSN/iOS;FBSV/10.1.1;FBSS/2;FBCR/;FBID/tablet;FBLC/vi_VN;FBOP/5;FBRV/0]
+- 
+  user_agent: 'Mozilla/5.0 (iPad; CPU OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 [FBAN/MessengerForiOS;FBAV/122.0.0.40.69;FBBV/61279955;FBDV/iPad4,1;FBMD/iPad;FBSN/iOS;FBSV/10.1.1;FBSS/2;FBCR/;FBID/tablet;FBLC/vi_VN;FBOP/5;FBRV/0]'
   os:
     name: iOS
     short_name: IOS
     version: "10.1.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Facebook Messenger
@@ -134,13 +135,13 @@
     model: iPad Air
   os_family: iOS
   browser_family: Unknown
--
-  user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/114.0.0.21.71;]
+- 
+  user_agent: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/114.0.0.21.71;]'
   os:
     name: Android
     short_name: AND
     version: "7.1.2"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Facebook Messenger
@@ -151,13 +152,13 @@
     model: Nexus 5X
   os_family: Android
   browser_family: Unknown
--
-  user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T280 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Safari/537.36 [FB_IAB/MESSENGER;FBAV/112.0.0.17.70;]
+- 
+  user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; SM-T280 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Safari/537.36 [FB_IAB/MESSENGER;FBAV/112.0.0.17.70;]'
   os:
     name: Android
     short_name: AND
     version: "5.1.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Facebook Messenger
@@ -168,7 +169,7 @@
     model: GALAXY Tab A 7.0" WiFi
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: '[FBAN/FB4A;FBAV/26.0.0.22.16;FBBV/6590638;FBDM/{density=1.5,width=791,height=480};FBLC/en_US;FBCR/SmarTone HK;FBMF/Sony;FBBD/Sony;FBPN/com.facebook.katana;FBDV/C1905;FBSV/4.1.2;FBOP/19;FBCA/armeabi-v7a:armeabi;]'
   os: [ ]
   client:
@@ -181,13 +182,13 @@
     model: Xperia M
   os_family: Unknown
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 Safari Line/5.9.5
   os:
     name: iOS
     short_name: IOS
     version: "8.2"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Line
@@ -198,13 +199,13 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13D15 Safari Line/5.10.0
   os:
     name: iOS
     short_name: IOS
     version: "9.2.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Line
@@ -215,30 +216,30 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Podcat/8577 CFNetwork/711.3.18 Darwin/14.0.0
   os:
     name: iOS
     short_name: IOS
     version: "8.3"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Podcat
     version: "8577"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Podcat/1.1.4.14639 (iPhone; de-DE; iPhone OS 9.2.1)
   os:
     name: iOS
     short_name: IOS
     version: "9.2.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Podcat
@@ -249,7 +250,7 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: PodcastRepublic/18.0 (Linux; U; Android 8.0.0;OnePlus3T/OPR1.170623.032)
   os:
     name: Android
@@ -266,7 +267,7 @@
     model: 3T
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 6.0; FEVER Build/MRA58K)'
   os:
     name: Android
@@ -283,132 +284,132 @@
     model: Fever
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Podcatcher Deluxe
   os:
     name: Android
     short_name: AND
-    version:
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mobile app
     name: Podcatcher Deluxe
-    version:
+    version: ""
   device:
-    type: 
-    brand: 
-    model: 
+    type: ""
+    brand: ""
+    model: ""
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: iCatcher! Podcast Player/2.6.2
   os:
     name: iOS
     short_name: IOS
-    version: 
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mobile app
     name: iCatcher
     version: "2.6.2"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: icatcher/4535 CFNetwork/672.1.14 Darwin/14.0.0
   os:
     name: iOS
     short_name: IOS
     version: "7.1"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: iCatcher
     version: "4535"
   device:
-    type: 
+    type: ""
     brand: AP
-    model: 
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Castro 2 Episode Download
   os:
     name: iOS
     short_name: IOS
-    version: 
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mobile app
     name: Castro 2
-    version:
+    version: ""
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Castro 2 2.1.2/646 Like iTunes
   os:
     name: iOS
     short_name: IOS
-    version: 
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mobile app
     name: Castro 2
     version: "2.1.2"
   device:
-    type:
+    type: ""
     brand: AP
-    model:
+    model: ""
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Player FM
   os:
     name: Android
     short_name: AND
-    version: 
-    platform:
+    version: ""
+    platform: ""
   client:
     type: mobile app
     name: Player FM
-    version:
+    version: ""
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: okhttp/2.7.5
   os:
     name: Android
     short_name: AND
-    version: 
-    platform:
+    version: ""
+    platform: ""
   client:
     type: library
     name: OkHttp
     version: "2.7.5"
   device:
-    type:
-    brand:
-    model:
+    type: ""
+    brand: ""
+    model: ""
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) News/582.1 Version/2.0
   os:
     name: iOS
     short_name: IOS
     version: "10.0"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Apple News
@@ -419,13 +420,13 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.43 (KHTML, like Gecko) AppleNews/607 Version/2.0
   os:
     name: iOS
     short_name: IOS
     version: "10.0"
-    platform:
+    platform: ""
   client:
     type: mobile app
     name: Apple News
@@ -436,7 +437,7 @@
     model: iPhone
   os_family: iOS
   browser_family: Unknown
--
+- 
   user_agent: YelpWebView/1.5 Android/7.0 YelpApp/9.10.0 (x-screen-scale 1.0;)
   os:
     name: Android

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -468,8 +468,8 @@
     name: Baidu Browser
     short_name: BD
     version: "5.3.4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: M1
@@ -1165,8 +1165,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -1185,8 +1185,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -1205,8 +1205,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -1225,8 +1225,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -1265,8 +1265,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -1285,8 +1285,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -2276,8 +2276,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -2296,8 +2296,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -2356,8 +2356,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -2536,8 +2536,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: SA
@@ -3076,8 +3076,8 @@
     name: MIUI Browser
     short_name: MU
     version: "2.1.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: phablet
     brand: XI

--- a/Tests/fixtures/smartphone-1.yml
+++ b/Tests/fixtures/smartphone-1.yml
@@ -4250,8 +4250,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.2.1184"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: AU
@@ -4864,8 +4864,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.5.1189"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: AU
@@ -5621,8 +5621,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.8.1206"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: B2

--- a/Tests/fixtures/smartphone-10.yml
+++ b/Tests/fixtures/smartphone-10.yml
@@ -2568,8 +2568,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.2.1188"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SO
@@ -6029,8 +6029,8 @@
     name: UC Browser
     short_name: UC
     version: "12.8.5.1121"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: TZ
@@ -6189,8 +6189,8 @@
     name: UC Browser
     short_name: UC
     version: "12.5.0.1109"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: TZ
@@ -6289,8 +6289,8 @@
     name: Puffin
     short_name: PU
     version: "7.5.3.20547"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: TZ
@@ -7883,8 +7883,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: V2

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -2404,8 +2404,8 @@
     name: MIUI Browser
     short_name: MU
     version: "2.1.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: XI
@@ -2424,8 +2424,8 @@
     name: MIUI Browser
     short_name: MU
     version: "2.1.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: XI
@@ -2464,8 +2464,8 @@
     name: MIUI Browser
     short_name: MU
     version: "1.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: XI
@@ -2744,8 +2744,8 @@
     name: MIUI Browser
     short_name: MU
     version: "2.1.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: XI
@@ -2821,8 +2821,8 @@
     name: QQ Browser
     short_name: QQ
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: XI
@@ -5518,8 +5518,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.5.1171"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: ZT
@@ -5586,14 +5586,14 @@
     model: Smart Max 4.0 Plus
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: lephone K7/Dorado WAP-Browser/1.0.0
   os: [ ]
   client:
     type: browser
     name: Dorado
     short_name: DO
-    version: 1.0.0
+    version: "1.0.0"
     engine: ""
     engine_version: ""
   device:
@@ -5602,14 +5602,14 @@
     model: K7
   os_family: Unknown
   browser_family: Nokia Browser
--
+- 
   user_agent: lephone K10/Dorado WAP-Browser/1.0.0
   os: [ ]
   client:
     type: browser
     name: Dorado
     short_name: DO
-    version: 1.0.0
+    version: "1.0.0"
     engine: ""
     engine_version: ""
   device:
@@ -5618,7 +5618,7 @@
     model: K10
   os_family: Unknown
   browser_family: Nokia Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W7 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
@@ -5629,16 +5629,16 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 12.9.9.1155
-    engine: WebKit
-    engine_version: "537.36"
+    version: "12.9.9.1155"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: L7
     model: W7
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-IN; lephone_W9 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.4.9.900
   os:
     name: Android
@@ -5649,16 +5649,16 @@
     type: browser
     name: UC Browser
     short_name: UC
-    version: 12.10.0.1163
-    engine: WebKit
-    engine_version: "537.36"
+    version: "12.10.0.1163"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: L7
     model: W9
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ716 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
@@ -5669,7 +5669,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -5678,7 +5678,7 @@
     model: TZ716
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
@@ -5689,7 +5689,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 70.0.3538.110
+    version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
@@ -5698,7 +5698,7 @@
     model: Enjoy 7
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
@@ -5709,7 +5709,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -5718,7 +5718,7 @@
     model: Enjoy 7
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; BLA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -5729,7 +5729,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -5738,7 +5738,7 @@
     model: Mate 10 Pro
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; CLT-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
@@ -5749,7 +5749,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -5758,7 +5758,7 @@
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; DUK-TL30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -5769,7 +5769,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -5778,7 +5778,7 @@
     model: Honor 8 Pro
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; EML-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -5789,7 +5789,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -5798,7 +5798,7 @@
     model: P20
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; PCT-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
@@ -5809,7 +5809,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.136
+    version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
@@ -5818,7 +5818,7 @@
     model: Honor V20
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
@@ -5829,7 +5829,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -5838,7 +5838,7 @@
     model: Enjoy 9e
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9.0; MRD-TL00 Build/HUAWEIMRD-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
@@ -5849,7 +5849,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 58.0.3029.83
+    version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
@@ -5858,58 +5858,58 @@
     model: Enjoy 9e
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; ru-ru; ATH-UL00) Build/HONORATH-UL00 AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
     short_name: QQ
     version: "6.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
     model: Honor 7i
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; ru-ua; ATH-TL00H) Build/HONORATH-TL00H AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
     short_name: QQ
     version: "6.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
     model: Honor 7i
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ETL-S5042 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.2.1
+    version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 42.0.2311.111
+    version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
@@ -5918,18 +5918,18 @@
     model: ETL-S5042
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ETL-S4521 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 26.0.1410.58
+    version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
@@ -5938,18 +5938,18 @@
     model: ETL-S4521
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ETL-T752G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 67.0.3396.87
+    version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
@@ -5958,38 +5958,38 @@
     model: ETL-T752G
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; ETL-T882G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 12.11.8.1186
-    engine: WebKit
-    engine_version: "537.36"
+    version: "12.11.8.1186"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: 1E
     model: ETL-T882G
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ETL-S6022 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 OPR/36.2.2254.130496
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 36.2.2254.130496
+    version: "36.2.2254.130496"
     engine: Blink
     engine_version: ""
   device:
@@ -5998,12 +5998,12 @@
     model: ETL-S6022
   os_family: Android
   browser_family: Opera
--
-  user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ETL-S3520    Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
+- 
+  user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ETL-S3520    Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
@@ -6018,38 +6018,38 @@
     model: ETL-S3520
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 Linux; Android 4.1.1; ETL-T980 Build/MASTER; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.81 Safari/537.36 Puffin/7.8.1.40497AT
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Puffin
     short_name: PU
-    version: 7.8.1.40497
-    engine: WebKit
-    engine_version: "537.36"
+    version: "7.8.1.40497"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: 1E
     model: ETL-T980
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ETL-S5084) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 73.0.3683.90
+    version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
@@ -6058,27 +6058,27 @@
     model: ETL-S5084
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; en-US; ETL-T970 Build/ETL-T970 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.1.1
+    version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 12.9.9.1155
-    engine: WebKit
-    engine_version: "537.36"
+    version: "12.9.9.1155"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: 1E
     model: ETL-T970
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SYX-T704) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
@@ -6089,7 +6089,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -6098,18 +6098,18 @@
     model: SYX-T704
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SYX-T101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -6118,18 +6118,18 @@
     model: SYX-T101
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SYX-T700) Build/KVT49L AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6138,7 +6138,7 @@
     model: SYX-T700
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SYX-T102) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
@@ -6149,7 +6149,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -6158,7 +6158,7 @@
     model: SYX-T102
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN_N2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
@@ -6169,7 +6169,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 62.0.3202.84
+    version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
@@ -6178,7 +6178,7 @@
     model: N2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN_A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
@@ -6189,7 +6189,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -6198,7 +6198,7 @@
     model: A1
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN N1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
@@ -6209,7 +6209,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 73.0.3683.90
+    version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
@@ -6218,7 +6218,7 @@
     model: N1
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; E1051X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
@@ -6229,7 +6229,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -6238,7 +6238,7 @@
     model: E1051X
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; E1041X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
@@ -6249,7 +6249,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -6258,38 +6258,38 @@
     model: E1041X
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; TZ772 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1196 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
     short_name: UC
-    version: 12.10.0.1196
-    engine: WebKit
-    engine_version: "537.36"
+    version: "12.10.0.1196"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: I6
     model: TZ772
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CHE2-L12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.136
+    version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
@@ -6298,7 +6298,7 @@
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GEM-703L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -6309,7 +6309,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -6318,7 +6318,7 @@
     model: MediaPad X2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GEM-702L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
@@ -6329,7 +6329,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -6338,7 +6338,7 @@
     model: MediaPad X2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
@@ -6349,7 +6349,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.101
+    version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
@@ -6358,18 +6358,18 @@
     model: P8 Lite (2015)
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10D Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 75.0.3770.101
+    version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
@@ -6378,18 +6378,18 @@
     model: TPCY-TXE10D
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -6398,18 +6398,18 @@
     model: TPCY-TXE10DS
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DW Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.121 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 72.0.3626.121
+    version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
@@ -6418,18 +6418,18 @@
     model: TPCY-TXE10DW
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DW232 Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 74.0.3729.136
+    version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
@@ -6438,18 +6438,18 @@
     model: TPCY-TXE10DW232
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE7D Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -6458,18 +6458,18 @@
     model: TPCY-TXE7D
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE7DW) Build/MXC89K; wv AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 6.0.1
+    version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 75.0.3770.101
+    version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
@@ -6478,12 +6478,12 @@
     model: TPCY-TXE7DW
   os_family: Android
   browser_family: Chrome
--
-  user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4503; Android/4.4.2; Release/07.22.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30
+- 
+  user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4503; Android/4.4.2; Release/07.22.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
@@ -6498,12 +6498,12 @@
     model: Dubai
   os_family: Android
   browser_family: Android Browser
--
-  user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4550; Android/4.4.2; Release/12.19.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30
+- 
+  user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4550; Android/4.4.2; Release/12.19.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
@@ -6518,18 +6518,18 @@
     model: Richmond
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-3510 Build/BQS3510-2015.07.03) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6538,18 +6538,18 @@
     model: Aspen Mini
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4001 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6558,18 +6558,18 @@
     model: Oxford
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4004 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 14.5.1847.18432.00
+    version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
@@ -6578,7 +6578,7 @@
     model: Dusseldorf
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4008 Build/MocorDroid) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: MocorDroid
@@ -6589,7 +6589,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6598,18 +6598,18 @@
     model: Shanghai
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4009 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6618,18 +6618,18 @@
     model: Orleans
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4010 Build/BQS4010-2015.07.10-HSS0721P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6638,18 +6638,18 @@
     model: Aspen
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4502 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6658,18 +6658,18 @@
     model: Kingston
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4516 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6678,18 +6678,18 @@
     model: Singapore
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-5501 Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.0.0
+    version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6698,18 +6698,18 @@
     model: Kawasaki
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-5002 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6718,18 +6718,18 @@
     model: Colombo
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BQS-4800 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 5.0.2
+    version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.2171.93
+    version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
@@ -6738,7 +6738,7 @@
     model: Blade
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4555 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
@@ -6749,7 +6749,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 55.0.2883.91
+    version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
@@ -6758,7 +6758,7 @@
     model: Turbo
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4525 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
@@ -6769,7 +6769,7 @@
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 14.5.1847.18432.00
+    version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
@@ -6778,7 +6778,7 @@
     model: Vienna
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4560 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 YaBrowser/15.10.2454.3908.00 Mobile Safari/537.36
   os:
     name: Android
@@ -6789,7 +6789,7 @@
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 15.10.2454.3908.00
+    version: "15.10.2454.3908.00"
     engine: Blink
     engine_version: ""
   device:
@@ -6798,7 +6798,7 @@
     model: Golf
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4570 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.2.2517.139816
   os:
     name: Android
@@ -6809,7 +6809,7 @@
     type: browser
     name: Opera Mobile
     short_name: OM
-    version: 52.2.2517.139816
+    version: "52.2.2517.139816"
     engine: Blink
     engine_version: ""
   device:
@@ -6818,7 +6818,7 @@
     model: Drive
   os_family: Android
   browser_family: Opera
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4707 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
@@ -6829,7 +6829,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.0.0
+    version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -6838,7 +6838,7 @@
     model: Montreal
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5006 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
@@ -6849,7 +6849,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 63.0.3239.111
+    version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
@@ -6858,7 +6858,7 @@
     model: Los Angeles
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5009 Build/BQS5009-2015.12.11-HSS0721T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
@@ -6869,7 +6869,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.89
+    version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
@@ -6878,7 +6878,7 @@
     model: Sydney
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
@@ -6889,7 +6889,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.89
+    version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
@@ -6898,7 +6898,7 @@
     model: Prague
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5011 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
@@ -6909,7 +6909,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 50.0.2661.89
+    version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
@@ -6918,7 +6918,7 @@
     model: Monte Carlo
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm; Android 7.0; BQru-1057L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 YaBrowser/19.7.0.117.00 Mobile Safari/537.36
   os:
     name: Android
@@ -6929,7 +6929,7 @@
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 19.7.0.117.00
+    version: "19.7.0.117.00"
     engine: Blink
     engine_version: ""
   device:
@@ -6938,12 +6938,12 @@
     model: Passion
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; BQS-3503 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
     platform: ""
   client:
     type: browser
@@ -6958,12 +6958,12 @@
     model: Bombay
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; ru-ru; BQS-4505 Build/MocorDroid2.3.5_Trout) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
     short_name: MCD
-    version: 2.3.5
+    version: "2.3.5"
     platform: ""
   client:
     type: browser
@@ -6978,12 +6978,12 @@
     model: Santiago
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4005 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
@@ -6998,12 +6998,12 @@
     model: Seoul
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4501 Bristol Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
@@ -7018,12 +7018,12 @@
     model: Bristol
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4510 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
@@ -7038,12 +7038,12 @@
     model: Florence
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-5000 Tokyo Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
     short_name: AND
-    version: 4.2.2
+    version: "4.2.2"
     platform: ""
   client:
     type: browser
@@ -7058,12 +7058,12 @@
     model: Tokyo
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.3; ru-ru; BQS-5001 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
     short_name: AND
-    version: 4.2.3
+    version: "4.2.3"
     platform: ""
   client:
     type: browser
@@ -7078,18 +7078,18 @@
     model: Milan
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4702 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7098,7 +7098,7 @@
     model: Оsaka
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4; BQS-4515 Build/Android) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
@@ -7109,7 +7109,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 30.0.0.0
+    version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7118,7 +7118,7 @@
     model: Moscow
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4; BQS-5005 Build/BQS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
@@ -7129,7 +7129,7 @@
     type: browser
     name: Yandex Browser
     short_name: YA
-    version: 14.5.1847.18432.00
+    version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
@@ -7138,7 +7138,7 @@
     model: Sydney
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5030 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
@@ -7149,7 +7149,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 68.0.3440.91
+    version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
@@ -7158,7 +7158,7 @@
     model: Fresh
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5502 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
@@ -7169,7 +7169,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 43.0.2357.121
+    version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
@@ -7178,7 +7178,7 @@
     model: Hammer
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Dalvik/v3.3.127 Compatible (TVM xx; YunOS 3.0; Linux; U; Android 4.4.4 Compatible; lephone T2 Build/KTU84P)
   os:
     name: YunOs
@@ -7198,7 +7198,7 @@
     model: T2
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TPCY-TXTE10D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
@@ -7209,7 +7209,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 74.0.3729.112
+    version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
@@ -7218,7 +7218,7 @@
     model: TPCY-TXTE10D
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TPCY-TXTE7D) Build/MRA58K AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
@@ -7229,7 +7229,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 68.0.3440.91
+    version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
@@ -7238,7 +7238,7 @@
     model: TPCY-TXTE7D
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NCE-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -7249,7 +7249,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -7258,7 +7258,7 @@
     model: Enjoy 6
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NCE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
@@ -7269,7 +7269,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -7278,7 +7278,7 @@
     model: Enjoy 6
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; JDN2-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
@@ -7289,7 +7289,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.67
+    version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
@@ -7298,18 +7298,18 @@
     model: MediaPad M5 lite
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BAC-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.0.0
+    version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.89
+    version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
@@ -7318,18 +7318,18 @@
     model: Nova 2 Plus
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AGS2-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.0.0
+    version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
     short_name: CH
-    version: 76.0.3809.111
+    version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
@@ -7338,7 +7338,7 @@
     model: MediaPad T5 10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; EVR-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
@@ -7349,7 +7349,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -7358,18 +7358,18 @@
     model: Mate 20 X
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; JKM-TL00 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -7378,18 +7378,18 @@
     model: Y9 (2019)
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.136
+    version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
@@ -7398,18 +7398,18 @@
     model: Y7 Pro (2019)
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -7418,18 +7418,18 @@
     model: Y7 (2019)
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUA-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -7438,7 +7438,7 @@
     model: Honor 7S
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; J8170) AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
@@ -7449,7 +7449,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.136
+    version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
@@ -7458,7 +7458,7 @@
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; I4213) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
@@ -7469,7 +7469,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.89
+    version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
@@ -7478,7 +7478,7 @@
     model: Xperia 10 Plus
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; I4113 Build/53.0.A.6.92; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
@@ -7489,7 +7489,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.101
+    version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
@@ -7498,7 +7498,7 @@
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; I3223) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
@@ -7509,7 +7509,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.89
+    version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
@@ -7518,7 +7518,7 @@
     model: Xperia 10 Plus
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; I3123) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
@@ -7529,7 +7529,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -7538,7 +7538,7 @@
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; I3113) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
@@ -7549,7 +7549,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.143
+    version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
@@ -7558,18 +7558,18 @@
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 2PZC5 Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.0.0
+    version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 39.0.0.0
+    version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7578,7 +7578,7 @@
     model: U11
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; POCO F1 Build/PKQ1.180729.001; wv) AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
@@ -7589,7 +7589,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 73.0.3683.90
+    version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
@@ -7598,18 +7598,18 @@
     model: Pocophone F1
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; LA2-SN Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.0.0
+    version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7618,18 +7618,18 @@
     model: LA2-SN
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; LA2-S Build/KTU84P AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.0.0
+    version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7638,18 +7638,18 @@
     model: LA2-S
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; LA2-L Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.4
+    version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 33.0.0.0
+    version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
@@ -7658,12 +7658,12 @@
     model: LA2-L
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; iLA_Silk Build/iLA_Silk)
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
@@ -7678,7 +7678,7 @@
     model: Silk
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iLA-X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
@@ -7689,7 +7689,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 75.0.3770.101
+    version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
@@ -7698,7 +7698,7 @@
     model: X
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KODAK Tablet 7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
@@ -7709,7 +7709,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 69.0.3497.100
+    version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
@@ -7718,7 +7718,7 @@
     model: Tablet 7
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KODAK Tablet 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
@@ -7729,7 +7729,7 @@
     type: browser
     name: Chrome
     short_name: CH
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -7738,18 +7738,18 @@
     model: Tablet 10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; IM5 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 4.4.2
+    version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 73.0.3683.90
+    version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
@@ -7758,18 +7758,18 @@
     model: IM5
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X210K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 7.1.2
+    version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 74.0.3729.157
+    version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
@@ -7778,18 +7778,18 @@
     model: X2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X212(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.111
+    version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
@@ -7798,7 +7798,7 @@
     model: K8 (2018)
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-V350N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
@@ -7809,7 +7809,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 71.0.3578.99
+    version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
@@ -7818,18 +7818,18 @@
     model: V35
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X410S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.1.0
+    version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.111
+    version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
@@ -7838,7 +7838,7 @@
     model: X4
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-Q910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
@@ -7849,7 +7849,7 @@
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.111
+    version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
@@ -7858,18 +7858,18 @@
     model: G7 One
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LM-G710VM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
     short_name: AND
-    version: 8.0.0
+    version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
     short_name: CM
-    version: 76.0.3809.111
+    version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
@@ -7878,4 +7878,3 @@
     model: G7 ThinQ
   os_family: Android
   browser_family: Chrome
-

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -531,8 +531,8 @@
     name: UC Browser
     short_name: UC
     version: "12.9.5.1146"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BV
@@ -1608,8 +1608,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.6.1200"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -1788,8 +1788,8 @@
     name: Puffin
     short_name: PU
     version: "7.8.1.40497"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -1828,8 +1828,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.6.1200"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -2008,8 +2008,8 @@
     name: UC Browser
     short_name: UC
     version: "11.5.0.1015"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -2245,8 +2245,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.8.1186"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -2265,8 +2265,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.3.1202"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -2285,8 +2285,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.5.1185"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -2445,8 +2445,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.2.1164"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -3085,8 +3085,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.3.1204"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX
@@ -3105,8 +3105,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.6.1200"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: BX

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -471,8 +471,8 @@
     name: Aloha Browser
     short_name: AL
     version: "1.3.3.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: FL
@@ -571,8 +571,8 @@
     name: Puffin
     short_name: PU
     version: "6.1.0.15920"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: FL
@@ -7417,8 +7417,8 @@
     name: Puffin
     short_name: PU
     version: "7.0.6.18027"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HT

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -3388,8 +3388,8 @@
     name: UC Browser
     short_name: UC
     version: "11.7.0.953"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -3408,8 +3408,8 @@
     name: Baidu Browser
     short_name: BD
     version: "5.3.4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -3805,8 +3805,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -4022,8 +4022,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -4102,8 +4102,8 @@
     name: QQ Browser
     short_name: QQ
     version: "7.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -4402,8 +4402,8 @@
     name: QQ Browser
     short_name: QQ
     version: "7.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -5550,8 +5550,8 @@
     name: QQ Browser
     short_name: QQ
     version: "9.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -6774,8 +6774,8 @@
     name: QQ Browser
     short_name: QQ
     version: "9.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -6894,8 +6894,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -6994,8 +6994,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -7454,8 +7454,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -311,8 +311,8 @@
     name: UC Browser
     short_name: UC
     version: "12.1.3.993"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: HU
@@ -3228,8 +3228,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.0.1183"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: J5
@@ -3648,8 +3648,8 @@
     name: Puffin
     short_name: PU
     version: "7.8.2.40664"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: K3
@@ -3848,8 +3848,8 @@
     name: Puffin
     short_name: PU
     version: "7.8.0.40457"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: K3
@@ -9916,8 +9916,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.8.1186"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: LG

--- a/Tests/fixtures/smartphone-6.yml
+++ b/Tests/fixtures/smartphone-6.yml
@@ -4326,8 +4326,8 @@
     name: QQ Browser
     short_name: QQ
     version: "7.6"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: M1
@@ -5679,8 +5679,8 @@
     name: UC Browser
     short_name: UC
     version: "12.10.9.1193"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: M9

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -4279,8 +4279,8 @@
     name: UC Browser
     short_name: UC
     version: "3.4.3.532"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OB
@@ -5590,8 +5590,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.5.1189"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -5670,8 +5670,8 @@
     name: Oppo Browser
     short_name: PP
     version: "1.0.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -5710,8 +5710,8 @@
     name: Oppo Browser
     short_name: PP
     version: "1.0.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -6010,8 +6010,8 @@
     name: Oppo Browser
     short_name: PP
     version: "1.0.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -6818,8 +6818,8 @@
     name: UC Browser
     short_name: UC
     version: "12.1.4.994"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -6838,8 +6838,8 @@
     name: UC Browser
     short_name: UC
     version: "12.1.4.994"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -7083,8 +7083,8 @@
     name: Baidu Browser
     short_name: BD
     version: "5.3.4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP
@@ -7519,8 +7519,8 @@
     name: UC Browser
     short_name: UC
     version: "12.5.5.1111"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: OP

--- a/Tests/fixtures/smartphone-8.yml
+++ b/Tests/fixtures/smartphone-8.yml
@@ -3371,8 +3371,8 @@
     name: QQ Browser
     short_name: QQ
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: S7
@@ -3545,8 +3545,8 @@
     name: Samsung Browser
     short_name: SB
     version: "9.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3605,8 +3605,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3625,8 +3625,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3645,8 +3645,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.5"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3665,8 +3665,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3685,8 +3685,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3705,8 +3705,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3865,8 +3865,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.5"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3885,8 +3885,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3925,8 +3925,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -3985,8 +3985,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4005,8 +4005,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4025,8 +4025,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4245,8 +4245,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4265,8 +4265,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4285,8 +4285,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4305,8 +4305,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4325,8 +4325,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4345,8 +4345,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4385,8 +4385,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4405,8 +4405,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4445,8 +4445,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4485,8 +4485,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4505,8 +4505,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4525,8 +4525,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4585,8 +4585,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4605,8 +4605,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4705,8 +4705,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4802,8 +4802,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4822,8 +4822,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4842,8 +4842,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4882,8 +4882,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4902,8 +4902,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4942,8 +4942,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -4962,8 +4962,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5002,8 +5002,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5622,8 +5622,8 @@
     name: Samsung Browser
     short_name: SB
     version: "2.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5702,8 +5702,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5722,8 +5722,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5742,8 +5742,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5762,8 +5762,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5802,8 +5802,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5822,8 +5822,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5842,8 +5842,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5862,8 +5862,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -5902,8 +5902,8 @@
     name: UC Browser
     short_name: UC
     version: "12.0.0.1088"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6322,8 +6322,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.8"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6382,8 +6382,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6442,8 +6442,8 @@
     name: Samsung Browser
     short_name: SB
     version: "2.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6622,8 +6622,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6682,8 +6682,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6782,8 +6782,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -6842,8 +6842,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7022,8 +7022,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7102,8 +7102,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7162,8 +7162,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7182,8 +7182,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7222,8 +7222,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7242,8 +7242,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7342,8 +7342,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7382,8 +7382,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7402,8 +7402,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7422,8 +7422,8 @@
     name: UC Browser
     short_name: UC
     version: "12.5.0.1109"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7522,8 +7522,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7722,8 +7722,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.5"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7782,8 +7782,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7842,8 +7842,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -7882,8 +7882,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -8922,8 +8922,8 @@
     name: Samsung Browser
     short_name: SB
     version: "9.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9302,8 +9302,8 @@
     name: Samsung Browser
     short_name: SB
     version: "2.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9622,8 +9622,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9642,8 +9642,8 @@
     name: Samsung Browser
     short_name: SB
     version: "2.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9662,8 +9662,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9702,8 +9702,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9802,8 +9802,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9882,8 +9882,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -9962,8 +9962,8 @@
     name: QQ Browser
     short_name: QQ
     version: "8.9"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA

--- a/Tests/fixtures/smartphone-9.yml
+++ b/Tests/fixtures/smartphone-9.yml
@@ -11,8 +11,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -191,8 +191,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -211,8 +211,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -271,8 +271,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -391,8 +391,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -411,8 +411,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -451,8 +451,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -511,8 +511,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -531,8 +531,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -551,8 +551,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -571,8 +571,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -691,8 +691,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -791,8 +791,8 @@
     name: Samsung Browser
     short_name: SB
     version: "4.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -811,8 +811,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -911,8 +911,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -931,8 +931,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -951,8 +951,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -971,8 +971,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1091,8 +1091,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1111,8 +1111,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1131,8 +1131,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1171,8 +1171,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1191,8 +1191,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1251,8 +1251,8 @@
     name: Samsung Browser
     short_name: SB
     version: "5.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1371,8 +1371,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1411,8 +1411,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1431,8 +1431,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1451,8 +1451,8 @@
     name: Samsung Browser
     short_name: SB
     version: "7.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1751,8 +1751,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -1871,8 +1871,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -2331,8 +2331,8 @@
     name: Samsung Browser
     short_name: SB
     version: "2.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SA
@@ -8093,8 +8093,8 @@
     name: UC Browser
     short_name: UC
     version: "3.4.1.483"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: SO

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -371,8 +371,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.0.1187"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: 1S
@@ -3831,8 +3831,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.6.1205"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: A8
@@ -4428,8 +4428,8 @@
     name: UC Browser
     short_name: UC
     version: "11.5.0.1015"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: AA
@@ -6965,8 +6965,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.0.1187"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: AL

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -631,8 +631,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.2.1188"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: D2
@@ -5131,8 +5131,8 @@
     name: UC Browser
     short_name: UC
     version: "12.8.8.1140"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: I2
@@ -7205,8 +7205,8 @@
     name: UC Browser
     short_name: UC
     version: "12.11.3.1204"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: KN

--- a/Tests/fixtures/tablet-2.yml
+++ b/Tests/fixtures/tablet-2.yml
@@ -6648,8 +6648,8 @@
     name: UC Browser
     short_name: UC
     version: "12.12.0.1187"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: PR
@@ -7705,8 +7705,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9342,8 +9342,8 @@
     name: Samsung Browser
     short_name: SB
     version: "3.5"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9422,8 +9422,8 @@
     name: Samsung Browser
     short_name: SB
     version: "9.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9462,8 +9462,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9562,8 +9562,8 @@
     name: Samsung Browser
     short_name: SB
     version: "9.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9622,8 +9622,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9802,8 +9802,8 @@
     name: Samsung Browser
     short_name: SB
     version: "6.4"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA
@@ -9822,8 +9822,8 @@
     name: Samsung Browser
     short_name: SB
     version: "8.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: SA

--- a/Tests/fixtures/tablet-3.yml
+++ b/Tests/fixtures/tablet-3.yml
@@ -3004,8 +3004,8 @@
     name: Puffin
     short_name: PU
     version: "7.1.2.18064"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: TZ

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -1836,7 +1836,7 @@
   device:
     type: tablet
     brand: AB
-    model: 100
+    model: "100"
   os_family: Android
   browser_family: Chrome
 - 
@@ -7733,8 +7733,8 @@
     name: Puffin
     short_name: PU
     version: "7.7.5.30963"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: tablet
     brand: BX

--- a/regexes/client/browser_engine.yml
+++ b/regexes/client/browser_engine.yml
@@ -14,7 +14,7 @@
 - regex: 'Trident'
   name: 'Trident'
 
-- regex: 'Blink'
+- regex: 'Chrome/(?:1[89]|[2-9][0-9]|[1-9][0-9]{2,})'
   name: 'Blink'
 
 - regex: '(?:Apple)?WebKit'


### PR DESCRIPTION
This PR changes the auto-detection for the Blink engine, as it does not use a `Blink` token. 
The test fixtures were rewriten using the script from PR #6017.