### PR TITLE
Add surf browser

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -232,6 +232,7 @@ class Browser extends ClientParserAbstract
         'SR' => 'Sunrise',
         'SP' => 'SuperBird',
         'SU' => 'Super Fast Browser',
+        'S3' => 'surf',
         'S0' => 'START Internet Browser',
         'ST' => 'Streamy',
         'SX' => 'Swiftfox',

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -2537,3 +2537,12 @@
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
+-
+  user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Safari/605.1.15 Surf/2.0
+  client:
+    type: browser
+    name: surf
+    short_name: S3
+    version: "2.0"
+    engine: WebKit
+    engine_version: 605.1.15

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -1544,6 +1544,13 @@
   name: 'Qutebrowser'
   version: '$1'
 
+# surf (https://surf.suckless.org/)
+- regex: 'Surf(?:/(\d+[\.\d]+))?'
+  name: 'surf'
+  version: '$1'
+  engine:
+    default: 'WebKit'
+
 #Safari
 - regex: '(?:(?:iPod|iPad|iPhone).+Version|MobileSafari)/(\d+[\.\d]+)'
   name: 'Mobile Safari'


### PR DESCRIPTION
[surf](https://surf.suckless.org/) is a minimalist browser based on WebKitGTK. On my system, it is currently misdetected as Safari 13.0 on Linux.