### PR TITLE
Fix Kazehakase browser detection

### DIFF
--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -9906,4 +9906,4 @@
     brand: 
     model: 
   os_family: Unix
-  browser_family: Firefox
+  browser_family: Unknown

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -9897,7 +9897,7 @@
   client:
     type: browser
     name: Kazehakase
-    short_name: KA
+    short_name: KZ
     version: "0.5.4"
     engine: Gecko
     engine_version: ""

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -9887,3 +9887,23 @@
     model: Q1010i
   os_family: Android
   browser_family: Chrome
+- 
+  user_agent: Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.8.1.18) Gecko/20081206 Firefox/2.0.0.18 Kazehakase/0.5.4
+  os:
+    name: FreeBSD
+    short_name: BSD
+    version: ""
+    platform: "x86"
+  client:
+    type: browser
+    name: Kazehakase
+    short_name: KA
+    version: "0.5.4"
+    engine: Gecko
+    engine_version: ""
+  device:
+    type: desktop
+    brand: 
+    model: 
+  os_family: Unix
+  browser_family: Firefox

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -5,6 +5,13 @@
 # @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
 ###############
 
+#Kazehakase
+- regex: 'Kazehakase(?:/(\d+[\.\d]+))?'
+  name: 'Kazehakase'
+  version: '$1'
+  engine:
+    default: '' # multi engine
+
 # COS Browser (https://sj.qq.com/myapp/detail.htm?apkName=com.qcloud.cos.client)
 - regex: 'COSBrowser(?:/(\d+[\.\d]+))?'
   name: 'COS Browser'
@@ -1205,13 +1212,6 @@
   version: '$1'
   engine:
     default: 'Trident'
-
-#Kazehakase
-- regex: 'Kazehakase(?:/(\d+[\.\d]+))?'
-  name: 'Kazehakase'
-  version: '$1'
-  engine:
-    default: '' # multi engine
 
 #Kindle Browser
 - regex: 'Kindle/(\d+[\.\d]+)'


### PR DESCRIPTION
Its regex has to be placed before generic Chrome regex, or Chrome regex will match first and the browser is mistaken as "Chrome".