### PR TITLE
Adds detection for Procast and alternative user agent of Podcat

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Audacious, Banshee, Boxee, Clementine, Deezer, FlyCast, Foobar2000, Google Podca
 
 ### List of detected mobile apps:
 
-AndroidDownloadManager, AntennaPod, Apple News, Baidu Box App, BeyondPod, BingWebApp, bPod, Castro, Castro 2, CrosswalkApp, DoggCatcher, douban App, Facebook, Facebook Messenger, FeedR, Flipboard App, Google Play Newsstand, Google Plus, Google Search App, iCatcher, Instacast, Instagram App, Line, NewsArticle App, Overcast, Pinterest, Player FM, Pocket Casts, Podcast & Radio Addict, Podcast Republic, Podcasts, Podcat, Podcatcher Deluxe, Podkicker, RSSRadio, Sina Weibo, SogouSearch App, tieba, WeChat, WhatsApp, Yahoo! Japan, Yelp Mobile, YouTube  and *mobile apps using [AFNetworking](https://github.com/AFNetworking/AFNetworking)*
+AndroidDownloadManager, AntennaPod, Apple News, Baidu Box App, BeyondPod, BingWebApp, bPod, Castro, Castro 2, CrosswalkApp, DoggCatcher, douban App, Facebook, Facebook Messenger, FeedR, Flipboard App, Google Play Newsstand, Google Plus, Google Search App, iCatcher, Instacast, Instagram App, Line, NewsArticle App, Overcast, Pinterest, Player FM, Pocket Casts, Podcast & Radio Addict, Podcast Republic, Podcasts, Podcat, Podcatcher Deluxe, Podkicker, Procast, RSSRadio, Sina Weibo, SogouSearch App, tieba, WeChat, WhatsApp, Yahoo! Japan, Yelp Mobile, YouTube  and *mobile apps using [AFNetworking](https://github.com/AFNetworking/AFNetworking)*
 
 ### List of detected PIMs (personal information manager):
 

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -238,6 +238,7 @@
   os:
     name: iOS
     short_name: IOS
+    version: ""
     platform: ""
   client:
     type: mobile app
@@ -475,7 +476,7 @@
   os:
     name: iOS
     short_name: IOS
-    version: "7.1"
+    version: ""
     platform: ""
   client:
     type: mobile app

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -233,7 +233,23 @@
     model: ""
   os_family: iOS
   browser_family: Unknown
-- 
+-
+  user_agent: Podcat%202/22296 CFNetwork/1121.2.2 Darwin/19.2.0
+  os:
+    name: iOS
+    short_name: IOS
+    platform: ""
+  client:
+    type: mobile app
+    name: Podcat
+    version: "22296"
+  device:
+    type: ""
+    brand: AP
+    model: ""
+  os_family: iOS
+  browser_family: Unknown
+-
   user_agent: Podcat/1.1.4.14639 (iPhone; de-DE; iPhone OS 9.2.1)
   os:
     name: iOS
@@ -453,4 +469,38 @@
     brand: ""
     model: ""
   os_family: Android
+  browser_family: Unknown
+-
+  user_agent: ProCast/2 CFNetwork/978.0.7 Darwin/18.7.0
+  os:
+    name: iOS
+    short_name: IOS
+    version: "7.1"
+    platform: ""
+  client:
+    type: mobile app
+    name: Procast
+    version: "2"
+  device:
+    type: ""
+    brand: AP
+    model: ""
+  os_family: iOS
+  browser_family: Unknown
+-
+  user_agent: Procast (iOS)
+  os:
+    name: iOS
+    short_name: IOS
+    version: ""
+    platform: ""
+  client:
+    type: mobile app
+    name: Procast
+    version: ""
+  device:
+    type: ""
+    brand: AP
+    model: ""
+  os_family: iOS
   browser_family: Unknown

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -146,7 +146,7 @@
   name: 'Podcast & Radio Addict'
   version: '$1'
 -
-  regex: 'Podcat/([\d]+) CFNetwork/([\d\.]+) Darwin/([\d\.]+)'
+  regex: 'Podcat(?:%202)?/([\d]+) CFNetwork/([\d\.]+) Darwin/([\d\.]+)'
   name: 'Podcat'
   version: '$1'
 -
@@ -204,4 +204,8 @@
 -
   regex: 'Crosswalk(?!.*Streamy)/([\d\.]+)?'
   name: 'CrosswalkApp'
+  version: '$1'
+
+  regex: 'Pro[cC]ast/?([\d\.]+)?'
+  name: 'Procast'
   version: '$1'

--- a/regexes/client/mobile_apps.yml
+++ b/regexes/client/mobile_apps.yml
@@ -206,6 +206,6 @@
   name: 'CrosswalkApp'
   version: '$1'
 
-  regex: 'Pro[cC]ast/?([\d\.]+)?'
+  regex: 'Procast/?([\d\.]+)?'
   name: 'Procast'
   version: '$1'

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -421,7 +421,7 @@
   name: 'iOS'
   version: '$1'
 
-- regex: 'Podcasts/(?:[\d\.]+)|Instacast(?:HD)?/(?:\d\.[\d\.abc]+)|Pocket Casts, iOS|Overcast|Castro|Podcat|Procast|i[cC]atcher|RSSRadio/'
+- regex: 'Podcasts/(?:[\d\.]+)|Instacast(?:HD)?/(?:\d\.[\d\.abc]+)|Pocket Casts, iOS|Overcast|Castro|Podcat|i[cC]atcher|RSSRadio/'
   name: 'iOS'
   version: ''
 

--- a/regexes/oss.yml
+++ b/regexes/oss.yml
@@ -421,7 +421,7 @@
   name: 'iOS'
   version: '$1'
 
-- regex: 'Podcasts/(?:[\d\.]+)|Instacast(?:HD)?/(?:\d\.[\d\.abc]+)|Pocket Casts, iOS|Overcast|Castro|Podcat|i[cC]atcher|RSSRadio/'
+- regex: 'Podcasts/(?:[\d\.]+)|Instacast(?:HD)?/(?:\d\.[\d\.abc]+)|Pocket Casts, iOS|Overcast|Castro|Podcat|Procast|i[cC]atcher|RSSRadio/'
   name: 'iOS'
   version: ''
 


### PR DESCRIPTION
Found them in my podcast statistics. But I had problems with the iOS-Versions. I'm not sure how to determine the correct iOS-Version out of this:

```
ProCast/1 CFNetwork/978.0.7 Darwin/18.7.0
ProCast/2 CFNetwork/978.0.7 Darwin/18.7.0
Podcat%202/22296 CFNetwork/978.0.7 Darwin/18.7.0
Podcat%202/22296 CFNetwork/1121.2.2 Darwin/19.2.0
```

The highest value I found was CFNetwork/889 for iOS 11.1