### PR TITLE
Excluded tests from autoload and fixed a few test namespaces

### DIFF
--- a/Tests/Cache/StaticCacheTest.php
+++ b/Tests/Cache/StaticCacheTest.php
@@ -10,7 +10,7 @@ namespace DeviceDetector\Tests\Cache;
 use DeviceDetector\Cache\StaticCache;
 use PHPUnit\Framework\TestCase;
 
-class StaticCacheTests extends TestCase
+class StaticCacheTest extends TestCase
 {
     protected function setUp()
     {

--- a/Tests/Parser/Client/LibraryTest.php
+++ b/Tests/Parser/Client/LibraryTest.php
@@ -11,7 +11,7 @@ use DeviceDetector\Parser\Client\Library;
 use \Spyc;
 use PHPUnit\Framework\TestCase;
 
-class ToolTest extends TestCase
+class LibraryTest extends TestCase
 {
     /**
      * @dataProvider getFixtures

--- a/Tests/Parser/Devices/CameraTest.php
+++ b/Tests/Parser/Devices/CameraTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\Camera;
 use \Spyc;

--- a/Tests/Parser/Devices/CarBrowserTest.php
+++ b/Tests/Parser/Devices/CarBrowserTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\CarBrowser;
 use \Spyc;

--- a/Tests/Parser/Devices/ConsoleTest.php
+++ b/Tests/Parser/Devices/ConsoleTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\Console;
 use \Spyc;

--- a/Tests/Parser/Devices/DeviceParserAbstractTest.php
+++ b/Tests/Parser/Devices/DeviceParserAbstractTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\DeviceParserAbstract;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Parser/Devices/HbbTvTest.php
+++ b/Tests/Parser/Devices/HbbTvTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\HbbTv;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Parser/Devices/NotebookTest.php
+++ b/Tests/Parser/Devices/NotebookTest.php
@@ -5,7 +5,7 @@
  * @link https://matomo.org
  * @license http://www.gnu.org/licenses/lgpl.html LGPL v3 or later
  */
-namespace DeviceDetector\Tests\Parser\Device;
+namespace DeviceDetector\Tests\Parser\Devices;
 
 use DeviceDetector\Parser\Device\Notebook;
 use \Spyc;

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "source": "https://github.com/matomo-org/piwik"
     },
     "autoload": {
-        "psr-4": { "DeviceDetector\\": "" }
+        "psr-4": { "DeviceDetector\\": "" },
+        "exclude-from-classmap": ["Tests/"]
     },
     "require": {
         "php": ">=5.5",


### PR DESCRIPTION
 I excluded the tests in the composer.json as it is not necessary to autoload them to run successfully.
Composer displays deprecation messages when building an optimized autoload file in a project this package is used.

It prevents updating to the soon coming version 2 of composer.

Excluding the test from autoloading solves the problem, but I also fixed the wrong namespaces and classnames.

This was the list of deprecation messages

```
Deprecation Notice: Class DeviceDetector\Tests\Cache\StaticCacheTests located in ./Tests/Cache/StaticCacheTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Client\ToolTest located in ./Tests/Parser/Client/LibraryTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\CameraTest located in ./Tests/Parser/Devices/CameraTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\CarBrowserTest located in ./Tests/Parser/Devices/CarBrowserTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\ConsoleTest located in ./Tests/Parser/Devices/ConsoleTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\DeviceParserAbstractTest located in ./Tests/Parser/Devices/DeviceParserAbstractTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\HbbTvTest located in ./Tests/Parser/Devices/HbbTvTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class DeviceDetector\Tests\Parser\Device\NotebookTest located in ./Tests/Parser/Devices/NotebookTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in /usr/share/php/Composer/Autoload/ClassMapGenerator.php:201

```