### PR TITLE
use memcached in tests instead of memcache

### DIFF
--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -10,6 +10,7 @@
 
 namespace DeviceDetector\Tests;
 
+use DeviceDetector\Cache\DoctrineBridge;
 use DeviceDetector\DeviceDetector;
 use DeviceDetector\Parser\AbstractParser;
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
@@ -113,14 +114,15 @@ class DeviceDetectorTest extends TestCase
 
     public function testCacheSetAndGet(): void
     {
-        if (!\extension_loaded('memcache') || !\class_exists('\Doctrine\Common\Cache\MemcacheCache')) {
-            $this->markTestSkipped('memcache not enabled');
+        if (!\extension_loaded('memcached') || !\class_exists('\Doctrine\Common\Cache\MemcachedCache')) {
+            $this->markTestSkipped('memcached not enabled');
         }
 
-        $dd             = new DeviceDetector();
-        $memcacheServer = new \Memcache();
-        $memcacheServer->connect('localhost', 11211);
-        $dd->setCache(new DoctrineBridge(new \Doctrine\Common\Cache\MemcacheCache($memcacheServer)));
+        $dd = new DeviceDetector();
+        $memcached = new \Memcached();
+        $doctrineCache = new \Doctrine\Common\Cache\MemcachedCache();
+        $doctrineCache->setMemcached($memcached);
+        $dd->setCache(new DoctrineBridge($doctrineCache));
         $this->assertInstanceOf(DoctrineBridge::class, $dd->getCache());
     }
 

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -118,8 +118,8 @@ class DeviceDetectorTest extends TestCase
             $this->markTestSkipped('memcached not enabled');
         }
 
-        $dd = new DeviceDetector();
-        $memcached = new \Memcached();
+        $dd            = new DeviceDetector();
+        $memcached     = new \Memcached();
         $doctrineCache = new \Doctrine\Common\Cache\MemcachedCache();
         $doctrineCache->setMemcached($memcached);
         $dd->setCache(new DoctrineBridge($doctrineCache));


### PR DESCRIPTION
when looking through #6396 I noticed that the tests use \Doctrine\Common\Cache\MemcacheCache which is deprecated (and it seems like the whole memcache php module isn't really maintained).

So I replaced the test with one using the memcached module that I guess most people use nowadays.

(The PR goes against 4.x-dev)