### PR TITLE
Deprecate usage of short names

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -612,13 +612,19 @@ class DeviceDetector
         $osFamily      = OperatingSystem::getOsFamily($deviceDetector->getOsAttribute('short_name'));
         $browserFamily = Browser::getBrowserFamily($deviceDetector->getClientAttribute('short_name'));
 
+        $os = $deviceDetector->getOs();
+        unset($os['short_name']);
+
+        $client = $deviceDetector->getClient();
+        unset($client['short_name']);
+
         $processed = [
             'user_agent'     => $deviceDetector->getUserAgent(),
-            'os'             => $deviceDetector->getOs(),
-            'client'         => $deviceDetector->getClient(),
+            'os'             => $os,
+            'client'         => $client,
             'device'         => [
                 'type'  => $deviceDetector->getDeviceName(),
-                'brand' => $deviceDetector->getBrand(),
+                'brand' => $deviceDetector->getBrandName(),
                 'model' => $deviceDetector->getModel(),
             ],
             'os_family'      => $osFamily ?? 'Unknown',

--- a/Tests/Parser/Client/BrowserTest.php
+++ b/Tests/Parser/Client/BrowserTest.php
@@ -26,8 +26,10 @@ class BrowserTest extends TestCase
         $browserParser = new Browser();
         $browserParser->setVersionTruncation(Browser::VERSION_TRUNCATION_NONE);
         $browserParser->setUserAgent($useragent);
-        $this->assertEquals($client, $browserParser->parse(), "UserAgent: {$useragent}");
-        self::$browsersTested[] = $client['short_name'];
+        $browser = $browserParser->parse();
+        unset($browser['short_name']);
+        $this->assertEquals($client, $browser, "UserAgent: {$useragent}");
+        self::$browsersTested[] = $client['name'];
     }
 
     public function getFixtures(): array
@@ -44,7 +46,7 @@ class BrowserTest extends TestCase
 
     public function testAllBrowsersTested(): void
     {
-        $allBrowsers       = \array_keys(Browser::getAvailableBrowsers());
+        $allBrowsers       = \array_values(Browser::getAvailableBrowsers());
         $browsersNotTested = \array_diff($allBrowsers, self::$browsersTested);
         $this->assertEmpty($browsersNotTested, 'This browsers are not tested: ' . \implode(', ', $browsersNotTested));
     }

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -4,7 +4,6 @@
   client:
     type: browser
     name: Beaker Browser
-    short_name: BA
     version: "0.8.2"
     engine: Blink
     engine_version: ""
@@ -13,7 +12,6 @@
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.8.7"
     engine: WebKit
     engine_version: "534.30"
@@ -22,7 +20,6 @@
   client:
     type: browser
     name: 360 Browser
-    short_name: 3B
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -31,7 +28,6 @@
   client:
     type: browser
     name: 360 Browser
-    short_name: 3B
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -40,7 +36,6 @@
   client:
     type: browser
     name: Avant Browser
-    short_name: AA
     version: ""
     engine: ""
     engine_version: ""
@@ -49,7 +44,6 @@
   client:
     type: browser
     name: ABrowse
-    short_name: AB
     version: "0.6"
     engine: WebKit
     engine_version: "420"
@@ -58,7 +52,6 @@
   client:
     type: browser
     name: ANT Fresco
-    short_name: AF
     version: "2.17"
     engine: ""
     engine_version: ""
@@ -67,7 +60,6 @@
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.1.1.23.04.09"
     engine: ""
     engine_version: ""
@@ -76,7 +68,6 @@
   client:
     type: browser
     name: Amaya
-    short_name: AM
     version: "9.51"
     engine: ""
     engine_version: ""
@@ -85,7 +76,6 @@
   client:
     type: browser
     name: Amigo
-    short_name: AO
     version: "28.0.1500.74"
     engine: Blink
     engine_version: ""
@@ -94,7 +84,6 @@
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "522"
@@ -103,7 +92,6 @@
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -112,7 +100,6 @@
   client:
     type: browser
     name: Arora
-    short_name: AR
     version: "0.10.1"
     engine: WebKit
     engine_version: "532.1"
@@ -121,7 +108,6 @@
   client:
     type: browser
     name: Amiga Voyager
-    short_name: AV
     version: "3.2"
     engine: ""
     engine_version: ""
@@ -130,7 +116,6 @@
   client:
     type: browser
     name: Amiga Aweb
-    short_name: AW
     version: ""
     engine: ""
     engine_version: ""
@@ -139,7 +124,6 @@
   client:
     type: browser
     name: Atomic Web Browser
-    short_name: AT
     version: "7.0.1"
     engine: ""
     engine_version: ""
@@ -148,7 +132,6 @@
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: ""
     engine_version: ""
@@ -157,7 +140,6 @@
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.5.20.0"
     engine: WebKit
     engine_version: "534.24"
@@ -166,7 +148,6 @@
   client:
     type: browser
     name: Baidu Spark
-    short_name: BS
     version: "26.4"
     engine: WebKit
     engine_version: "537.31"
@@ -175,7 +156,6 @@
   client:
     type: browser
     name: Beonex
-    short_name: BE
     version: "0.8.1"
     engine: Gecko
     engine_version: ""
@@ -184,7 +164,6 @@
   client:
     type: browser
     name: Bunjalloo
-    short_name: BJ
     version: "0.7.6"
     engine: ""
     engine_version: ""
@@ -193,7 +172,6 @@
   client:
     type: browser
     name: BriskBard
-    short_name: BK
     version: "1.0"
     engine: ""
     engine_version: ""
@@ -202,7 +180,6 @@
   client:
     type: browser
     name: Brave
-    short_name: BR
     version: "0.7.9"
     engine: Blink
     engine_version: ""
@@ -211,7 +188,6 @@
   client:
     type: browser
     name: BrowseX
-    short_name: BX
     version: "2.0.0"
     engine: ""
     engine_version: ""
@@ -220,7 +196,6 @@
   client:
     type: browser
     name: Camino
-    short_name: CA
     version: "2.1.2"
     engine: Gecko
     engine_version: "1.9.2.28"
@@ -229,7 +204,6 @@
   client:
     type: browser
     name: Cunaguaro
-    short_name: CU
     version: "27.0"
     engine: Gecko
     engine_version: "27.0"
@@ -238,7 +212,6 @@
   client:
     type: browser
     name: Coc Coc
-    short_name: CC
     version: "45.0"
     engine: Blink
     engine_version: ""
@@ -247,7 +220,6 @@
   client:
     type: browser
     name: Comodo Dragon
-    short_name: CD
     version: "17.1.0.0"
     engine: WebKit
     engine_version: "535.11"
@@ -256,7 +228,6 @@
   client:
     type: browser
     name: Charon
-    short_name: CX
     version: ""
     engine: ""
     engine_version: ""
@@ -265,7 +236,6 @@
   client:
     type: browser
     name: Chrome Frame
-    short_name: CF
     version: "19.0.1084.52"
     engine: WebKit
     engine_version: ""
@@ -274,7 +244,6 @@
   client:
     type: browser
     name: Headless Chrome
-    short_name: HC
     version: "63.0.3205.0"
     engine: Blink
     engine_version: ""
@@ -283,7 +252,6 @@
   client:
     type: browser
     name: Headless Chrome
-    short_name: HC
     version: "60.0.3112.78"
     engine: Blink
     engine_version: ""
@@ -292,7 +260,6 @@
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "12.0.742.100"
     engine: WebKit
     engine_version: "534.30"
@@ -301,7 +268,6 @@
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
@@ -310,7 +276,6 @@
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.125"
     engine: Blink
     engine_version: ""
@@ -319,7 +284,6 @@
   client:
     type: browser
     name: Chrome Mobile iOS
-    short_name: CI
     version: "31.0.1650.18"
     engine: WebKit
     engine_version: "536.26"
@@ -328,7 +292,6 @@
   client:
     type: browser
     name: Conkeror
-    short_name: CK
     version: "1.0"
     engine: Gecko
     engine_version: "17.0"
@@ -337,7 +300,6 @@
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -346,7 +308,6 @@
   client:
     type: browser
     name: CoolNovo
-    short_name: CN
     version: "1.6.5.28"
     engine: WebKit
     engine_version: "535.7"
@@ -355,7 +316,6 @@
   client:
     type: browser
     name: CometBird
-    short_name: CO
     version: "11.0"
     engine: Gecko
     engine_version: "11.0"
@@ -364,7 +324,6 @@
   client:
     type: browser
     name: ChromePlus
-    short_name: CP
     version: "1.6.0.0"
     engine: WebKit
     engine_version: "534.13"
@@ -373,7 +332,6 @@
   client:
     type: browser
     name: Chromium
-    short_name: CR
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
@@ -382,7 +340,6 @@
   client:
     type: browser
     name: Cheshire
-    short_name: CS
     version: "1.0"
     engine: WebKit
     engine_version: "418.9"
@@ -391,7 +348,6 @@
   client:
     type: browser
     name: B-Line
-    short_name: BL
     version: ""
     engine: WebKit
     engine_version: "537.51.2"
@@ -400,7 +356,6 @@
   client:
     type: browser
     name: B-Line
-    short_name: BL
     version: "1.04"
     engine: WebKit
     engine_version: "601.1.46"
@@ -409,7 +364,6 @@
   client:
     type: browser
     name: dbrowser
-    short_name: DB
     version: ""
     engine: WebKit
     engine_version: "536.26"
@@ -418,7 +372,6 @@
   client:
     type: browser
     name: dbrowser
-    short_name: DB
     version: ""
     engine: WebKit
     engine_version: "536.26"
@@ -427,7 +380,6 @@
   client:
     type: browser
     name: Deepnet Explorer
-    short_name: DE
     version: "1.5.3"
     engine: ""
     engine_version: ""
@@ -436,7 +388,6 @@
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
@@ -445,7 +396,6 @@
   client:
     type: browser
     name: Dillo
-    short_name: DI
     version: "0.8.5"
     engine: Dillo
     engine_version: "0.8.5"
@@ -454,7 +404,6 @@
   client:
     type: browser
     name: Dorado
-    short_name: DO
     version: "1.0"
     engine: ""
     engine_version: ""
@@ -463,7 +412,6 @@
   client:
     type: browser
     name: DuckDuckGo Privacy Browser
-    short_name: DD
     version: "5"
     engine: Blink
     engine_version: ""
@@ -472,7 +420,6 @@
   client:
     type: browser
     name: Element Browser
-    short_name: EB
     version: "5.0"
     engine: WebKit
     engine_version: "533"
@@ -481,7 +428,6 @@
   client:
     type: browser
     name: Elinks
-    short_name: EL
     version: "0.12"
     engine: Text-based
     engine_version: ""
@@ -490,7 +436,6 @@
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "1.2.6"
     engine: Gecko
     engine_version: "1.6"
@@ -499,7 +444,6 @@
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "2.30.6"
     engine: WebKit
     engine_version: "531.2"
@@ -508,7 +452,6 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.1.5"
     engine: WebKit
     engine_version: "531.2"
@@ -517,7 +460,6 @@
   client:
     type: browser
     name: Firebird
-    short_name: FB
     version: "0.7"
     engine: Gecko
     engine_version: "1.5"
@@ -526,7 +468,6 @@
   client:
     type: browser
     name: Fluid
-    short_name: FD
     version: "0.9.6"
     engine: WebKit
     engine_version: "528.16"
@@ -535,7 +476,6 @@
   client:
     type: browser
     name: Fennec
-    short_name: FE
     version: "10.0"
     engine: Gecko
     engine_version: "10.0"
@@ -544,7 +484,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "4.0"
     engine: Gecko
     engine_version: "2.0"
@@ -553,7 +492,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "2.0.0.21"
     engine: Gecko
     engine_version: "1.8.1.21"
@@ -562,7 +500,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.11"
     engine: Gecko
     engine_version: ""
@@ -571,7 +508,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0"
     engine: Gecko
     engine_version: "1.9"
@@ -580,7 +516,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5"
     engine: Gecko
     engine_version: "1.9.1"
@@ -589,7 +524,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.3"
     engine: Gecko
     engine_version: "1.9.2.3"
@@ -598,7 +532,6 @@
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.13"
     engine: Gecko
     engine_version: "1.9.2.13"
@@ -607,7 +540,6 @@
   client:
     type: browser
     name: Firefox Mobile iOS
-    short_name: F1
     version: "1.0"
     engine: WebKit
     engine_version: "600.1.4"
@@ -616,7 +548,6 @@
   client:
     type: browser
     name: Firefox Focus
-    short_name: FK
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
@@ -625,7 +556,6 @@
   client:
     type: browser
     name: Firefox Focus
-    short_name: FK
     version: "1.1"
     engine: WebKit
     engine_version: "537.36"
@@ -634,7 +564,6 @@
   client:
     type: browser
     name: Flock
-    short_name: FL
     version: "2.5.6"
     engine: Gecko
     engine_version: "1.9.0.16"
@@ -643,7 +572,6 @@
   client:
     type: browser
     name: Fireweb Navigator
-    short_name: FN
     version: "2.4"
     engine: ""
     engine_version: ""
@@ -652,7 +580,6 @@
   client:
     type: browser
     name: Fireweb
-    short_name: FW
     version: "1.0.0.0"
     engine: WebKit
     engine_version: "534"
@@ -661,7 +588,6 @@
   client:
     type: browser
     name: Galeon
-    short_name: GA
     version: "1.3.21"
     engine: Gecko
     engine_version: "1.7.12"
@@ -670,7 +596,6 @@
   client:
     type: browser
     name: Google Earth
-    short_name: GE
     version: "5.2.1.1329"
     engine: WebKit
     engine_version: "532.4"
@@ -679,7 +604,6 @@
   client:
     type: browser
     name: HotJava
-    short_name: HJ
     version: "1.1.2"
     engine: ""
     engine_version: ""
@@ -688,7 +612,6 @@
   client:
     type: browser
     name: IBrowse
-    short_name: IB
     version: "2.4"
     engine: ""
     engine_version: ""
@@ -697,7 +620,6 @@
   client:
     type: browser
     name: iCab
-    short_name: IC
     version: "2.9.9"
     engine: iCab
     engine_version: "2.9.9"
@@ -706,7 +628,6 @@
   client:
     type: browser
     name: iCab
-    short_name: IC
     version: "4.8"
     engine: WebKit
     engine_version: "533.19.4"
@@ -715,7 +636,6 @@
   client:
     type: browser
     name: IceDragon
-    short_name: ID
     version: "26.0.0.2"
     engine: Gecko
     engine_version: "26.0"
@@ -724,7 +644,6 @@
   client:
     type: browser
     name: Iceweasel
-    short_name: IW
     version: "3.0.6"
     engine: Gecko
     engine_version: "1.9.0.15"
@@ -733,7 +652,6 @@
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "4.01"
     engine: Trident
     engine_version: ""
@@ -742,7 +660,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "12.0"
     engine: Edge
     engine_version: "12.0"
@@ -751,7 +668,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "12.10240"
     engine: Edge
     engine_version: "12.10240"
@@ -760,7 +676,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10537"
     engine: Edge
     engine_version: "13.10537"
@@ -769,7 +684,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10547"
     engine: Edge
     engine_version: "13.10547"
@@ -778,7 +692,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "41.1.35.1"
     engine: WebKit
     engine_version: "603.2.4"
@@ -787,7 +700,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "41.1.35.1"
     engine: Blink
     engine_version: ""
@@ -796,7 +708,6 @@
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "75.0.107.0"
     engine: Blink
     engine_version: ""
@@ -805,7 +716,6 @@
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -814,7 +724,6 @@
   client:
     type: browser
     name: Iron
-    short_name: IR
     version: "26.0.1450.0"
     engine: WebKit
     engine_version: "537.36"
@@ -823,7 +732,6 @@
   client:
     type: browser
     name: Isivioo
-    short_name: IV
     version: ""
     engine: WebKit
     engine_version: "538.34.9"
@@ -832,7 +740,6 @@
   client:
     type: browser
     name: Isivioo
-    short_name: IV
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -841,7 +748,6 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "0.8"
     engine: ""
     engine_version: ""
@@ -850,7 +756,6 @@
   client:
     type: browser
     name: Jig Browser
-    short_name: JI
     version: "5.0.1"
     engine: ""
     engine_version: ""
@@ -859,7 +764,6 @@
   client:
     type: browser
     name: Jig Browser
-    short_name: JI
     version: "1.0.4"
     engine: ""
     engine_version: ""
@@ -868,7 +772,6 @@
   client:
     type: browser
     name: Jig Browser
-    short_name: JI
     version: "1.5.0"
     engine: ""
     engine_version: ""
@@ -877,7 +780,6 @@
   client:
     type: browser
     name: Jig Browser
-    short_name: JI
     version: "1.4.9"
     engine: ""
     engine_version: ""
@@ -886,7 +788,6 @@
   client:
     type: browser
     name: Kindle Browser
-    short_name: KI
     version: "2.0"
     engine: NetFront
     engine_version: "3.4"
@@ -895,7 +796,6 @@
   client:
     type: browser
     name: K-meleon
-    short_name: KM
     version: "1.5.4"
     engine: Gecko
     engine_version: "1.8.1.24"
@@ -904,7 +804,6 @@
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "3.5"
     engine: KHTML
     engine_version: "3.5.8"
@@ -913,7 +812,6 @@
   client:
     type: browser
     name: Kapiko
-    short_name: KP
     version: "3.0"
     engine: Gecko
     engine_version: "1.9"
@@ -922,7 +820,6 @@
   client:
     type: browser
     name: Kazehakase
-    short_name: KZ
     version: "0.5.6"
     engine: Gecko
     engine_version: ""
@@ -931,7 +828,6 @@
   client:
     type: browser
     name: Kylo
-    short_name: KY
     version: "0.6.1.70394"
     engine: Gecko
     engine_version: "1.9.2"
@@ -940,7 +836,6 @@
   client:
     type: browser
     name: Cheetah Browser
-    short_name: LB
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -949,7 +844,6 @@
   client:
     type: browser
     name: Links
-    short_name: LI
     version: "2.1"
     engine: Text-based
     engine_version: ""
@@ -958,7 +852,6 @@
   client:
     type: browser
     name: LuaKit
-    short_name: LU
     version: ""
     engine: WebKit
     engine_version: "538.1"
@@ -967,7 +860,6 @@
   client:
     type: browser
     name: Lunascape
-    short_name: LS
     version: "2.1.3"
     engine: ""
     engine_version: ""
@@ -976,7 +868,6 @@
   client:
     type: browser
     name: Lynx
-    short_name: LX
     version: "2.8.8"
     engine: Text-based
     engine_version: ""
@@ -985,7 +876,6 @@
   client:
     type: browser
     name: MicroB
-    short_name: MB
     version: "0.9.7"
     engine: Gecko
     engine_version: "1.9.2"
@@ -994,7 +884,6 @@
   client:
     type: browser
     name: Avast Secure Browser
-    short_name: AS
     version: "66.2.567.182"
     engine: WebKit
     engine_version: "537.36"
@@ -1003,7 +892,6 @@
   client:
     type: browser
     name: MicroB
-    short_name: MB
     version: ""
     engine: Gecko
     engine_version: ""
@@ -1012,7 +900,6 @@
   client:
     type: browser
     name: MicroB
-    short_name: MB
     version: "1.7.4.8"
     engine: Gecko
     engine_version: "1.9.2.3"
@@ -1021,7 +908,6 @@
   client:
     type: browser
     name: NCSA Mosaic
-    short_name: MC
     version: "2.7"
     engine: ""
     engine_version: ""
@@ -1030,7 +916,6 @@
   client:
     type: browser
     name: Mercury
-    short_name: ME
     version: "8.0.1"
     engine: WebKit
     engine_version: "536.26"
@@ -1039,7 +924,6 @@
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
@@ -1048,7 +932,6 @@
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
@@ -1057,7 +940,6 @@
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "9537.53"
     engine: WebKit
     engine_version: ""
@@ -1066,7 +948,6 @@
   client:
     type: browser
     name: Midori
-    short_name: MI
     version: "0.5"
     engine: WebKit
     engine_version: "535.22"
@@ -1075,7 +956,6 @@
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.12"
     engine: WebKit
     engine_version: "535.19"
@@ -1084,7 +964,6 @@
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.1.2.2000"
     engine: WebKit
     engine_version: "537.22"
@@ -1093,7 +972,6 @@
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "8.3.1.4"
     engine: WebKit
     engine_version: "535.1"
@@ -1102,7 +980,6 @@
   client:
     type: browser
     name: Nokia OSS Browser
-    short_name: 'NO'
     version: "3.0"
     engine: ""
     engine_version: ""
@@ -1111,7 +988,6 @@
   client:
     type: browser
     name: NetFront Life
-    short_name: NL
     version: "2.3"
     engine: NetFront
     engine_version: ""
@@ -1120,7 +996,6 @@
   client:
     type: browser
     name: Nokia Ovi Browser
-    short_name: NV
     version: "3.9.0.0.22"
     engine: Gecko
     engine_version: ""
@@ -1129,7 +1004,6 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
@@ -1138,7 +1012,6 @@
   client:
     type: browser
     name: NetPositive
-    short_name: NP
     version: "2.2.1"
     engine: ""
     engine_version: ""
@@ -1147,7 +1020,6 @@
   client:
     type: browser
     name: Netscape
-    short_name: NS
     version: "6.01"
     engine: Gecko
     engine_version: ""
@@ -1156,7 +1028,6 @@
   client:
     type: browser
     name: Netscape
-    short_name: NS
     version: "8.1.3"
     engine: Gecko
     engine_version: "1.7.5"
@@ -1165,7 +1036,6 @@
   client:
     type: browser
     name: NTENT Browser
-    short_name: NT
     version: "1.0.0.547"
     engine: WebKit
     engine_version: "537.36"
@@ -1174,7 +1044,6 @@
   client:
     type: browser
     name: LG Browser
-    short_name: LG
     version: "5.00.00"
     engine: WebKit
     engine_version: "534.26"
@@ -1183,7 +1052,6 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
@@ -1192,7 +1060,6 @@
   client:
     type: browser
     name: Odyssey Web Browser
-    short_name: OD
     version: "1.23"
     engine: WebKit
     engine_version: "538.1"
@@ -1201,7 +1068,6 @@
   client:
     type: browser
     name: Off By One
-    short_name: OF
     version: ""
     engine: ""
     engine_version: ""
@@ -1210,7 +1076,6 @@
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "4.2.0"
     engine: WebKit
     engine_version: "533.1"
@@ -1219,7 +1084,6 @@
   client:
     type: browser
     name: Opera Touch
-    short_name: OO
     version: "1.10.36"
     engine: Blink
     engine_version: ""
@@ -1228,7 +1092,6 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "12.16"
     engine: Presto
     engine_version: "2.12.423"
@@ -1237,7 +1100,6 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
@@ -1246,7 +1108,6 @@
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "15.0.1162.61541"
     engine: Blink
     engine_version: ""
@@ -1255,7 +1116,6 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "5.0.21073"
     engine: Presto
     engine_version: ""
@@ -1264,7 +1124,6 @@
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.11.355"
@@ -1273,7 +1132,6 @@
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "3.2"
     engine: ""
     engine_version: ""
@@ -1282,7 +1140,6 @@
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "6.04"
     engine: Elektra
     engine_version: ""
@@ -1291,7 +1148,6 @@
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "8.00"
     engine: Presto
     engine_version: ""
@@ -1300,7 +1156,6 @@
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "20.0.1387.37"
     engine: Blink
     engine_version: ""
@@ -1309,7 +1164,6 @@
   client:
     type: browser
     name: Oregano
-    short_name: OR
     version: "1.10"
     engine: ""
     engine_version: ""
@@ -1318,7 +1172,6 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.2"
     engine: ""
     engine_version: ""
@@ -1327,7 +1180,6 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "1.0"
     engine: ""
     engine_version: ""
@@ -1336,7 +1188,6 @@
   client:
     type: browser
     name: OmniWeb
-    short_name: OW
     version: "624.0"
     engine: WebKit
     engine_version: "9537.73.11"
@@ -1345,7 +1196,6 @@
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.36"
@@ -1354,7 +1204,6 @@
   client:
     type: browser
     name: Otter Browser
-    short_name: OT
     version: "0.9.04"
     engine: WebKit
     engine_version: "538.1"
@@ -1363,7 +1212,6 @@
   client:
     type: browser
     name: Palm Blazer
-    short_name: PL
     version: "4.3"
     engine: ""
     engine_version: ""
@@ -1372,7 +1220,6 @@
   client:
     type: browser
     name: Pale Moon
-    short_name: PM
     version: "24.3.1"
     engine: Gecko
     engine_version: "24.0"
@@ -1381,7 +1228,6 @@
   client:
     type: browser
     name: Palm Pre
-    short_name: PR
     version: "1.0"
     engine: WebKit
     engine_version: "525.27.1"
@@ -1390,7 +1236,6 @@
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "2.10977"
     engine: WebKit
     engine_version: "534.35"
@@ -1399,7 +1244,6 @@
   client:
     type: browser
     name: Palm WebPro
-    short_name: PW
     version: ""
     engine: ""
     engine_version: ""
@@ -1408,7 +1252,6 @@
   client:
     type: browser
     name: Palmscape
-    short_name: PA
     version: "3.0"
     engine: ""
     engine_version: ""
@@ -1417,7 +1260,6 @@
   client:
     type: browser
     name: Phoenix
-    short_name: PX
     version: "0.4"
     engine: Gecko
     engine_version: "1.2"
@@ -1426,7 +1268,6 @@
   client:
     type: browser
     name: Polaris
-    short_name: PO
     version: "6.2"
     engine: ""
     engine_version: ""
@@ -1435,7 +1276,6 @@
   client:
     type: browser
     name: Rekonq
-    short_name: RK
     version: "2.3.2"
     engine: WebKit
     engine_version: "537.21"
@@ -1444,7 +1284,6 @@
   client:
     type: browser
     name: RockMelt
-    short_name: RM
     version: "0.16.91.483"
     engine: WebKit
     engine_version: "535.7"
@@ -1453,7 +1292,6 @@
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.0"
     engine: WebKit
     engine_version: "538.1"
@@ -1462,7 +1300,6 @@
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
@@ -1471,7 +1308,6 @@
   client:
     type: browser
     name: Sailfish Browser
-    short_name: SA
     version: "1.0"
     engine: Gecko
     engine_version: "26.0"
@@ -1480,7 +1316,6 @@
   client:
     type: browser
     name: Sogou Explorer
-    short_name: SE
     version: "2"
     engine: ""
     engine_version: ""
@@ -1489,7 +1324,6 @@
   client:
     type: browser
     name: Vision Mobile Browser
-    short_name: VB
     version: "8.1"
     engine: Gecko
     engine_version: ""
@@ -1498,7 +1332,6 @@
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: ""
@@ -1507,7 +1340,6 @@
   client:
     type: browser
     name: Seraphic Sraf
-    short_name: SS
     version: "3.0"
     engine: Blink
     engine_version: ""
@@ -1516,7 +1348,6 @@
   client:
     type: browser
     name: SEMC-Browser
-    short_name: SC
     version: "4.0.3"
     engine: ""
     engine_version: ""
@@ -1525,7 +1356,6 @@
   client:
     type: browser
     name: Shiira
-    short_name: SH
     version: "1.2.3"
     engine: WebKit
     engine_version: "419"
@@ -1534,7 +1364,6 @@
   client:
     type: browser
     name: Skyfire
-    short_name: SK
     version: ""
     engine: WebKit
     engine_version: "530.17"
@@ -1543,7 +1372,6 @@
   client:
     type: browser
     name: Sleipnir
-    short_name: SL
     version: "2.9.18"
     engine: Trident
     engine_version: "6.0"
@@ -1552,7 +1380,6 @@
   client:
     type: browser
     name: Snowshoe
-    short_name: SN
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.21"
@@ -1561,7 +1388,6 @@
   client:
     type: browser
     name: Streamy
-    short_name: ST
     version: "1.1.11"
     engine: WebKit
     engine_version: "601.1.46"
@@ -1570,7 +1396,6 @@
   client:
     type: browser
     name: Streamy
-    short_name: ST
     version: "1.1.11"
     engine: WebKit
     engine_version: "601.1.46"
@@ -1579,7 +1404,6 @@
   client:
     type: browser
     name: Streamy
-    short_name: ST
     version: "1.1.193"
     engine: WebKit
     engine_version: "537.36"
@@ -1588,7 +1412,6 @@
   client:
     type: browser
     name: Sunrise
-    short_name: SR
     version: "0.833"
     engine: WebKit
     engine_version: "125.5.7"
@@ -1597,7 +1420,6 @@
   client:
     type: browser
     name: SuperBird
-    short_name: SP
     version: "24.0"
     engine: WebKit
     engine_version: "537.17"
@@ -1606,7 +1428,6 @@
   client:
     type: browser
     name: Swiftfox
-    short_name: SX
     version: "2.0"
     engine: Gecko
     engine_version: "1.8.1"
@@ -1615,7 +1436,6 @@
   client:
     type: browser
     name: Tizen Browser
-    short_name: TZ
     version: "1.0"
     engine: WebKit
     engine_version: "534.46"
@@ -1624,7 +1444,6 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.377"
     engine: ""
     engine_version: ""
@@ -1633,7 +1452,6 @@
   client:
     type: browser
     name: Vivaldi
-    short_name: VI
     version: "1.0.105.7"
     engine: Blink
     engine_version: ""
@@ -1642,7 +1460,6 @@
   client:
     type: browser
     name: TweakStyle
-    short_name: TS
     version: "0.9.2"
     engine: Blink
     engine_version: ""
@@ -1651,7 +1468,6 @@
   client:
     type: browser
     name: WebPositive
-    short_name: WE
     version: ""
     engine: WebKit
     engine_version: "533.4"
@@ -1660,7 +1476,6 @@
   client:
     type: browser
     name: WeTab Browser
-    short_name: WT
     version: ""
     engine: WebKit
     engine_version: "534.3"
@@ -1669,7 +1484,6 @@
   client:
     type: browser
     name: wOSBrowser
-    short_name: WO
     version: "1.4.5"
     engine: WebKit
     engine_version: "532.2"
@@ -1678,7 +1492,6 @@
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "13.10.1500.9323"
     engine: Blink
     engine_version: ""
@@ -1687,7 +1500,6 @@
   client:
     type: browser
     name: Xiino
-    short_name: XI
     version: "1.0.9"
     engine: ""
     engine_version: ""
@@ -1696,7 +1508,6 @@
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.0.3197.400"
     engine: WebKit
     engine_version: "537.36"
@@ -1705,7 +1516,6 @@
   client:
     type: browser
     name: QQ Browser Mini
-    short_name: Q1
     version: "2.6"
     engine: ""
     engine_version: ""
@@ -1714,7 +1524,6 @@
   client:
     type: browser
     name: Polarity
-    short_name: PT
     version: "6.0.0"
     engine: WebKit
     engine_version: "534.30"
@@ -1723,7 +1532,6 @@
   client:
     type: browser
     name: QupZilla
-    short_name: QZ
     version: "1.1.5"
     engine: WebKit
     engine_version: "533.3"
@@ -1732,7 +1540,6 @@
   client:
     type: browser
     name: Dooble
-    short_name: DL
     version: "1.41"
     engine: WebKit
     engine_version: "534.34"
@@ -1741,7 +1548,6 @@
   client:
     type: browser
     name: Epic
-    short_name: EI
     version: "1.2"
     engine: Gecko
     engine_version: "1.9.2.10"
@@ -1750,7 +1556,6 @@
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
@@ -1759,7 +1564,6 @@
   client:
     type: browser
     name: Coast
-    short_name: C1
     version: "1.0.2.62956"
     engine: WebKit
     engine_version: "536.26"
@@ -1768,7 +1572,6 @@
   client:
     type: browser
     name: Qutebrowser
-    short_name: QT
     version: "0.2.1"
     engine: WebKit
     engine_version: "538.1"
@@ -1777,7 +1580,6 @@
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "1.4"
     engine: WebKit
     engine_version: "602.1.50"
@@ -1786,7 +1588,6 @@
   client:
     type: browser
     name: Waterfox
-    short_name: WF
     version: "30.0"
     engine: Gecko
     engine_version: "30.0"
@@ -1795,7 +1596,6 @@
   client:
     type: browser
     name: Iridium
-    short_name: I1
     version: "41.2"
     engine: WebKit
     engine_version: "537.36"
@@ -1804,7 +1604,6 @@
   client:
     type: browser
     name: Cyberfox
-    short_name: CY
     version: "28.0.1"
     engine: Gecko
     engine_version: "28.0"
@@ -1813,7 +1612,6 @@
   client:
     type: browser
     name: iCab Mobile
-    short_name: I2
     version: "1.1"
     engine: WebKit
     engine_version: "538.34.9"
@@ -1822,7 +1620,6 @@
   client:
     type: browser
     name: NetSurf
-    short_name: NE
     version: "3.7"
     engine: NetSurf
     engine_version: "3.7"
@@ -1831,7 +1628,6 @@
   client:
     type: browser
     name: Tenta Browser
-    short_name: TB
     version: "2.10.3"
     engine: Webkit
     engine_version: "537.36"
@@ -1840,7 +1636,6 @@
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "2.5"
     engine: Gecko
     engine_version: "63.0"
@@ -1849,7 +1644,6 @@
   client:
     type: browser
     name: TenFourFox
-    short_name: TF
     version: ""
     engine: Gecko
     engine_version: "45.0"
@@ -1858,7 +1652,6 @@
   client:
     type: browser
     name: AOL Shield
-    short_name: AD
     version: "52.4.2"
     engine: Gecko
     engine_version: "52.0"
@@ -1867,7 +1660,6 @@
   client:
     type: browser
     name: Firefox Rocket
-    short_name: FR
     version: "1.6.2"
     engine: Webkit
     engine_version: "537.36"
@@ -1876,7 +1668,6 @@
   client:
     type: browser
     name: Web Explorer
-    short_name: WP
     version: "2.6.6"
     engine: Webkit
     engine_version: "537.36"
@@ -1885,7 +1676,6 @@
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -1894,7 +1684,6 @@
   client:
     type: browser
     name: 2345 Browser
-    short_name: 2B
     version: "4.0"
     engine: WebKit
     engine_version: "534.30"
@@ -1903,7 +1692,6 @@
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -1912,7 +1700,6 @@
   client:
     type: browser
     name: Ecosia
-    short_name: EC
     version: "3.0.1.533"
     engine: WebKit
     engine_version: "602.4.6"
@@ -1921,7 +1708,6 @@
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "18.1"
     engine: Gecko
     engine_version: "18.1"
@@ -1930,7 +1716,6 @@
   client:
     type: browser
     name: Iron Mobile
-    short_name: I3
     version: "1.3.0"
     engine: Blink
     engine_version: ""
@@ -1939,7 +1724,6 @@
   client:
     type: browser
     name: IceCat
-    short_name: I4
     version: "52.6.0"
     engine: Gecko
     engine_version: "52.6.0"
@@ -1948,7 +1732,6 @@
   client:
     type: browser
     name: Kiwi
-    short_name: KW
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -1957,7 +1740,6 @@
   client:
     type: browser
     name: LieBaoFast
-    short_name: LF
     version: "3.17.4"
     engine: WebKit
     engine_version: "537.36"
@@ -1966,7 +1748,6 @@
   client:
     type: browser
     name: Mobicip
-    short_name: MO
     version: ""
     engine: Gecko
     engine_version: ""
@@ -1975,7 +1756,6 @@
   client:
     type: browser
     name: Mint Browser
-    short_name: MT
     version: "1.3.3"
     engine: WebKit
     engine_version: "537.36"
@@ -1984,7 +1764,6 @@
   client:
     type: browser
     name: Opera Neon
-    short_name: OG
     version: "1.0.2459.0"
     engine: Blink
     engine_version: ""
@@ -1993,7 +1772,6 @@
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.2.12.29"
     engine: Blink
     engine_version: ""
@@ -2002,7 +1780,6 @@
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "1.3"
     engine: Gecko
     engine_version: ""
@@ -2011,7 +1788,6 @@
   client:
     type: browser
     name: Opera Mini iOS
-    short_name: O1
     version: "8.0.1.80062"
     engine: WebKit
     engine_version: "537.51.2"
@@ -2020,7 +1796,6 @@
   client:
     type: browser
     name: QtWebEngine
-    short_name: QW
     version: "5.2.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2029,7 +1804,6 @@
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "3.8.5"
     engine: WebKit
     engine_version: "534.30"
@@ -2038,7 +1812,6 @@
   client:
     type: browser
     name: Seznam Browser
-    short_name: SZ
     version: "3.0.0"
     engine: Blink
     engine_version: ""
@@ -2047,7 +1820,6 @@
   client:
     type: browser
     name: UC Browser Mini
-    short_name: UM
     version: "10.9.0.946"
     engine: ""
     engine_version: ""
@@ -2056,7 +1828,6 @@
   client:
     type: browser
     name: Whale Browser
-    short_name: WH
     version: "0.7.33.5"
     engine: Blink
     engine_version: ""
@@ -2065,7 +1836,6 @@
   client:
     type: browser
     name: Hawk Turbo Browser
-    short_name: HA
     version: "3.0.0.4.21.06211557"
     engine: Blink
     engine_version: ""
@@ -2074,7 +1844,6 @@
   client:
     type: browser
     name: Hawk Turbo Browser
-    short_name: HA
     version: "2.0.51"
     engine: Blink
     engine_version: ""
@@ -2083,7 +1852,6 @@
   client:
     type: browser
     name: Nox Browser
-    short_name: NX
     version: "2.0.0"
     engine: Blink
     engine_version: ""
@@ -2092,7 +1860,6 @@
   client:
     type: browser
     name: FreeU
-    short_name: FU
     version: "1.2.148"
     engine: Blink
     engine_version: ""
@@ -2101,7 +1868,6 @@
   client:
     type: browser
     name: Basilisk
-    short_name: BI
     version: "20190912"
     engine: Goanna
     engine_version: "4.4"
@@ -2110,7 +1876,6 @@
   client:
     type: browser
     name: Sputnik Browser
-    short_name: SI
     version: "1.2.5.158"
     engine: Blink
     engine_version: ""
@@ -2119,7 +1884,6 @@
   client:
     type: browser
     name: K.Browser
-    short_name: KB
     version: "26.07"
     engine: Blink
     engine_version: ""
@@ -2128,7 +1892,6 @@
   client:
     type: browser
     name: Oculus Browser
-    short_name: OC
     version: "6.0.17.167158974"
     engine: WebKit
     engine_version: "537.36"
@@ -2137,7 +1900,6 @@
   client:
     type: browser
     name: Jio Browser
-    short_name: JO
     version: "1.4.2"
     engine: Blink
     engine_version: ""
@@ -2146,7 +1908,6 @@
   client:
     type: browser
     name: hola! Browser
-    short_name: HO
     version: "1.148.217"
     engine: Blink
     engine_version: ""
@@ -2155,7 +1916,6 @@
   client:
     type: browser
     name: Huawei Browser
-    short_name: HU
     version: "10.0.1.332"
     engine: WebKit
     engine_version: "537.36"
@@ -2164,7 +1924,6 @@
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "5.10.0.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2173,7 +1932,6 @@
   client:
     type: browser
     name: Realme Browser
-    short_name: RE
     version: "35.5.0.8"
     engine: WebKit
     engine_version: "537.36"
@@ -2182,7 +1940,6 @@
   client:
     type: browser
     name: Yandex Browser Lite
-    short_name: YL
     version: "19.1.0.130"
     engine: Blink
     engine_version: ""
@@ -2191,7 +1948,6 @@
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.822.00 alpha"
     engine: Blink
     engine_version: ""
@@ -2200,7 +1956,6 @@
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.0.350.01 beta"
     engine: Blink
     engine_version: ""
@@ -2209,7 +1964,6 @@
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.8.20"
     engine: Gecko
     engine_version: "52.0"
@@ -2218,7 +1972,6 @@
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.7.22"
     engine: Gecko
     engine_version: "42.0"
@@ -2227,7 +1980,6 @@
   client:
     type: browser
     name: COS Browser
-    short_name: CB
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.17"
@@ -2236,7 +1988,6 @@
   client:
     type: browser
     name: Crusta
-    short_name: CT
     version: "1.4.3"
     engine: WebKit
     engine_version: "537.36"
@@ -2245,7 +1996,6 @@
   client:
     type: browser
     name: Opera GX
-    short_name: OX
     version: "60.0.3255.50747"
     engine: Blink
     engine_version: ""
@@ -2254,7 +2004,6 @@
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.9.900"
     engine: WebKit
     engine_version: "537.36"
@@ -2263,7 +2012,6 @@
   client:
     type: browser
     name: UBrowser
-    short_name: UB
     version: "5.5.5701.114"
     engine: WebKit
     engine_version: "537.36"
@@ -2272,7 +2020,6 @@
   client:
     type: browser
     name: eZ Browser
-    short_name: EZ
     version: "1.0"
     engine: ""
     engine_version: ""
@@ -2281,7 +2028,6 @@
   client:
     type: browser
     name: EUI Browser
-    short_name: EU
     version: "5.8.018"
     engine: WebKit
     engine_version: "537.36"
@@ -2290,7 +2036,6 @@
   client:
     type: browser
     name: Super Fast Browser
-    short_name: SU
     version: "12.0.2115.28"
     engine: WebKit
     engine_version: "537.36"
@@ -2299,7 +2044,6 @@
   client:
     type: browser
     name: Super Fast Browser
-    short_name: SU
     version: "11.0.1001.0327"
     engine: WebKit
     engine_version: "537.36"
@@ -2308,7 +2052,6 @@
   client:
     type: browser
     name: t-online.de Browser
-    short_name: TO
     version: "7.68.0.201"
     engine: Gecko
     engine_version: "68.0"
@@ -2317,7 +2060,6 @@
   client:
     type: browser
     name: Sleipnir
-    short_name: SL
     version: "3.5.7"
     engine: WebKit
     engine_version: "537.36"
@@ -2326,7 +2068,6 @@
   client:
     type: browser
     name: SimpleBrowser
-    short_name: S1
     version: ""
     engine: ""
     engine_version: ""
@@ -2335,7 +2076,6 @@
   client:
     type: browser
     name: Uzbl
-    short_name: UZ
     version: ""
     engine: WebKit
     engine_version: "1.3"
@@ -2344,7 +2084,6 @@
   client:
     type: browser
     name: CCleaner
-    short_name: CL
     version: "75.1.103.145"
     engine: WebKit
     engine_version: "537.36"
@@ -2353,7 +2092,6 @@
   client:
     type: browser
     name: Aloha Browser Lite
-    short_name: AH
     version: "1.4.0.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2362,7 +2100,6 @@
   client:
     type: browser
     name: Tao Browser
-    short_name: TA
     version: "3.1"
     engine: WebKit
     engine_version: "536.11"
@@ -2371,7 +2108,6 @@
   client:
     type: browser
     name: Falkon
-    short_name: FA
     version: "3.1.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2380,7 +2116,6 @@
   client:
     type: browser
     name: mCent
-    short_name: M1
     version: "0.13.1027"
     engine: WebKit
     engine_version: "537.36"
@@ -2389,7 +2124,6 @@
   client:
     type: browser
     name: SalamWeb
-    short_name: SW
     version: "3.0.1.592"
     engine: WebKit
     engine_version: "537.36"
@@ -2398,7 +2132,6 @@
   client:
     type: browser
     name: BlackHawk
-    short_name: BH
     version: "25.3.1"
     engine: Gecko
     engine_version: "25.3"
@@ -2407,7 +2140,6 @@
   client:
     type: browser
     name: Minimo
-    short_name: MN
     version: "0.020"
     engine: Gecko
     engine_version: "1.8.1.5"
@@ -2416,7 +2148,6 @@
   client:
     type: browser
     name: Wear Internet Browser
-    short_name: WI
     version: "0.9.8"
     engine: WebKit
     engine_version: "537.36"
@@ -2425,7 +2156,6 @@
   client:
     type: browser
     name: Origyn Web Browser
-    short_name: OY
     version: ""
     engine: WebKit
     engine_version: "528.5"
@@ -2434,7 +2164,6 @@
   client:
     type: browser
     name: Kinza
-    short_name: KN
     version: "4.8.2"
     engine: WebKit
     engine_version: "537.36"
@@ -2443,7 +2172,6 @@
   client:
     type: browser
     name: Beamrise
-    short_name: BM
     version: "17.2.0.9"
     engine: WebKit
     engine_version: "535.8"
@@ -2452,7 +2180,6 @@
   client:
     type: browser
     name: Faux Browser
-    short_name: FX
     version: "20151018"
     engine: ""
     engine_version: ""
@@ -2461,7 +2188,6 @@
   client:
     type: browser
     name: Iron
-    short_name: IR
     version: "77.0.4000.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2470,7 +2196,6 @@
   client:
     type: browser
     name: Splash
-    short_name: S2
     version: "10.0"
     engine: WebKit
     engine_version: "602.1"
@@ -2479,7 +2204,6 @@
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "6.9.410"
     engine: WebKit
     engine_version: "537.36"
@@ -2488,7 +2212,6 @@
   client:
     type: browser
     name: AVG Secure Browser
-    short_name: VG
     version: "77.2.2156.122"
     engine: WebKit
     engine_version: "537.36"
@@ -2497,7 +2220,6 @@
   client:
     type: browser
     name: START Internet Browser
-    short_name: S0
     version: "53.0.2785.97"
     engine: WebKit
     engine_version: "537.36"
@@ -2506,7 +2228,6 @@
   client:
     type: browser
     name: Lovense Browser
-    short_name: LO
     version: "20.0.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2515,7 +2236,6 @@
   client:
     type: browser
     name: Delta Browser
-    short_name: DT
     version: "2.0.8.2"
     engine: WebKit
     engine_version: "537.36"
@@ -2524,7 +2244,6 @@
   client:
     type: browser
     name: Firefox Reality
-    short_name: FY
     version: ""
     engine: Gecko
     engine_version: "66.0"
@@ -2533,7 +2252,6 @@
   client:
     type: browser
     name: TV Bro
-    short_name: TV
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2542,7 +2260,6 @@
   client:
     type: browser
     name: surf
-    short_name: S3
     version: "2.0"
     engine: WebKit
     engine_version: "605.1.15"
@@ -2551,7 +2268,6 @@
   client:
     type: browser
     name: Origin In-Game Overlay
-    short_name: O0
     version: "9.1.11.2678"
     engine: WebKit
     engine_version: "534.34"
@@ -2560,7 +2276,6 @@
   client:
     type: browser
     name: VMware AirWatch
-    short_name: VM
     version: "6.14.0.19"
     engine: WebKit
     engine_version: "537.36"
@@ -2569,7 +2284,6 @@
   client:
     type: browser
     name: AOL Desktop
-    short_name: AE
     version: "11.0.2617"
     engine: WebKit
     engine_version: "537.36"
@@ -2578,7 +2292,6 @@
   client:
     type: browser
     name: Elements Browser
-    short_name: EE
     version: "1.1.35"
     engine: WebKit
     engine_version: "537.36"
@@ -2587,7 +2300,6 @@
   client:
     type: browser
     name: Light
-    short_name: LH
     version: "49.0"
     engine: Gecko
     engine_version: "49.0"
@@ -2596,7 +2308,6 @@
   client:
     type: browser
     name: Steam In-Game Overlay
-    short_name: S4
     version: "1586022601"
     engine: WebKit
     engine_version: "537.36"
@@ -2605,7 +2316,6 @@
   client:
     type: browser
     name: Centaury
-    short_name: C0
     version: "20200313"
     engine: Goanna
     engine_version: "4.5"
@@ -2614,7 +2324,6 @@
   client:
     type: browser
     name: Avast Secure Browser
-    short_name: AS
     version: "4.58.2552.909"
     engine: WebKit
     engine_version: "537.36"
@@ -2623,7 +2332,6 @@
   client:
     type: browser
     name: Arctic Fox
-    short_name: AX
     version: "27.9.19"
     engine: Goanna
     engine_version: "3.4"
@@ -2632,7 +2340,6 @@
   client:
     type: browser
     name: Mypal
-    short_name: MY
     version: "28.9.0"
     engine: Goanna
     engine_version: "4.5"
@@ -2641,7 +2348,6 @@
   client:
     type: browser
     name: Atom
-    short_name: A0
     version: "6.3.0.4"
     engine: WebKit
     engine_version: "537.36"
@@ -2650,7 +2356,6 @@
   client:
     type: browser
     name: 115 Browser
-    short_name: 1B
     version: "12.0.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2659,7 +2364,6 @@
   client:
     type: browser
     name: Safe Exam Browser
-    short_name: S5
     version: "2.4"
     engine: Gecko
     engine_version: "52.0"
@@ -2668,7 +2372,6 @@
   client:
     type: browser
     name: Colibri
-    short_name: C2
     version: "1.16.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2677,7 +2380,6 @@
   client:
     type: browser
     name: Xvast
-    short_name: XV
     version: "1.1.0.8"
     engine: WebKit
     engine_version: "537.36"
@@ -2686,7 +2388,6 @@
   client:
     type: browser
     name: Tungsten
-    short_name: TU
     version: "2.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2695,7 +2396,6 @@
   client:
     type: browser
     name: Lulumi
-    short_name: LL
     version: "1.3.2"
     engine: WebKit
     engine_version: "537.36"
@@ -2704,7 +2404,6 @@
   client:
     type: browser
     name: Yahoo! Japan Browser
-    short_name: YJ
     version: "1.0.20.0"
     engine: WebKit
     engine_version: "605.1.15"
@@ -2713,7 +2412,6 @@
   client:
     type: browser
     name: Yahoo! Japan Browser
-    short_name: YJ
     version: "1.6.9.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2722,7 +2420,6 @@
   client:
     type: browser
     name: Lunascape
-    short_name: LS
     version: "3251"
     engine: WebKit
     engine_version: "601.1.46"
@@ -2731,7 +2428,6 @@
   client:
     type: browser
     name: Lunascape Lite
-    short_name: LN
     version: "3.2.1"
     engine: WebKit
     engine_version: "533.17.9"
@@ -2740,7 +2436,6 @@
   client:
     type: browser
     name: Polypane
-    short_name: PY
     version: "2.1.2"
     engine: WebKit
     engine_version: "537.36"
@@ -2749,7 +2444,6 @@
   client:
     type: browser
     name: OhHai Browser
-    short_name: HH
     version: "3.3.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2758,7 +2452,6 @@
   client:
     type: browser
     name: Jig Browser Plus
-    short_name: JP
     version: "1.8.2"
     engine: WebKit
     engine_version: "601.1.46"
@@ -2767,7 +2460,6 @@
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "1.1"
     engine: Gecko
     engine_version: ""
@@ -2776,7 +2468,6 @@
   client:
     type: browser
     name: Sizzy
-    short_name: SY
     version: "0.0.21"
     engine: WebKit
     engine_version: "537.36"
@@ -2785,7 +2476,6 @@
   client:
     type: browser
     name: Glass Browser
-    short_name: GB
     version: "0.5.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2794,7 +2484,6 @@
   client:
     type: browser
     name: Avast Secure Browser
-    short_name: AS
     version: "49.0.79.75"
     engine: WebKit
     engine_version: "537.36"
@@ -2803,7 +2492,6 @@
   client:
     type: browser
     name: ToGate
-    short_name: TG
     version: "72.0.3626.109"
     engine: WebKit
     engine_version: "537.36"
@@ -2812,7 +2500,6 @@
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "1.9.0.2"
     engine: WebKit
     engine_version: "537.36"
@@ -2821,7 +2508,6 @@
   client:
     type: browser
     name: Zvu
-    short_name: ZV
     version: "18.0.1"
     engine: Gecko
     engine_version: "18.0"
@@ -2830,7 +2516,6 @@
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "4.1.2.133"
     engine: WebKit
     engine_version: "537.36"
@@ -2839,7 +2524,6 @@
   client:
     type: browser
     name: Blue Browser
-    short_name: BU
     version: "3.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2848,7 +2532,6 @@
   client:
     type: browser
     name: Yaani Browser
-    short_name: YN
     version: "4.3.0.153"
     engine: Blink
     engine_version: ""
@@ -2857,7 +2540,6 @@
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.20.39"
     engine: ""
     engine_version: ""

--- a/Tests/Parser/Devices/NotebookTest.php
+++ b/Tests/Parser/Devices/NotebookTest.php
@@ -24,8 +24,8 @@ class NotebookTest extends TestCase
         $notebookParser = new Notebook();
         $notebookParser->setUserAgent($useragent);
         $this->assertNotNull($notebookParser->parse());
-        $this->assertEquals($device['type'], $notebookParser->getDeviceType());
-        $this->assertEquals($device['brand'], $notebookParser->getBrand());
+        $this->assertEquals($device['type'], Notebook::getDeviceName($notebookParser->getDeviceType()));
+        $this->assertEquals($device['brand'], Notebook::getFullName($notebookParser->getBrand()));
         $this->assertEquals($device['model'], $notebookParser->getModel());
     }
 

--- a/Tests/Parser/Devices/fixtures/notebook.yml
+++ b/Tests/Parser/Devices/fixtures/notebook.yml
@@ -2,6 +2,6 @@
 - 
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.125; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/80VR;FBSN/Windows;FBSV/10.0.16299.371;FBSS/1;FBCR/;FBID/desktop;FBLC/ru_RU;FBOP/45;FBRV/0]'
   device:
-    type: 0
-    brand: LE
+    type: desktop
+    brand: Lenovo
     model: Legion Y720

--- a/Tests/fixtures/bots.yml
+++ b/Tests/fixtures/bots.yml
@@ -583,8 +583,8 @@
   user_agent: coccocbot-web/1.0 (+http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -592,8 +592,8 @@
   user_agent: Mozilla/5.0 (compatible; coccoc/1.0; +http://help.coccoc.com/)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -601,8 +601,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot-ads/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -610,8 +610,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot-fast/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -619,8 +619,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot-image/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -628,8 +628,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot-shopping/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -637,8 +637,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot-web/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -646,8 +646,8 @@
   user_agent: Mozilla/5.0 (compatible; coccocbot/1.0; +http://help.coccoc.com/searchengine)
   bot:
     name: Cốc Cốc Bot
-    category: Search bot
     url: https://help.coccoc.com/en/search-engine/coccoc-robots
+    category: Search bot
     producer:
       name: Cốc Cốc
       url: https://coccoc.com/
@@ -3597,8 +3597,8 @@
   user_agent: zelist.ro feed parser (+http://www.zelist.ro)
   bot:
     name: Ze List
-    category: Feed Fetcher
     url: https://www.zelist.ro/
+    category: Feed Fetcher
     producer:
       name: Treeworks SRL
       url: https://www.tree.ro/

--- a/Tests/fixtures/camera.yml
+++ b/Tests/fixtures/camera.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; COOLPIX S800c Build/CP01_WW) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: camera
-    brand: NN
+    brand: Nikon
     model: Coolpix S800c
   os_family: Android
   browser_family: Android Browser
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; DMC-CM1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: camera
-    brand: PA
+    brand: Panasonic
     model: Lumix DMC-CM1
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0; de-DE; EK-GC100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: camera
-    brand: SA
+    brand: Samsung
     model: GALAXY Camera
   os_family: Android
   browser_family: Android Browser
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; EK-GC100 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.60140
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "15.0.1162.60140"
     engine: Blink
     engine_version: ""
   device:
     type: camera
-    brand: SA
+    brand: Samsung
     model: GALAXY Camera
   os_family: Android
   browser_family: Opera
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; EK-GC200 Build/JSS15J) AppleWebKit/537.36 (KHTML like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: camera
-    brand: SA
+    brand: Samsung
     model: GALAXY Camera 2
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; EK-GC110 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: camera
-    brand: SA
+    brand: Samsung
     model: GALAXY Camera WiFi only
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-nz; SAMSUNG EK-GN120 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: camera
-    brand: SA
+    brand: Samsung
     model: GALAXY NX
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/car_browser.yml
+++ b/Tests/fixtures/car_browser.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CarPad-II-P Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: car browser
-    brand: NS
+    brand: NewsMy
     model: CarPad-II-P
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CarPad-III-P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: car browser
-    brand: NS
+    brand: NewsMy
     model: CarPad-III-P
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (X11; GNU/Linux) AppleWebKit/537.36 (KHTML, like Gecko) Chromium/75.0.3770.100 Chrome/75.0.3770.100 Safari/537.36 Tesla/2019.40.50.7-ad132c7b057e
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Chromium
-    short_name: CR
     version: "75.0.3770.100"
     engine: Blink
     engine_version: ""
   device:
     type: car browser
-    brand: TA
+    brand: Tesla
     model: ""
   os_family: GNU/Linux
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (X11; u; Linux; C) AppleWebKit /533.3 (Khtml, like Gheko) QtCarBrowser Safari/533.3
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: "533.3"
   device:
     type: car browser
-    brand: TA
+    brand: Tesla
     model: Model S
   os_family: GNU/Linux
   browser_family: Safari

--- a/Tests/fixtures/console.yml
+++ b/Tests/fixtures/console.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS GAMEPAD Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: console
-    brand: AR
+    brand: Archos
     model: Gamepad
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; ARCHOS GAMEPAD2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: console
-    brand: AR
+    brand: Archos
     model: Gamepad 2
   os_family: Android
   browser_family: Android Browser
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; Xbox)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: console
-    brand: MS
+    brand: Microsoft
     model: Xbox 360
   os_family: Windows
   browser_family: Internet Explorer
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Xbox; Xbox One)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: console
-    brand: MS
+    brand: Microsoft
     model: Xbox One
   os_family: Windows
   browser_family: Internet Explorer
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; Xbox; Xbox One)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: console
-    brand: MS
+    brand: Microsoft
     model: Xbox One
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Nintendo 3DS; U; ; en) Version/1.7498.EU
   os:
     name: Nintendo Mobile
-    short_name: NDS
     version: "3DS"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: console
-    brand: NI
+    brand: Nintendo
     model: 3DS
   os_family: Mobile Gaming Console
   browser_family: NetFront
@@ -123,19 +111,17 @@
   user_agent: Bunjalloo/0.7.6(Nintendo DS;U;en)
   os:
     name: Nintendo Mobile
-    short_name: NDS
     version: "DS"
     platform: ""
   client:
     type: browser
     name: Bunjalloo
-    short_name: BJ
     version: "0.7.6"
     engine: ""
     engine_version: ""
   device:
     type: console
-    brand: NI
+    brand: Nintendo
     model: DS
   os_family: Mobile Gaming Console
   browser_family: Unknown
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Nintendo Switch; WifiWebAuthApplet) AppleWebKit/601.6 (KHTML, like Gecko) NF/4.0.0.7.9 NintendoBrowser/5.1.0.15785
   os:
     name: Nintendo
-    short_name: WII
     version: "Switch"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: WebKit
     engine_version: "601.6"
   device:
     type: console
-    brand: NI
+    brand: Nintendo
     model: Switch
   os_family: Gaming Console
   browser_family: NetFront
@@ -163,19 +147,17 @@
   user_agent: Opera/9.30 (Nintendo Wii; U; ; 3642; en)
   os:
     name: Nintendo
-    short_name: WII
     version: "Wii"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.30"
     engine: Presto
     engine_version: ""
   device:
     type: console
-    brand: NI
+    brand: Nintendo
     model: Wii
   os_family: Gaming Console
   browser_family: Opera
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Nintendo WiiU) AppleWebKit/534.52 (KHTML, like Gecko) NX/2.1.0.8.21 NintendoBrowser/1.0.0.7494.US
   os:
     name: Nintendo
-    short_name: WII
     version: "Wii"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: WebKit
     engine_version: "534.52"
   device:
     type: console
-    brand: NI
+    brand: Nintendo
     model: WiiU
   os_family: Gaming Console
   browser_family: NetFront
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android OUYA 4.1.2; en-us; OUYA Build/JZO54L-OUYA) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: console
-    brand: OU
+    brand: OUYA
     model: OUYA
   os_family: Android
   browser_family: Android Browser
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (PLAYSTATION 3 4.46) AppleWebKit/531.22.8 (KHTML, like Gecko)
   os:
     name: PlayStation
-    short_name: PS3
     version: "3"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: WebKit
     engine_version: "531.22.8"
   device:
     type: console
-    brand: SO
+    brand: Sony
     model: PlayStation 3
   os_family: Gaming Console
   browser_family: NetFront
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (PlayStation 4 1.52) AppleWebKit/536.26 (KHTML, like Gecko)
   os:
     name: PlayStation
-    short_name: PS3
     version: "4"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: WebKit
     engine_version: "536.26"
   device:
     type: console
-    brand: SO
+    brand: Sony
     model: PlayStation 4
   os_family: Gaming Console
   browser_family: NetFront
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (PlayStation 4 Pro 5.0)
   os:
     name: PlayStation
-    short_name: PS3
     version: "4"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: console
-    brand: SO
+    brand: Sony
     model: PlayStation 4 Pro
   os_family: Gaming Console
   browser_family: NetFront
@@ -283,19 +255,17 @@
   user_agent: Mozilla/4.0 (PlayStation Portable); 2.00)
   os:
     name: PlayStation Portable
-    short_name: PSP
     version: "Portable"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: console
-    brand: SO
+    brand: Sony
     model: PlayStation Portable
   os_family: Mobile Gaming Console
   browser_family: NetFront
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (PlayStation Vita 3.01) AppleWebKit/536.26 (KHTML, like Gecko) Silk/3.2
   os:
     name: PlayStation Portable
-    short_name: PSP
     version: "Vita"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.2"
     engine: WebKit
     engine_version: "536.26"
   device:
     type: console
-    brand: SO
+    brand: Sony
     model: PlayStation Vita
   os_family: Mobile Gaming Console
   browser_family: Chrome

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -3,13 +3,11 @@
   user_agent: Mozilla/6.0 (Macintosh; U; Amiga-AWeb) Safari 3.1
   os:
     name: AmigaOS
-    short_name: AMG
     version: ""
     platform: ""
   client:
     type: browser
     name: Amiga Aweb
-    short_name: AW
     version: ""
     engine: ""
     engine_version: ""
@@ -23,13 +21,11 @@
   user_agent: AmigaVoyager/3.2 (AmigaOS/MC680x0)
   os:
     name: AmigaOS
-    short_name: AMG
     version: ""
     platform: ""
   client:
     type: browser
     name: Amiga Voyager
-    short_name: AV
     version: "3.2"
     engine: ""
     engine_version: ""
@@ -43,7 +39,6 @@
   user_agent: Mozilla/5.0 (AmigaOS; U; AmigaOS 1.3; en-US; rv:1.8.1.21) Gecko/20090303 SeaMonkey/1.1.15
   os:
     name: AmigaOS
-    short_name: AMG
     version: "1.3"
     platform: ""
   client:
@@ -60,13 +55,11 @@
   user_agent: IBrowse/2.4 (AmigaOS 3.9; 68K)
   os:
     name: AmigaOS
-    short_name: AMG
     version: "3.9"
     platform: ""
   client:
     type: browser
     name: IBrowse
-    short_name: IB
     version: "2.4"
     engine: ""
     engine_version: ""
@@ -80,13 +73,11 @@
   user_agent: Mozilla/5.0 (compatible; IBrowse 3.0; AmigaOS4.0)
   os:
     name: AmigaOS
-    short_name: AMG
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: IBrowse
-    short_name: IB
     version: "3.0"
     engine: ""
     engine_version: ""
@@ -100,13 +91,11 @@
   user_agent: Mozilla/5.0 ArchLinux (X11; U; Linux x86_64; en-US) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/12.0.742.100 Safari/534.30
   os:
     name: Arch Linux
-    short_name: ARL
     version: ""
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "12.0.742.100"
     engine: WebKit
     engine_version: "534.30"
@@ -120,13 +109,11 @@
   user_agent: Mozilla/5.0 (X11; Arch Linux i686; rv:2.0) Gecko/20110321 Firefox/4.0
   os:
     name: Arch Linux
-    short_name: ARL
     version: ""
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "4.0"
     engine: Gecko
     engine_version: "2.0"
@@ -140,13 +127,11 @@
   user_agent: Mozilla/5 (X11; Linux x86_64) AppleWebKit/537.4 (KHTML like Gecko) Arch Linux Firefox/23.0 Xfce
   os:
     name: Arch Linux
-    short_name: ARL
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "23.0"
     engine: Gecko
     engine_version: ""
@@ -160,13 +145,11 @@
   user_agent: Mozilla/3.0 (compatible; NetPositive/2.2.1; BeOS)
   os:
     name: BeOS
-    short_name: BEO
     version: ""
     platform: ""
   client:
     type: browser
     name: NetPositive
-    short_name: NP
     version: "2.2.1"
     engine: ""
     engine_version: ""
@@ -180,13 +163,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686 (x86_64); en-US; rv:1.9.0.6) Gecko/2009020414 CentOS/3.0.6-1.el5.centos Firefox/3.0.6
   os:
     name: CentOS
-    short_name: CES
     version: "3.0.6"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.6"
     engine: Gecko
     engine_version: "1.9.0.6"
@@ -200,13 +181,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.13) Gecko/20101209 CentOS/3.6-2.el5.centos Firefox/3.6.13
   os:
     name: CentOS
-    short_name: CES
     version: "3.6"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.13"
     engine: Gecko
     engine_version: "1.9.2.13"
@@ -220,13 +199,11 @@
   user_agent: Mozilla/5.0 (X11; CrOS x86_64 4731.101.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.67 Safari/537.36
   os:
     name: Chrome OS
-    short_name: COS
     version: "31.0.1650.67"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.67"
     engine: Blink
     engine_version: ""
@@ -240,13 +217,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; fr-fr) AppleWebKit/531.2+ (KHTML, like Gecko) Version/5.0 Safari/531.2+ Debian/squeeze (2.30.6-1) Epiphany/2.30.6
   os:
     name: Debian
-    short_name: DEB
     version: ""
     platform: x86
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "2.30.6"
     engine: WebKit
     engine_version: "531.2"
@@ -260,13 +235,11 @@
   user_agent: Mozilla/5.0 (X11; Intel Mac OS X) AppleWebKit/538.1 (KHTML, like Gecko) Safari/538.1 debian/unstable (3.8.2-5) Epiphany/3.8.2
   os:
     name: Debian
-    short_name: DEB
     version: ""
     platform: ""
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "3.8.2"
     engine: WebKit
     engine_version: "538.1"
@@ -280,13 +253,11 @@
   user_agent: Mozilla/5.0 (compatible; Konqueror/3.5; Linux; de) KHTML/3.5.8 (like Gecko) (Debian)
   os:
     name: Debian
-    short_name: DEB
     version: ""
     platform: ""
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "3.5"
     engine: KHTML
     engine_version: "3.5.8"
@@ -300,13 +271,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20131030 conkeror/1.0pre (Debian-1.0~~pre+git131116-1)
   os:
     name: Debian
-    short_name: DEB
     version: "1.0"
     platform: x64
   client:
     type: browser
     name: Conkeror
-    short_name: CK
     version: "1.0"
     engine: Gecko
     engine_version: "17.0"
@@ -320,13 +289,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.0.15) Gecko/2009102815 Iceweasel/3.0.6 (Debian-3.0.6-3)
   os:
     name: Debian
-    short_name: DEB
     version: "3.0.6"
     platform: x86
   client:
     type: browser
     name: Iceweasel
-    short_name: IW
     version: "3.0.6"
     engine: Gecko
     engine_version: "1.9.0.15"
@@ -340,13 +307,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux sparc64; es-PY; rv:5.0) Gecko/20100101 IceCat/5.0 (like Firefox/5.0; Debian-6.0.1)
   os:
     name: Debian
-    short_name: DEB
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: IceCat
-    short_name: I4
     version: "5.0"
     engine: Gecko
     engine_version: "5.0"
@@ -360,13 +325,11 @@
   user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/535.22+ (KHTML, like Gecko) Chromium/17.0.963.56 Chrome/17.0.963.56 Safari/535.22+ Debian/7.0 (3.4.2-2.1) Epiphany/3.4.2
   os:
     name: Debian
-    short_name: DEB
     version: "7.0"
     platform: x86
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "3.4.2"
     engine: WebKit
     engine_version: "535.22"
@@ -380,13 +343,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/535.22+ (KHTML, like Gecko) Chromium/17.0.963.56 Chrome/17.0.963.56 Safari/535.22+ Debian/7.0 (3.4.2-2.1) Epiphany/3.4.2
   os:
     name: Debian
-    short_name: DEB
     version: "7.0"
     platform: x64
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "3.4.2"
     engine: WebKit
     engine_version: "535.22"
@@ -400,13 +361,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.8) Gecko Fedora/1.9.0.8-1.fc10 Kazehakase/0.5.6
   os:
     name: Fedora
-    short_name: FED
     version: "1.9.0.8"
     platform: x86
   client:
     type: browser
     name: Kazehakase
-    short_name: KZ
     version: "0.5.6"
     engine: Gecko
     engine_version: ""
@@ -420,13 +379,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.8) Gecko/20071019 Fedora/2.0.0.8-1.fc7 Firefox/2.0.0.8
   os:
     name: Fedora
-    short_name: FED
     version: "2.0.0.8"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "2.0.0.8"
     engine: Gecko
     engine_version: "1.8.1.8"
@@ -440,13 +397,11 @@
   user_agent: Mozilla/5.0 (compatible; Konqueror/4.1; Linux 2.6.27.7-134.fc10.x86_64; X11; x86_64) KHTML/4.1.3 (like Gecko) Fedora/4.1.3-4.fc10
   os:
     name: Fedora
-    short_name: FED
     version: "4.1.3"
     platform: x64
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "4.1"
     engine: KHTML
     engine_version: "4.1.3"
@@ -460,13 +415,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) KHTML/4.11.4 (like Gecko) Konqueror/4.11 Fedora/4.11.4-1.fc19
   os:
     name: Fedora
-    short_name: FED
     version: "4.11.4"
     platform: x64
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "4.11"
     engine: KHTML
     engine_version: "4.11.4"
@@ -480,13 +433,11 @@
   user_agent: Mozilla/5.0 (X11; FreeBSD amd64; rv:25.0) Gecko/20100101 Firefox/25.0
   os:
     name: FreeBSD
-    short_name: BSD
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "25.0"
     engine: Gecko
     engine_version: "25.0"
@@ -500,13 +451,11 @@
   user_agent: Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.7.12) Gecko/20051105 Galeon/1.3.21
   os:
     name: FreeBSD
-    short_name: BSD
     version: ""
     platform: x86
   client:
     type: browser
     name: Galeon
-    short_name: GA
     version: "1.3.21"
     engine: Gecko
     engine_version: "1.7.12"
@@ -520,13 +469,11 @@
   user_agent: Mozilla/5.0 (X11; U; FreeBSD i386; en-US; rv:1.8.1.18) Gecko/20081206 Firefox/2.0.0.18 Kazehakase/0.5.4
   os:
     name: FreeBSD
-    short_name: BSD
     version: ""
     platform: x86
   client:
     type: browser
     name: Kazehakase
-    short_name: KZ
     version: "0.5.4"
     engine: Gecko
     engine_version: "1.8.1.18"
@@ -540,7 +487,6 @@
   user_agent: Mozilla/3.0 (WorldGate Gazelle 3.5.1 build 11; FreeBSD2.2.8-STABLE)
   os:
     name: FreeBSD
-    short_name: BSD
     version: "2.2.8"
     platform: ""
   client: null
@@ -554,13 +500,11 @@
   user_agent: Mozilla/5.0 (X11; U; Gentoo x86_64; de-DE) Firefox/26.0
   os:
     name: Gentoo
-    short_name: GNT
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: ""
@@ -574,13 +518,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.7) Gecko/2009031915 Gentoo Firefox/3.0.7
   os:
     name: Gentoo
-    short_name: GNT
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.7"
     engine: Gecko
     engine_version: "1.9.0.7"
@@ -594,13 +536,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:25.0) Gecko/20100101 conkeror/1.0pre
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Conkeror
-    short_name: CK
     version: "1.0"
     engine: Gecko
     engine_version: "25.0"
@@ -614,13 +554,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9a3pre) Gecko/20070301 Minefield/3.0a3pre
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0"
     engine: Gecko
     engine_version: "1.9"
@@ -634,13 +572,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.0.11) Gecko GranParadiso/3.0.11
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.11"
     engine: Gecko
     engine_version: ""
@@ -654,13 +590,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.1b5pre) Gecko/20090424 Shiretoko/3.5b5pre
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5"
     engine: Gecko
     engine_version: "1.9.1"
@@ -674,13 +608,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; en; rv:2.0) Gecko/20100101 Firefox/4.0
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "4.0"
     engine: Gecko
     engine_version: "2.0"
@@ -694,13 +626,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:17.0) Gecko/20131030 Firefox/17.0 Iceweasel/17.0.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Iceweasel
-    short_name: IW
     version: "17.0.10"
     engine: Gecko
     engine_version: "17.0"
@@ -714,13 +644,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) KHTML/4.8.5 (like Gecko) Mageia Konqueror/4.8
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "4.8"
     engine: KHTML
     engine_version: "4.8.5"
@@ -734,13 +662,11 @@
   user_agent: Links (2.1pre23; Linux 3.5.0 i686; 237x63)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Links
-    short_name: LI
     version: "2.1"
     engine: Text-based
     engine_version: ""
@@ -754,13 +680,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux armv7l; en-GB; rv:1.9.2a1pre) Gecko/20090514 Firefox/3.0 Tablet browser 0.9.7 RX-34
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: MicroB
-    short_name: MB
     version: "0.9.7"
     engine: Gecko
     engine_version: "1.9.2"
@@ -774,13 +698,11 @@
   user_agent: Mozilla/5.0 (X11; Linux) AppleWebKit/535.22 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/535.22 Midori/0.5
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Midori
-    short_name: MI
     version: "0.5"
     engine: WebKit
     engine_version: "535.22"
@@ -794,13 +716,11 @@
   user_agent: Mozilla/5.0 (X11; Linux) AppleWebKit/538.1 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/538.1 Midori/0.5
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Midori
-    short_name: MI
     version: "0.5"
     engine: WebKit
     engine_version: "538.1"
@@ -814,13 +734,11 @@
   user_agent: NCSA_Mosaic/2.7b5 (X11;Linux 2.6.7 i686) libwww/2.12 modified
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: NCSA Mosaic
-    short_name: MC
     version: "2.7"
     engine: ""
     engine_version: ""
@@ -834,13 +752,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux 2.4.2-2 i586; en-US; m18) Gecko/20010131 Netscape6/6.01
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Netscape
-    short_name: NS
     version: "6.01"
     engine: Gecko
     engine_version: ""
@@ -854,13 +770,11 @@
   user_agent: Opera/9.80 (X11; Linux zbov) Presto/2.11.355 Version/12.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.11.355"
@@ -874,13 +788,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.2b) Gecko/20021029 Phoenix/0.4
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Phoenix
-    short_name: PX
     version: "0.4"
     engine: Gecko
     engine_version: "1.2"
@@ -894,13 +806,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) rekonq/2.3.2 Safari/537.21
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Rekonq
-    short_name: RK
     version: "2.3.2"
     engine: WebKit
     engine_version: "537.21"
@@ -914,7 +824,6 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:29.0) Gecko/20100101 Firefox/29.0 SeaMonkey/2.26a1 Lightning/3.1a1
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
@@ -931,7 +840,6 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64; rv:10.0.12) Gecko/20130823 Firefox/10.0.11esrpre Iceape/2.7.12
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
@@ -948,13 +856,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) Snowshoe/1.0.0 Safari/537.21
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Snowshoe
-    short_name: SN
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.21"
@@ -968,13 +874,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1) Gecko/20061024 Firefox/2.0 (Swiftfox)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Swiftfox
-    short_name: SX
     version: "2.0"
     engine: Gecko
     engine_version: "1.8.1"
@@ -988,7 +892,6 @@
   user_agent: Mozilla/5.0 (X11; Linux i686; rv:17.0) Gecko/20130330 Thunderbird/17.0.5
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
@@ -1005,13 +908,11 @@
   user_agent: Mozilla/5.0 (BeOS; U; Haiku BePC; en-US; rv:1.8.1.21pre) Gecko/20090218 BonEcho/2.0.0.21pre
   os:
     name: Haiku OS
-    short_name: HAI
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "2.0.0.21"
     engine: Gecko
     engine_version: "1.8.1.21"
@@ -1025,13 +926,11 @@
   user_agent: Mozilla/5.0 (compatible; U; Webpositive/533.4; Haiku) AppleWebkit/533.4 (KHTML, like gecko) Chrome/5.0.375.55 Safari/533.4
   os:
     name: Haiku OS
-    short_name: HAI
     version: ""
     platform: ""
   client:
     type: browser
     name: WebPositive
-    short_name: WE
     version: ""
     engine: WebKit
     engine_version: "533.4"
@@ -1045,13 +944,11 @@
   user_agent: Mozilla/4.08 (Charon; Inferno)
   os:
     name: Inferno
-    short_name: INF
     version: ""
     platform: ""
   client:
     type: browser
     name: Charon
-    short_name: CX
     version: ""
     engine: ""
     engine_version: ""
@@ -1065,7 +962,6 @@
   user_agent: 'Mozilla/4.04 [en] (X11; I; IRIX 5.3 IP22)'
   os:
     name: IRIX
-    short_name: IRI
     version: "5.3"
     platform: ""
   client: null
@@ -1079,13 +975,11 @@
   user_agent: Mozilla/5.0 (compatible; Konqueror/3.5; Linux) KHTML/3.5.5 (like Gecko) (Kubuntu)
   os:
     name: Kubuntu
-    short_name: KBT
     version: ""
     platform: ""
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "3.5"
     engine: KHTML
     engine_version: "3.5.5"
@@ -1099,13 +993,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.0.1) Gecko/2008072820 Kubuntu/8.04 (hardy) Firefox/3.0.1
   os:
     name: Kubuntu
-    short_name: KBT
     version: "8.04"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.1"
     engine: Gecko
     engine_version: "1.9.0.1"
@@ -1119,13 +1011,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.17) Gecko/20110429 Mandriva Linux/1.9.2.17-0.1mdv2010.0 (2010.0) Firefox/3.6.17
   os:
     name: Mandriva
-    short_name: MDR
     version: "1.9.2.17"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.17"
     engine: Gecko
     engine_version: "1.9.2.17"
@@ -1139,13 +1029,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; es-ES; rv:2.0) Gecko/20100101 Linux Mint 16/Petra Firefox/25.0.1.
   os:
     name: Mint
-    short_name: MIN
     version: "16"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "25.0.1"
     engine: Gecko
     engine_version: "2.0"
@@ -1159,13 +1047,11 @@
   user_agent: Mozilla/5.0 (Macintosh; PowerPC MorphOS 3.7; Odyssey Web Browser; rv:1.23) AppleWebKit/538.1 (KHTML, like Gecko) OWB/1.23 Safari/538.1
   os:
     name: MorphOS
-    short_name: MOR
     version: "3.7"
     platform: ""
   client:
     type: browser
     name: Odyssey Web Browser
-    short_name: OD
     version: "1.23"
     engine: WebKit
     engine_version: "538.1"
@@ -1179,13 +1065,11 @@
   user_agent: Mozilla/5.0 (X11; U; NetBSD amd64; fr-FR; rv:1.8.0.7) Gecko/20061102 Firefox/1.5.0.7
   os:
     name: NetBSD
-    short_name: NBS
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "1.5.0.7"
     engine: Gecko
     engine_version: "1.8.0.7"
@@ -1199,13 +1083,11 @@
   user_agent: Mozilla/5.0 (X11; OpenBSD amd64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.45 Safari/537.36
   os:
     name: OpenBSD
-    short_name: OBS
     version: ""
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.45"
     engine: Blink
     engine_version: ""
@@ -1219,13 +1101,11 @@
   user_agent: Mozilla/5.0 (X11; OpenBSD amd64; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: OpenBSD
-    short_name: OBS
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -1239,13 +1119,11 @@
   user_agent: Mozilla/5.0 (OS/2; Warp 4.5; rv:10.0.12) Gecko/20100101 Firefox/10.0.12
   os:
     name: OS/2
-    short_name: OS2
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "10.0.12"
     engine: Gecko
     engine_version: "10.0.12"
@@ -1259,7 +1137,6 @@
   user_agent: Mozilla/3.0 (X11; I; OSF1 V4.0 alpha)
   os:
     name: OSF1
-    short_name: T64
     version: "4.0"
     platform: ""
   client: null
@@ -1273,7 +1150,6 @@
   user_agent: 'Mozilla/4.75C-ja [ja] (X11; U; OSF1 V5.1 alpha)'
   os:
     name: OSF1
-    short_name: T64
     version: "5.1"
     platform: ""
   client: null
@@ -1287,7 +1163,6 @@
   user_agent: Wget/1.11.4 Red Hat modified
   os:
     name: Red Hat
-    short_name: RHT
     version: ""
     platform: ""
   client:
@@ -1304,13 +1179,11 @@
   user_agent: Mozilla/5.0 (compatible; Konqueror/4.3; Linux) KHTML/4.3.4 (like Gecko) Red Hat Enterprise Linux/4.3.4-19.el6
   os:
     name: Red Hat
-    short_name: RHT
     version: "4.3.4"
     platform: ""
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "4.3"
     engine: KHTML
     engine_version: "4.3.4"
@@ -1324,13 +1197,11 @@
   user_agent: Opera/9.80 (X11; Linux x86_64; Sabayon) Presto/2.12.388 Version/12.16
   os:
     name: Sabayon
-    short_name: SAB
     version: ""
     platform: x64
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.16"
     engine: Presto
     engine_version: "2.12.388"
@@ -1344,13 +1215,11 @@
   user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.30 (KHTML, like Gecko) Slackware/Chrome/12.0.742.100 Safari/534.30
   os:
     name: Slackware
-    short_name: SLW
     version: ""
     platform: x86
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "12.0.742.100"
     engine: WebKit
     engine_version: "534.30"
@@ -1364,13 +1233,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.1.2) Gecko/20090729 Slackware/13.0 Firefox/3.5.2
   os:
     name: Slackware
-    short_name: SLW
     version: "13.0"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5.2"
     engine: Gecko
     engine_version: "1.9.1.2"
@@ -1384,13 +1251,11 @@
   user_agent: Mozilla/5.0 (X11; U; SunOS i86pc; en-US; rv:1.9.1.9) Gecko/20100525 Firefox/3.5.9
   os:
     name: Solaris
-    short_name: SOS
     version: ""
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5.9"
     engine: Gecko
     engine_version: "1.9.1.9"
@@ -1404,7 +1269,6 @@
   user_agent: 'Mozilla/4.79 [en] (X11; U; SunOS 5.10 i86pc)'
   os:
     name: Solaris
-    short_name: SOS
     version: "5.10"
     platform: x86
   client: null
@@ -1418,13 +1282,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 5.0; SunOS 5.10 sun4u; X11)
   os:
     name: Solaris
-    short_name: SOS
     version: "5.10"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "5.0"
     engine: Trident
     engine_version: ""
@@ -1438,7 +1300,6 @@
   user_agent: Mozilla/5.0 (X11; U; Linux x86_64; en-US; rv:1.9.1.8) Gecko/20100215 Solaris/10.1 (GNU) Superswan/3.5.8 (Byte/me)
   os:
     name: Solaris
-    short_name: SOS
     version: "10.1"
     platform: x64
   client: null
@@ -1452,7 +1313,6 @@
   user_agent: Mozilla/3.01Gold (X11; I; SunOS 5.5.1 sun4m)
   os:
     name: Solaris
-    short_name: SOS
     version: "5.5.1"
     platform: ""
   client: null
@@ -1466,13 +1326,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.24) Gecko/20111101 SUSE/3.6.24-0.2.1 Firefox/3.6.24
   os:
     name: SUSE
-    short_name: SSE
     version: "3.6.24"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.24"
     engine: Gecko
     engine_version: "1.9.2.24"
@@ -1486,13 +1344,11 @@
   user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 SUSE/31.0.1650.63
   os:
     name: SUSE
-    short_name: SSE
     version: "31.0.1650.63"
     platform: x86
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
@@ -1506,13 +1362,11 @@
   user_agent: Mozilla/5.0 (compatible; U; ABrowse 0.6; Syllable) AppleWebKit/420+ (KHTML, like Gecko)
   os:
     name: Syllable
-    short_name: SYL
     version: ""
     platform: ""
   client:
     type: browser
     name: ABrowse
-    short_name: AB
     version: "0.6"
     engine: WebKit
     engine_version: "420"
@@ -1526,13 +1380,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Ubuntu Chromium/31.0.1650.63 Chrome/31.0.1650.63 Safari/537.36
   os:
     name: Ubuntu
-    short_name: UBT
     version: ""
     platform: x64
   client:
     type: browser
     name: Chromium
-    short_name: CR
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
@@ -1546,13 +1398,11 @@
   user_agent: ELinks/0.12~pre6-1ubuntu1 (textmode; Ubuntu; Linux 3.11.0-13-generic i686; 100x25-2)
   os:
     name: Ubuntu
-    short_name: UBT
     version: ""
     platform: x86
   client:
     type: browser
     name: Elinks
-    short_name: EL
     version: "0.12"
     engine: Text-based
     engine_version: ""
@@ -1566,13 +1416,11 @@
   user_agent: Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Ubuntu
-    short_name: UBT
     version: ""
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -1586,7 +1434,6 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.8.1.13) Gecko/20080313 SeaMonkey/1.1.9 (Ubuntu-1.1.9+nobinonly-0ubuntu1)
   os:
     name: Ubuntu
-    short_name: UBT
     version: "1.1.9"
     platform: x86
   client:
@@ -1603,13 +1450,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; ru; rv:1.9.0.14) Gecko/2009090216 Ubuntu/9.04 (jaunty) Firefox/3.0.14
   os:
     name: Ubuntu
-    short_name: UBT
     version: "9.04"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.14"
     engine: Gecko
     engine_version: "1.9.0.14"
@@ -1623,13 +1468,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; de; rv:1.9.1.6) Gecko/20091215 Ubuntu/9.10 (karmic) Firefox/3.5.6
   os:
     name: Ubuntu
-    short_name: UBT
     version: "9.10"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5.6"
     engine: Gecko
     engine_version: "1.9.1.6"
@@ -1643,13 +1486,11 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; it-IT; rv:1.9.0.2) Gecko/2008092313 Ubuntu/9.25 (jaunty) Firefox/3.8
   os:
     name: Ubuntu
-    short_name: UBT
     version: "9.25"
     platform: x86
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.8"
     engine: Gecko
     engine_version: "1.9.0.2"
@@ -1663,13 +1504,11 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ Ubuntu/10.10 (2.30.6-1ubuntu5) Epiphany/2.30.6
   os:
     name: Ubuntu
-    short_name: UBT
     version: "10.10"
     platform: x64
   client:
     type: browser
     name: GNOME Web
-    short_name: EP
     version: "2.30.6"
     engine: WebKit
     engine_version: "534.26"
@@ -1683,13 +1522,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Win9x; en; Stable) Gecko/20020911 Beonex/0.8.1-stable
   os:
     name: Windows
-    short_name: WIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Beonex
-    short_name: BE
     version: "0.8.1"
     engine: Gecko
     engine_version: ""
@@ -1703,13 +1540,11 @@
   user_agent: 'Mozilla/4.61 [en] (X11; U; ) - BrowseX (2.0.0 Windows)'
   os:
     name: Windows
-    short_name: WIN
     version: ""
     platform: ""
   client:
     type: browser
     name: BrowseX
-    short_name: BX
     version: "2.0.0"
     engine: ""
     engine_version: ""
@@ -1723,7 +1558,6 @@
   user_agent: Postbox 1.0b14 (Windows/2009072715)
   os:
     name: Windows
-    short_name: WIN
     version: ""
     platform: ""
   client:
@@ -1740,13 +1574,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.74 Safari/537.36 MRCHROME
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Amigo
-    short_name: AO
     version: "28.0.1500.74"
     engine: Blink
     engine_version: ""
@@ -1760,13 +1592,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.4.9999.1900 Safari/537.31 BDSpark/26.4
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Baidu Spark
-    short_name: BS
     version: "26.4"
     engine: WebKit
     engine_version: "537.31"
@@ -1780,13 +1610,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.30 (KHTML, like Gecko) Chrome/26.0.1403.0 Safari/537.30
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1403.0"
     engine: WebKit
     engine_version: "537.30"
@@ -1800,13 +1628,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36 Squider/0.01
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "27.0.1453.110"
     engine: WebKit
     engine_version: "537.36"
@@ -1820,13 +1646,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
@@ -1840,13 +1664,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Bridge/2020.3.2 Chrome/69.0.3497.128 Electron/4.2.12 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.128"
     engine: Blink
     engine_version: ""
@@ -1860,13 +1682,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; chromeframe/19.0.1084.52)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Chrome Frame
-    short_name: CF
     version: "19.0.1084.52"
     engine: WebKit
     engine_version: ""
@@ -1880,13 +1700,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US) AppleWebKit/534.13 (KHTML, like Gecko) Chrome/9.0.597.98 Safari/534.13 ChromePlus/1.6.0.0
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: ChromePlus
-    short_name: CP
     version: "1.6.0.0"
     engine: WebKit
     engine_version: "534.13"
@@ -1900,13 +1718,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.11 (KHTML, like Gecko) Comodo_Dragon/17.1.0.0 Chrome/17.0.963.38 Safari/535.11
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Comodo Dragon
-    short_name: CD
     version: "17.1.0.0"
     engine: WebKit
     engine_version: "535.11"
@@ -1920,13 +1736,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/535.7 (KHTML, like Gecko) Chrome/16.0.912.63 Safari/535.7 CoolNovo/1.6.5.28
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: CoolNovo
-    short_name: CN
     version: "1.6.5.28"
     engine: WebKit
     engine_version: "535.7"
@@ -1940,13 +1754,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -1960,13 +1772,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.13) Gecko/20110504 Namoroka/3.6.13
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.13"
     engine: Gecko
     engine_version: "1.9.2.13"
@@ -1980,13 +1790,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; en-US; rv:1.9.2.3pre) Gecko/20100403 Lorentz/3.6.3plugin2pre (.NET CLR 4.0.20506)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.6.3"
     engine: Gecko
     engine_version: "1.9.2.3"
@@ -2000,13 +1808,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.1; pl; rv:1.9.0.16) Gecko/2010021013 Firefox/3.0.16 Flock/2.5.6
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Flock
-    short_name: FL
     version: "2.5.6"
     engine: Gecko
     engine_version: "1.9.0.16"
@@ -2020,13 +1826,11 @@
   user_agent: GOGGalaxyClient/2.0.20.39 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win7 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.20.39"
     engine: ""
     engine_version: ""
@@ -2040,13 +1844,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; rv:26.0) Gecko/20100101 Firefox/26.0 IceDragon/26.0.0.2
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: IceDragon
-    short_name: ID
     version: "26.0.0.2"
     engine: Gecko
     engine_version: "26.0"
@@ -2060,13 +1862,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; OfficeLiveConnector.1.4; OfficeLivePatch.1.3)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
@@ -2080,13 +1880,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; InfoPath.3; Corpo delle capitanerie di porto)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
@@ -2100,13 +1898,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; BOIE9;ENUS)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -2120,13 +1916,11 @@
   user_agent: 'Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0)69706759&#039;%20or%208056%3d8057--%20'
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -2140,13 +1934,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -2160,13 +1952,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
@@ -2180,13 +1970,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; Banca Caboto s.p.a.; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
@@ -2200,13 +1988,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
@@ -2220,13 +2006,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Iron/26.0.1450.0 Chrome/26.0.1450.0 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Iron
-    short_name: IR
     version: "26.0.1450.0"
     engine: WebKit
     engine_version: "537.36"
@@ -2240,7 +2024,6 @@
   user_agent: Microsoft Office/14.0 (Windows NT 6.1; Microsoft Outlook 14.0.6106; Pro; ms-office; MSOffice 14)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
@@ -2257,7 +2040,6 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Win64; x64; Trident/7.0; .NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; InfoPath.3; .NET CLR 1.1.4322; FDM; Tablet PC 2.0; .NET4.0E; Microsoft Outlook 14.0.7113; ms-office; MSOffice 14)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
@@ -2274,7 +2056,6 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E; InfoPath.3; IM-2014-026; IM-2014-043; Microsoft Outlook 14.0.7113; ms-office; MSOffice 14)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
@@ -2291,13 +2072,11 @@
   user_agent: Opera/9.80 (Windows NT 6.1; WOW64) Presto/2.12.388 Version/12.16
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.16"
     engine: Presto
     engine_version: "2.12.388"
@@ -2311,13 +2090,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1284.49
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "18.0.1284.49"
     engine: Blink
     engine_version: ""
@@ -2331,13 +2108,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.21 Safari/537.36 MMS/1.0.2459.0
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Opera Neon
-    short_name: OG
     version: "1.0.2459.0"
     engine: Blink
     engine_version: ""
@@ -2351,13 +2126,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML like Gecko) Chrome/33.0.1750.91 Safari/537.36 OPR/20.0.1387.37 (Edition Next-Campaign 21)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "20.0.1387.37"
     engine: Blink
     engine_version: ""
@@ -2371,7 +2144,6 @@
   user_agent: QuickTime E-/7.7.5 (qtver=7.7.5;os=Windows NT 6.1)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
@@ -2388,13 +2160,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/535.7 (KHTML, like Gecko) RockMelt/0.16.91.483 Chrome/16.0.912.77 Safari/535.7
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: RockMelt
-    short_name: RM
     version: "0.16.91.483"
     engine: WebKit
     engine_version: "535.7"
@@ -2408,13 +2178,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; Trident/6.0; Sleipnir/2.9.18)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Sleipnir
-    short_name: SL
     version: "2.9.18"
     engine: Trident
     engine_version: "6.0"
@@ -2428,13 +2196,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 9.0; Windows NT 6.1; SV1; SE 2.x)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Sogou Explorer
-    short_name: SE
     version: "2"
     engine: ""
     engine_version: ""
@@ -2448,13 +2214,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 SE 2.X MetaSr 1.0
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Sogou Explorer
-    short_name: SE
     version: "2"
     engine: WebKit
     engine_version: "537.36"
@@ -2468,13 +2232,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Whale/0.7.33.5 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Whale Browser
-    short_name: WH
     version: "0.7.33.5"
     engine: Blink
     engine_version: ""
@@ -2488,13 +2250,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.43 Spark/2.x Safari/537.31
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Baidu Spark
-    short_name: BS
     version: "2"
     engine: WebKit
     engine_version: "537.31"
@@ -2508,13 +2268,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.17 (KHTML, like Gecko) Chrome/24.0.1312.57 Safari/537.17
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "24.0.1312.57"
     engine: WebKit
     engine_version: "537.17"
@@ -2528,13 +2286,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:11.0) Gecko/20100101 Firefox/11.0 CometBird/11.0
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: CometBird
-    short_name: CO
     version: "11.0"
     engine: Gecko
     engine_version: "11.0"
@@ -2548,13 +2304,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -2568,13 +2322,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:25.0) Gecko/20100101 Firefox/25.0 IceDragon/25.0.0.1
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: IceDragon
-    short_name: ID
     version: "25.0.0.1"
     engine: Gecko
     engine_version: "25.0"
@@ -2588,13 +2340,11 @@
   user_agent: Opera/9.80 (Windows NT 6.2; U; Edition Next; ru) Presto/2.11 Version/12.50
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: ""
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "12.50"
     engine: Presto
     engine_version: "2.11"
@@ -2608,13 +2358,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.20 Safari/537.36 OPR/15.0.1147.18 (Edition Next)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "15.0.1147.18"
     engine: Blink
     engine_version: ""
@@ -2628,13 +2376,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; Win64; x64; rv:24.0) Gecko/20140129 Firefox/24.0 PaleMoon/24.3.1
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Pale Moon
-    short_name: PM
     version: "24.3.1"
     engine: Gecko
     engine_version: "24.0"
@@ -2648,13 +2394,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.5.1 Chrome/40.0.2214.115 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: ""
   client:
     type: browser
     name: QtWebEngine
-    short_name: QW
     version: "5.5.1"
     engine: WebKit
     engine_version: "537.36"
@@ -2668,7 +2412,6 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64; rv:20.0) Gecko/20100101 Firefox/20.0 SeaMonkey/2.17.1
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
@@ -2685,13 +2428,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.95 YaBrowser/13.10.1500.9323 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "13.10.1500.9323"
     engine: Blink
     engine_version: ""
@@ -2705,13 +2446,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.76 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.76"
     engine: Blink
     engine_version: ""
@@ -2725,13 +2464,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -2745,13 +2482,11 @@
   user_agent: Mozilla/5.0 (IE 11.0; Windows NT 6.3; Trident/7.0; .NET4.0E; .NET4.0C; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
@@ -2765,13 +2500,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36 OPR/18.0.1284.68
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "18.0.1284.68"
     engine: Blink
     engine_version: ""
@@ -2785,13 +2518,11 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Bridge/2020.2.1 Chrome/69.0.3497.128 Electron/4.2.12 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.128"
     engine: Blink
     engine_version: ""
@@ -2805,13 +2536,11 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Bridge/2020.2.3 Chrome/69.0.3497.128 Electron/4.2.12 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.128"
     engine: Blink
     engine_version: ""
@@ -2825,13 +2554,11 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Bridge/2020.3.1 Chrome/69.0.3497.128 Electron/4.2.12 Safari/537.36
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.128"
     engine: Blink
     engine_version: ""
@@ -2845,13 +2572,11 @@
   user_agent: GOGGalaxyClient/2.0.13.184 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.13.184"
     engine: ""
     engine_version: ""
@@ -2865,13 +2590,11 @@
   user_agent: GOGGalaxyClient/2.0.14.254 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.14.254"
     engine: ""
     engine_version: ""
@@ -2885,13 +2608,11 @@
   user_agent: GOGGalaxyClient/2.0.15.43 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.15.43"
     engine: ""
     engine_version: ""
@@ -2905,13 +2626,11 @@
   user_agent: GOGGalaxyClient/2.0.16.187 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.16.187"
     engine: ""
     engine_version: ""
@@ -2925,13 +2644,11 @@
   user_agent: GOGGalaxyClient/2.0.17.61 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.17.61"
     engine: ""
     engine_version: ""
@@ -2945,13 +2662,11 @@
   user_agent: GOGGalaxyClient/2.0.18.56 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.18.56"
     engine: ""
     engine_version: ""
@@ -2965,13 +2680,11 @@
   user_agent: GOGGalaxyClient/2.0.19.37 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.19.37"
     engine: ""
     engine_version: ""
@@ -2985,13 +2698,11 @@
   user_agent: GOGGalaxyClient/2.0.20.39 (GOG Galaxy) 83b6745cff679691b69876bc7ee33e05e5d90bda (win10 x64)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
     type: browser
     name: GOG Galaxy
-    short_name: GO
     version: "2.0.20.39"
     engine: ""
     engine_version: ""
@@ -3005,7 +2716,6 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 10.0; WOW64; Trident/8.0; .NET4.0C; .NET4.0E; .NET CLR 2.0.50727; .NET CLR 3.0.30729; .NET CLR 3.5.30729; Microsoft Outlook 15.0.4737; ms-office; MSOffice 15)
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: x64
   client:
@@ -3022,7 +2732,6 @@
   user_agent: Mozilla/2.02Gold (Win95; I)
   os:
     name: Windows
-    short_name: WIN
     version: "95"
     platform: ""
   client: null
@@ -3036,13 +2745,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Win95; en-US; rv:1.5) Gecko/20031007 Firebird/0.7
   os:
     name: Windows
-    short_name: WIN
     version: "95"
     platform: ""
   client:
     type: browser
     name: Firebird
-    short_name: FB
     version: "0.7"
     engine: Gecko
     engine_version: "1.5"
@@ -3056,13 +2763,11 @@
   user_agent: Mozilla/2.0 (compatible; MSIE 3.02; Update a; AOL 3.0; Windows 95)
   os:
     name: Windows
-    short_name: WIN
     version: "95"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "3.02"
     engine: Trident
     engine_version: ""
@@ -3076,13 +2781,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.0; de; rv:1.8.1.20) Gecko/20081217 Firefox/2.0.0.20
   os:
     name: Windows
-    short_name: WIN
     version: "2000"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "2.0.0.20"
     engine: Gecko
     engine_version: "1.8.1.20"
@@ -3096,13 +2799,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; AOL 9.0; Windows NT 5.0; AVPersonalSerial 0000000000000000000000000000000000000000; .NET CLR 2.0.50727)
   os:
     name: Windows
-    short_name: WIN
     version: "2000"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3116,13 +2817,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.0; .NET CLR 1.1.4322; Lunascape 2.1.3)
   os:
     name: Windows
-    short_name: WIN
     version: "2000"
     platform: ""
   client:
     type: browser
     name: Lunascape
-    short_name: LS
     version: "2.1.3"
     engine: ""
     engine_version: ""
@@ -3136,13 +2835,11 @@
   user_agent: Mozilla/4.7 (compatible; OffByOne; Windows 2000) Webster Pro V3.4
   os:
     name: Windows
-    short_name: WIN
     version: "2000"
     platform: ""
   client:
     type: browser
     name: Off By One
-    short_name: OF
     version: ""
     engine: ""
     engine_version: ""
@@ -3156,13 +2853,11 @@
   user_agent: 'Mozilla/4.0 (compatible; MSIE 5.0; Windows 2000) Opera 6.0 [en]'
   os:
     name: Windows
-    short_name: WIN
     version: "2000"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "6.0"
     engine: Elektra
     engine_version: ""
@@ -3176,13 +2871,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; Win 9x 4.90; .NET CLR 1.1.4322)
   os:
     name: Windows
-    short_name: WIN
     version: "ME"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3196,13 +2889,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Digital AlphaServer 1000A 4/233; Windows NT; Powered By 64-Bit Alpha Processor)
   os:
     name: Windows
-    short_name: WIN
     version: "NT"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "4.01"
     engine: Trident
     engine_version: ""
@@ -3216,13 +2907,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.2 x64; en-US; rv:1.9a1) Gecko/20061007 Minefield/3.0a1
   os:
     name: Windows
-    short_name: WIN
     version: "Server 2003"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0"
     engine: Gecko
     engine_version: "1.9"
@@ -3236,13 +2925,11 @@
   user_agent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2;  SLCC1;  .NET CLR 1.1.4325)'
   os:
     name: Windows
-    short_name: WIN
     version: "Server 2003"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3256,13 +2943,11 @@
   user_agent: Mozilla/5.0 (Windows; N; Windows NT 5.2; ru-RU) AppleWebKit/529 (KHTML, like Gecko, Safari/529.0) Lunascape/4.9.9.94
   os:
     name: Windows
-    short_name: WIN
     version: "Server 2003"
     platform: ""
   client:
     type: browser
     name: Lunascape
-    short_name: LS
     version: "4.9.9.94"
     engine: WebKit
     engine_version: "529"
@@ -3276,13 +2961,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.0; WOW64; rv:18.0) Gecko/20100101 Firefox/18.0
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: x64
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "18.0"
     engine: Gecko
     engine_version: "18.0"
@@ -3296,13 +2979,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 6.0; de; rv:1.9.1.6) Gecko/20091201 (WEB.DE/1.5) Firefox/3.5.6 (.NET CLR 3.5.30729)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5.6"
     engine: Gecko
     engine_version: "1.9.1.6"
@@ -3316,13 +2997,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; AOL 9.0; Windows NT 6.0; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.0.30618; .NET CLR 3.5.30729)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: ""
@@ -3336,13 +3015,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.0; GTB6; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30618; .NET CLR 1.1.4322)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: ""
@@ -3356,13 +3033,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.0; Trident/4.0; GTB6.3; Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1) ; SLCC1; .NET CLR 2.0.50727; Media Center PC 5.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; OfficeLiveConnector.1.4; OfficeLivePatch.1.3)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
@@ -3376,13 +3051,11 @@
   user_agent: Opera/9.80 (Windows NT 6.0; Edition Next) Presto/2.12 Version/12.10
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "12.10"
     engine: Presto
     engine_version: "2.12"
@@ -3396,7 +3069,6 @@
   user_agent: QuickTime (qtver=7.0.2a26;os=Windows NT 6.0)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
@@ -3413,7 +3085,6 @@
   user_agent: QuickTime.7.7.4 (qtver=7.7.4;os=Windows NT 6.0Service Pack 2)
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
@@ -3430,13 +3101,11 @@
   user_agent: Mozilla/5.0 (Windows NT 6.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Safari/537.36 SznProhlizec/3.0.0
   os:
     name: Windows
-    short_name: WIN
     version: "Vista"
     platform: ""
   client:
     type: browser
     name: Seznam Browser
-    short_name: SZ
     version: "3.0.0"
     engine: Blink
     engine_version: ""
@@ -3450,7 +3119,6 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.452) Gecko/20041027 Mnenhy/0.6.0.104
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client: null
@@ -3464,13 +3132,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; Avant Browser; InfoPath.1)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Avant Browser
-    short_name: AA
     version: ""
     engine: ""
     engine_version: ""
@@ -3484,13 +3150,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.43 BIDUBrowser/2.x Safari/537.31
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Baidu Spark
-    short_name: BS
     version: "2"
     engine: WebKit
     engine_version: "537.31"
@@ -3504,13 +3168,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; BIDUBrowser 2.6)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Baidu Spark
-    short_name: BS
     version: "2.6"
     engine: Trident
     engine_version: "4.0"
@@ -3524,13 +3186,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.137 Safari/537.36 LBBROWSER
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Cheetah Browser
-    short_name: LB
     version: ""
     engine: WebKit
     engine_version: "537.36"
@@ -3544,13 +3204,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.64 Safari/537.11
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "23.0.1271.64"
     engine: WebKit
     engine_version: "537.11"
@@ -3564,13 +3222,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; chromeframe/32.0.1700.76; .NET CLR 2.0.50727)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Chrome Frame
-    short_name: CF
     version: "32.0.1700.76"
     engine: WebKit
     engine_version: ""
@@ -3584,13 +3240,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.110 Safari/537.36 CoolNovo/2.0.9.20
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: CoolNovo
-    short_name: CN
     version: "2.0.9.20"
     engine: WebKit
     engine_version: "537.36"
@@ -3604,13 +3258,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.0.2pre) Gecko/2008071405 GranParadiso/3.0.2pre
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.0.2"
     engine: Gecko
     engine_version: "1.9.0.2"
@@ -3624,13 +3276,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-TW; rv:1.9.1b4pre) Gecko/20090308 Shiretoko/3.1b4pre (.NET CLR 3.5.30729)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.1"
     engine: Gecko
     engine_version: "1.9.1"
@@ -3644,13 +3294,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:2.0) Treco/20110515 Fireweb Navigator/2.4
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Fireweb Navigator
-    short_name: FN
     version: "2.4"
     engine: ""
     engine_version: ""
@@ -3664,13 +3312,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; cs-CZ) AppleWebKit/532.4 (KHTML, like Gecko) Google Earth/5.2.1.1329 Safari/532.4
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Google Earth
-    short_name: GE
     version: "5.2.1.1329"
     engine: WebKit
     engine_version: "532.4"
@@ -3684,13 +3330,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; TOB 6.07; Windows NT 5.1; .NET CLR 1.1.4322)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3704,13 +3348,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; .NET CLR 2.0.50727; 3P_UVRMDE 1.0.23.2)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3724,13 +3366,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; GTB6.3; .NET CLR 1.1.4322; .NET CLR 2.0.50727)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3744,13 +3384,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3764,13 +3402,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; .NET CLR 1.1.4322; AskTB5.4)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3784,13 +3420,11 @@
   user_agent: 'Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; SV1; SIMBAR={81EF9ABE-357A-484a-A97A-37904552D43B}; .NET CLR 2.0.50727)'
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
@@ -3804,13 +3438,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; .NET CLR 3.0.04506.648)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: ""
@@ -3824,13 +3456,11 @@
   user_agent: 'Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; i-NavFourF; TuneUp HTML Client Embedded Web Browser from: http://bsalsa.com/; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729)'
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: ""
@@ -3844,13 +3474,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; (R1 1.3))
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
@@ -3864,13 +3492,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.8.1.24pre) Gecko/20100228 K-Meleon/1.5.4
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: K-meleon
-    short_name: KM
     version: "1.5.4"
     engine: Gecko
     engine_version: "1.8.1.24"
@@ -3884,13 +3510,11 @@
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; zh-CN; rv:1.9) Gecko/20080705 Firefox/3.0 Kapiko/3.0
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Kapiko
-    short_name: KP
     version: "3.0"
     engine: Gecko
     engine_version: "1.9"
@@ -3904,13 +3528,11 @@
   user_agent: Mozilla/5.0 (compatible; Konqueror/3.4; CYGWIN_NT-5.1) KHTML/3.4.89 (like Gecko)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Konqueror
-    short_name: KO
     version: "3.4"
     engine: KHTML
     engine_version: "3.4.89"
@@ -3924,13 +3546,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; .NET CLR 2.0.50727; MAXTHON 2.0)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "2.0"
     engine: Trident
     engine_version: "4.0"
@@ -3944,13 +3564,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; Maxthon/3.0)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "3.0"
     engine: WebKit
     engine_version: ""
@@ -3964,13 +3582,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 5.1; Trident/4.0; Maxthon/4.2.0.4000)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.2.0.4000"
     engine: WebKit
     engine_version: ""
@@ -3984,13 +3600,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; en) Opera 8.00
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "8.00"
     engine: Presto
     engine_version: ""
@@ -4004,13 +3618,11 @@
   user_agent: Opera/9.27 (Windows NT 5.1; U; de)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.27"
     engine: Presto
     engine_version: ""
@@ -4024,13 +3636,11 @@
   user_agent: Opera/9.70 (Windows NT 5.1; U; en) TMO-US_LEO
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.70"
     engine: Presto
     engine_version: ""
@@ -4044,13 +3654,11 @@
   user_agent: Opera/9.80 (Windows NT 5.1; U; de) Presto/2.2.15 Version/10.10
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.10"
     engine: Presto
     engine_version: "2.2.15"
@@ -4064,13 +3672,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1; rv:52.9) Gecko/20100101 Goanna/3.4 Firefox/52.9 PaleMoon/27.9.1a1
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Pale Moon
-    short_name: PM
     version: "27.9.1"
     engine: Goanna
     engine_version: "3.4"
@@ -4084,13 +3690,11 @@
   user_agent: Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.48 Safari/537.36 QQBrowser/8.0.3197.400
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.0.3197.400"
     engine: WebKit
     engine_version: "537.36"
@@ -4104,7 +3708,6 @@
   user_agent: XBMC/9.04-beta1 r19639 (Windows; Windows XP Professional Service Pack 2 build 2600; http://www.xbmc.org)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
@@ -4121,19 +3724,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HiBox-hero) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: 1C
+    brand: Chuwi
     model: HiBox Hero
   os_family: Android
   browser_family: Chrome
@@ -4141,19 +3742,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/7.0; SLCC2; .NET CLR 2.0.50727; Media Center PC 6.0; MAAR; Tablet PC 2.0; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4161,7 +3760,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.14393.187; osmeta 8.3.40109042) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.40109042 Build/40109042 [FBAN/FBW;FBAV/65.0.0.44.139;FBBV/40161482;FBRV/0;FBDV/WindowsDevice;FBMD/Aspire E5-421G;FBSN/Windows;FBSV/10.0.14393.321;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4170,7 +3768,7 @@
     version: "65.0.0.44.139"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Aspire E5-421G
   os_family: Windows
   browser_family: Unknown
@@ -4178,7 +3776,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.125; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/Z5WAL;FBSN/Windows;FBSV/10.0.16299.371;FBSS/1;FBCR/;FBID/desktop;FBLC/ru_RU;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4187,7 +3784,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Aspire E5-511
   os_family: Windows
   browser_family: Unknown
@@ -4195,19 +3792,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Aspire V5-121 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Aspire V5-121
   os_family: Android
   browser_family: Chrome
@@ -4215,19 +3810,17 @@
   user_agent: 'Dalvik/2.1.0 (Linux## U## Android 7.1.1## Acer Chromebook R11 (CB5-132T / C738T) Build/R63-10032.86.0)'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Chromebook R11
   os_family: Android
   browser_family: Android Browser
@@ -4235,19 +3828,17 @@
   user_agent: 'Dalvik/2.1.0 (Linux## U## Android 7.1.1## Acer Chromebook R13 (CB5-312T) Build/R65-10323.30.0)'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Chromebook R13
   os_family: Android
   browser_family: Android Browser
@@ -4255,7 +3846,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/One S1003;FBSN/Windows;FBSV/10.0.17134.165;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4264,7 +3854,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: One 10
   os_family: Windows
   browser_family: Unknown
@@ -4272,7 +3862,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.98; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/Predator G9-793;FBSN/Windows;FBSV/10.0.16299.125;FBSS/1;FBCR/;FBID/desktop;FBLC/de_DE;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4281,7 +3870,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Predator G9-793
   os_family: Windows
   browser_family: Unknown
@@ -4289,19 +3878,17 @@
   user_agent: 'Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en-US) AppleWebKit/532.1 (KHTML, like Gecko) Arora/0.10.1 (Git: 1329 e5385f3) Safari/532.1'
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Arora
-    short_name: AR
     version: "0.10.1"
     engine: WebKit
     engine_version: "532.1"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4309,19 +3896,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en) AppleWebKit/418.9 (KHTML, like Gecko, Safari) Safari/419.3 Cheshire/1.0.ALPHA
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Cheshire
-    short_name: CS
     version: "1.0"
     engine: WebKit
     engine_version: "418.9"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4329,19 +3914,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Mac_PowerPC)
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "4.01"
     engine: Trident
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Internet Explorer
@@ -4349,19 +3932,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X; de-de) AppleWebKit/535+ (KHTML, like Gecko) Version/5.0 Safari/535.22+ Midori/0.4
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Midori
-    short_name: MI
     version: "0.4"
     engine: WebKit
     engine_version: "535"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4369,19 +3950,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X; U; en; rv:1.8.0) Gecko/20060728 Firefox/1.5.0 Opera 9.27
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.27"
     engine: Presto
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Opera
@@ -4389,19 +3968,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 1091) AppleWebKit/537.36 (KHTML like Gecko) Chrome/33.0.1750.91 Safari/537.36 OPR/20.0.1387.37 (Edition Next)
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Next
-    short_name: 'ON'
     version: "20.0.1387.37"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Opera
@@ -4409,19 +3986,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X; en-us) AppleWebKit/125.5.7 (KHTML, like Gecko) SunriseBrowser/0.833
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Sunrise
-    short_name: SR
     version: "0.833"
     engine: WebKit
     engine_version: "125.5.7"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4429,19 +4004,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X; en) AppleWebKit/418.9.1 (KHTML, like Gecko) Sunrise/1.6.5 like Safari/419.3
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Sunrise
-    short_name: SR
     version: "1.6.5"
     engine: WebKit
     engine_version: "418.9.1"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4449,19 +4022,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:37.0) Servo/1.0 Firefox/37.0
   os:
     name: Mac
-    short_name: MAC
     version: "10.10"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "37.0"
     engine: Servo
     engine_version: "1.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Firefox
@@ -4469,19 +4040,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_2) AppleWebKit/537.36 (KHTML, like Gecko) brave/0.7.9 Chrome/47.0.2526.73 Electron/0.36.2 Safari/537.36
   os:
     name: Mac
-    short_name: MAC
     version: "10.11.2"
     platform: ""
   client:
     type: browser
     name: Brave
-    short_name: BR
     version: "0.7.9"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Chrome
@@ -4489,7 +4058,6 @@
   user_agent: QuickTime\xaa.7.0.4 (qtver=7.0.4;cpu=PPC;os=Mac 10.3.9)
   os:
     name: Mac
-    short_name: MAC
     version: "10.3.9"
     platform: ""
   client:
@@ -4498,7 +4066,7 @@
     version: "7.0.4"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4506,19 +4074,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_6; en-us) AppleWebKit/528.16 (KHTML, like Gecko) Fluid/0.9.6 Safari/528.16
   os:
     name: Mac
-    short_name: MAC
     version: "10.5.6"
     platform: ""
   client:
     type: browser
     name: Fluid
-    short_name: FD
     version: "0.9.6"
     engine: WebKit
     engine_version: "528.16"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4526,19 +4092,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; PPC Mac OS X 10_5_8; en-us) AppleWebKit/533.19.4 (KHTML, like Gecko) iCab/4.8 Safari/533.16
   os:
     name: Mac
-    short_name: MAC
     version: "10.5.8"
     platform: ""
   client:
     type: browser
     name: iCab
-    short_name: IC
     version: "4.8"
     engine: WebKit
     engine_version: "533.19.4"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4546,19 +4110,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_5_8; de-de) AppleWebKit/531.21.8 (KHTML, like Gecko) Version/4.0.4 Safari/531.21.10
   os:
     name: Mac
-    short_name: MAC
     version: "10.5.8"
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "4.0.4"
     engine: WebKit
     engine_version: "531.21.8"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Safari
@@ -4566,19 +4128,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en; rv:1.9.2.28) Gecko/20120308 Camino/2.1.2 (like Firefox/3.6.28)
   os:
     name: Mac
-    short_name: MAC
     version: "10.6"
     platform: ""
   client:
     type: browser
     name: Camino
-    short_name: CA
     version: "2.1.2"
     engine: Gecko
     engine_version: "1.9.2.28"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4586,19 +4146,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; de; rv:1.9.1.6) Gecko/20091201 Firefox/3.5.6
   os:
     name: Mac
-    short_name: MAC
     version: "10.6"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "3.5.6"
     engine: Gecko
     engine_version: "1.9.1.6"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Firefox
@@ -4606,7 +4164,6 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.1.8) Gecko/20100317 Postbox/1.1.3
   os:
     name: Mac
-    short_name: MAC
     version: "10.6"
     platform: ""
   client:
@@ -4615,7 +4172,7 @@
     version: "1.1.3"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4623,7 +4180,6 @@
   user_agent: QuickTime/7.6.6 (qtver=7.6.6;cpu=IA32;os=Mac 10.6.8)
   os:
     name: Mac
-    short_name: MAC
     version: "10.6.8"
     platform: ""
   client:
@@ -4632,7 +4188,7 @@
     version: "7.6.6"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4640,19 +4196,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; en-us) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1
   os:
     name: Mac
-    short_name: MAC
     version: "10.6.8"
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "5.0.5"
     engine: WebKit
     engine_version: "533.21.1"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Safari
@@ -4660,19 +4214,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.7; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Mac
-    short_name: MAC
     version: "10.7"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Firefox
@@ -4680,19 +4232,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36
   os:
     name: Mac
-    short_name: MAC
     version: "10.8.5"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Chrome
@@ -4700,19 +4250,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_5) AppleWebKit/537.22 (KHTML, like Gecko) Maxthon/4.1.2.2000 Chrome/25.0.1364.99 Safari/537.22
   os:
     name: Mac
-    short_name: MAC
     version: "10.8.5"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.1.2.2000"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4720,19 +4268,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10.9; rv:26.0) Gecko/20100101 Firefox/26.0
   os:
     name: Mac
-    short_name: MAC
     version: "10.9"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Firefox
@@ -4740,19 +4286,17 @@
   user_agent: 'Safari/9537.73.11 CFNetwork/673.0.3 Darwin/13.0.0 (x86_64) (MacBookAir6%2C2)'
   os:
     name: Mac
-    short_name: MAC
     version: "10.9"
     platform: x64
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Safari
@@ -4760,19 +4304,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.63 Safari/537.36
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.63"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Chrome
@@ -4780,19 +4322,17 @@
   user_agent: 'Mozilla/5.0 (Macintosh; Intel  Mac OS X 10_9_1; en-US) AppleWebKit/9537.73.11 (KHTML, like Gecko) Version/7.0 Safari/537.71 OmniWeb/v624.0'
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.1"
     platform: ""
   client:
     type: browser
     name: OmniWeb
-    short_name: OW
     version: "624.0"
     engine: WebKit
     engine_version: "9537.73.11"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -4800,19 +4340,17 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_1) AppleWebKit/537.73.11 (KHTML, like Gecko) Version/7.0.1 Safari/537.73.11
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.1"
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "7.0.1"
     engine: WebKit
     engine_version: "537.73.11"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Safari
@@ -4820,19 +4358,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; MAAU; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4840,19 +4376,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; ASU2JS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4860,19 +4394,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; NP06; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4880,19 +4412,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; ASJB; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4900,19 +4430,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; NP02; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4920,7 +4448,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.608; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/K50IN;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4929,7 +4456,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: K50IN
   os_family: Windows
   browser_family: Unknown
@@ -4937,7 +4464,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/K54L;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4946,7 +4472,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: K54L
   os_family: Windows
   browser_family: Unknown
@@ -4954,7 +4480,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.14393.1770; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/T100HAN;FBSN/Windows;FBSV/10.0.14393.1914;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4963,7 +4488,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: Transformer Book
   os_family: Windows
   browser_family: Unknown
@@ -4971,7 +4496,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.309; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/T103HAF;FBSN/Windows;FBSV/10.0.16299.309;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4980,7 +4504,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: Transformer Mini
   os_family: Windows
   browser_family: Unknown
@@ -4988,7 +4512,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.674; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/X550LB;FBSN/Windows;FBSV/10.0.16299.64;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -4997,7 +4520,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: X550LB
   os_family: Windows
   browser_family: Unknown
@@ -5005,7 +4528,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.14393.693; osmeta 8.3.47029472) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.47029472 Build/47029472 [FBAN/FBW;FBAV/75.0.0.50.22;FBBV/47052341;FBRV/0;FBDV/WindowsDevice;FBMD/X553MA;FBSN/Windows;FBSV/10.0.14393.693;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5014,7 +4536,7 @@
     version: "75.0.0.50.22"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: X553MA
   os_family: Windows
   browser_family: Unknown
@@ -5022,7 +4544,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/X555LN;FBSN/Windows;FBSV/10.0.16299.309;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5031,7 +4552,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: X555LN
   os_family: Windows
   browser_family: Unknown
@@ -5039,7 +4560,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.64; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/X556UQK;FBSN/Windows;FBSV/10.0.16299.431;FBSS/1;FBCR/;FBID/desktop;FBLC/sv_SE;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5048,7 +4568,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: X556UQK
   os_family: Windows
   browser_family: Unknown
@@ -5056,7 +4576,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.674; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/UX360CAK;FBSN/Windows;FBSV/10.0.16299.248;FBSS/2;FBCR/;FBID/desktop;FBLC/pl_PL;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5065,7 +4584,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: AU
+    brand: Asus
     model: ZenBook Flip
   os_family: Windows
   browser_family: Unknown
@@ -5073,7 +4592,6 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; CPDTDF; .NET4.0C; InfoPath.3; .NET4.0E; Microsoft Outlook 14.0.7113; ms-office; MSOffice 14)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
@@ -5082,7 +4600,7 @@
     version: "14.0.7113"
   device:
     type: desktop
-    brand: CQ
+    brand: Compaq
     model: ""
   os_family: Windows
   browser_family: Unknown
@@ -5090,19 +4608,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; CPNTDFJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: CQ
+    brand: Compaq
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5110,19 +4626,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; Trident/4.0; .NET CLR 1.1.4322; .NET CLR 2.0.50727; .NET CLR 3.0.4506.2152; .NET CLR 3.5.30729; CMNTDF; InfoPath.2; .NET4.0C; .NET4.0E)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
   device:
     type: desktop
-    brand: CQ
+    brand: Compaq
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5130,7 +4644,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.98; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/SCL141CTP;FBSN/Windows;FBSV/10.0.16299.192;FBSS/2;FBCR/;FBID/desktop;FBLC/fr_FR;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5139,7 +4652,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: CZ
+    brand: Schneider
     model: Notebook 14" Cherry Trail
   os_family: Windows
   browser_family: Unknown
@@ -5147,19 +4660,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Win64; x64; Trident/4.0; .NET CLR 2.0.50727; SLCC2; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDC; .NET4.0C; .NET4.0E)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5167,19 +4678,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/4.0; GTB7.5; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MDDR)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5187,19 +4696,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; MDDRJS)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5207,19 +4714,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; Trident/7.0; MDDSJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5227,19 +4732,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; McAfee; MDDSJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5247,7 +4750,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17134.165; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/Inspiron 3541;FBSN/Windows;FBSV/10.0.17134.228;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5256,7 +4758,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: Inspiron 3541
   os_family: Windows
   browser_family: Unknown
@@ -5264,7 +4766,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.14393.1914; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/Latitude E4300;FBSN/Windows;FBSV/10.0.14393.1914;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5273,7 +4774,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: Latitude E4300
   os_family: Windows
   browser_family: Unknown
@@ -5281,7 +4782,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.64; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/XPS 15 9530;FBSN/Windows;FBSV/10.0.16299.309;FBSS/2;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5290,7 +4790,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: XPS 15 9530
   os_family: Windows
   browser_family: Unknown
@@ -5298,7 +4798,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.19; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/XPS 15 9550;FBSN/Windows;FBSV/10.0.16299.64;FBSS/2;FBCR/;FBID/desktop;FBLC/ko_KR;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5307,7 +4806,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: DL
+    brand: Dell
     model: XPS 15 9550
   os_family: Windows
   browser_family: Unknown
@@ -5315,19 +4814,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.04; pt-pt; H135 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: desktop
-    brand: DX
+    brand: DEXP
     model: Atlas
   os_family: Android
   browser_family: Android Browser
@@ -5335,19 +4832,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; MAFSJS)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: desktop
-    brand: FU
+    brand: Fujitsu
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5355,19 +4850,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; .NET4.0E; MAFS; InfoPath.2; OfficeLiveConnector.1.5; OfficeLivePatch.1.3; MSOffice 12)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: FU
+    brand: Fujitsu
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5375,7 +4868,6 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MAGW; .NET4.0C; .NET4.0E; Microsoft Outlook 14.0.7113; ms-office; MSOffice 14)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
@@ -5384,7 +4876,7 @@
     version: "14.0.7113"
   device:
     type: desktop
-    brand: GA
+    brand: Gateway
     model: ""
   os_family: Windows
   browser_family: Unknown
@@ -5392,19 +4884,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; MAGWJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: GA
+    brand: Gateway
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5412,13 +4902,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPDTDFJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
@@ -5432,13 +4920,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; HPNTDFJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
@@ -5452,7 +4938,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/HP Laptop 15-bs0xx;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5469,7 +4954,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.608; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/Compaq Presario CQ61 Notebook PC;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5486,7 +4970,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17763.379; osmeta 10.3.31799) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.31799 Build/31799 [FBAN/FBW;FBAV/186.0.0.83.783;FBBV/143636256;FBDV/HPEliteBook2560pLG669EA#AK8;FBMD/HP EliteBook 2560p;FBSN/Windows;FBSV/10.0.17763.503;FBSS/1;FBCR/;FBID/desktop;FBLC/sv_SE;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5503,7 +4986,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.64; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/HP EliteBook 2570p;FBSN/Windows;FBSV/10.0.17134.112;FBSS/1;FBCR/;FBID/desktop;FBLC/it_IT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5520,7 +5002,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/HP ENVY x360 Convertible 15-bp0xx;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5537,7 +5018,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.64; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/HP Pavilion Notebook;FBSN/Windows;FBSV/10.0.16299.431;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5554,7 +5034,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17134.648; osmeta 10.3.31799) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.31799 Build/31799 [FBAN/FBW;FBAV/186.0.0.83.783;FBBV/143636256;FBMD/HP Pavilion All-in-One 24-r0xx;FBSN/Windows;FBSV/10.0.17134.765;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5571,7 +5050,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.674; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/HP Pavilion dv6 Notebook PC;FBSN/Windows;FBSV/10.0.15063.726;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45;FBRV/'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5588,7 +5066,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.10586.494; osmeta 8.3.35371798) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.35371798 Build/35371798 [FBAN/FBW;FBAV/61.0.0.46.152;FBBV/35404853;FBRV/0;FBDV/WindowsDevice;FBMD/23-f364;FBSN/Windows;FBSV/10.0.10586.494;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5605,7 +5082,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.19; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/HP Pavilion x2 Detachable;FBSN/Windows;FBSV/10.0.16299.64;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5622,7 +5098,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17134.285; osmeta 10.3.8763) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.8763 Build/8763 [FBAN/FBW;FBAV/171.0.0.36.0;FBBV/123386314;FBDV/HPProBook440G52SZ73AV;FBMD/HP ProBook 440 G5;FBSN/Wind'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5639,7 +5114,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17134.765; osmeta 10.3.31799) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.31799 Build/31799 [FBAN/FBW;FBAV/186.0.0.83.783;FBBV/143636256;FBDV/HPProBook6360bLG633EA#AK8;FBMD/HP ProBook 6360b;FBSN/Windows;FBSV/10.0.17134.765;FBSS/1;FBCR/;FBID/desktop;FBLC/sv_SE;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5656,7 +5130,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.10586.494; osmeta 8.3.34265222) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.34265222 Build/34265222 [FBAN/FBW;FBAV/60.0.0.36.138;FBBV/34282524;FBRV/0;FBDV/WindowsDevice;FBMD/HP ProBook 6560b;FBSN/Windows;FBSV/10.0.10586.494;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5673,7 +5146,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.726; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/HP Spectre x360 Convertible;FBSN/Windows;FBSV/10.0.16299.309;FBSS/2;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45;FBRV/'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5690,19 +5162,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/6.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MANM; .NET4.0C; InfoPath.3; .NET4.0E)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: HY
+    brand: Hyrican
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5710,19 +5180,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; MANMJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: HY
+    brand: Hyrican
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5730,19 +5198,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; Trident/4.0; QQDownload 691; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; MALC)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "8.0"
     engine: Trident
     engine_version: "4.0"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5750,19 +5216,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; LEN2)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5770,19 +5234,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; WOW64; Trident/6.0; .NET4.0E; .NET4.0C; .NET CLR 3.5.30729; .NET CLR 2.0.50727; .NET CLR 3.0.30729; MALEJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5790,19 +5252,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; LCJB; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5810,19 +5270,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 5.1; .NET CLR 2.0.50727; .NET CLR 3.0.04506.30; MALN)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: ""
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5830,7 +5288,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.17134.81; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/80E5;FBSN/Windows;FBSV/10.0.17134.191;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5839,7 +5296,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: G50-80
   os_family: Windows
   browser_family: Unknown
@@ -5847,19 +5304,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 Safari/537.36 SailfishBrowser/Rulz ~LenovoG780
   os:
     name: Sailfish OS
-    short_name: SAF
     version: ""
     platform: x64
   client:
     type: browser
     name: Sailfish Browser
-    short_name: SA
     version: ""
     engine: Gecko
     engine_version: ""
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: G780
   os_family: GNU/Linux
   browser_family: Sailfish Browser
@@ -5867,7 +5322,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.786; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/80SM;FBSN/Windows;FBSV/10.0.16299.309;FBSS/1;FBCR/;FBID/desktop;FBLC/ru_RU;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5876,7 +5330,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: Ideapad 310-15ISK
   os_family: Windows
   browser_family: Unknown
@@ -5884,7 +5338,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.125; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/80VR;FBSN/Windows;FBSV/10.0.16299.371;FBSS/1;FBCR/;FBID/desktop;FBLC/ru_RU;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5893,7 +5346,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: Legion Y720
   os_family: Windows
   browser_family: Unknown
@@ -5901,7 +5354,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.125; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/37021C5;FBSN/Windows;FBSV/10.0.16299.334;FBSS/2;FBCR/;FBID/desktop;FBLC/fr_FR;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -5910,7 +5362,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: LE
+    brand: Lenovo
     model: ThinkPad Helix 3702
   os_family: Windows
   browser_family: Unknown
@@ -5918,19 +5370,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Win64; x64; Trident/5.0; MAMD)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: desktop
-    brand: MD
+    brand: Medion
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5938,19 +5388,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; .NET4.0C; MAM3; InfoPath.3; .NET4.0E; MAM3)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: desktop
-    brand: MZ
+    brand: MSI
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5958,19 +5406,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; MAMI; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: MZ
+    brand: MSI
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5978,19 +5424,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; MAMIJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: MZ
+    brand: MSI
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5998,19 +5442,17 @@
   user_agent: Mozilla/5.0 (X11; Linux i686 on x86_64; rv:42.0) Gecko/20100101 Firefox/42.0 webissimo3/3.7.22+svn30377
   os:
     name: Ordissimo
-    short_name: ORD
     version: ""
     platform: x64
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.7.22"
     engine: Gecko
     engine_version: "42.0"
   device:
     type: desktop
-    brand: OS
+    brand: Ordissimo
     model: ""
   os_family: GNU/Linux
   browser_family: Firefox
@@ -6018,19 +5460,17 @@
   user_agent: Mozilla/5.0 (X11; Linux i686; rv:45.0) Gecko/20100101 Firefox/45.0 webissimo3/3.7.30+svn32090
   os:
     name: Ordissimo
-    short_name: ORD
     version: ""
     platform: x86
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.7.30"
     engine: Gecko
     engine_version: "45.0"
   device:
     type: desktop
-    brand: OS
+    brand: Ordissimo
     model: ""
   os_family: GNU/Linux
   browser_family: Firefox
@@ -6038,19 +5478,17 @@
   user_agent: Mozilla/5.0 (X11; Linux i686 on x86_64; rv:52.0) Gecko/20100101 Firefox/52.0 Ordissimo/3.8.20+svn37598
   os:
     name: Ordissimo
-    short_name: ORD
     version: ""
     platform: x64
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.8.20"
     engine: Gecko
     engine_version: "52.0"
   device:
     type: desktop
-    brand: OS
+    brand: Ordissimo
     model: ""
   os_family: GNU/Linux
   browser_family: Firefox
@@ -6058,19 +5496,17 @@
   user_agent: Mozilla/5.0 (X11; Linux i686; rv:45.0) Gecko/20100101 Firefox/45.0 Ordissimo/3.8.6.6+svn37147
   os:
     name: Ordissimo
-    short_name: ORD
     version: ""
     platform: x86
   client:
     type: browser
     name: Ordissimo
-    short_name: OS
     version: "3.8.6.6"
     engine: Gecko
     engine_version: "45.0"
   device:
     type: desktop
-    brand: OS
+    brand: Ordissimo
     model: ""
   os_family: GNU/Linux
   browser_family: Firefox
@@ -6078,19 +5514,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0; MASM; .NET4.0C; .NET4.0E)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: SA
+    brand: Samsung
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6098,19 +5532,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; MASMJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: SA
+    brand: Samsung
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6118,19 +5550,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; SMJB)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: SA
+    brand: Samsung
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6138,19 +5568,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; MASP)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6158,19 +5586,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E; Media Center PC 6.0; MASA)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6178,19 +5604,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.1; WOW64; Trident/7.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; .NET4.0C; .NET4.0E; Media Center PC 6.0; MASE)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6198,19 +5622,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1; Win64; x64; Trident/7.0; MASAJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6218,19 +5640,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0; MASEJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6238,7 +5658,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.125; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/TH360R12.32CTW;FBSN/Windows;FBSV/10.0.16299.192;FBSS/1;FBCR/;FBID/desktop;FBLC/fr_FR;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6247,7 +5666,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: TN
+    brand: Thomson
     model: Prestige TH-360R12.32CTW
   os_family: Windows
   browser_family: Unknown
@@ -6255,19 +5674,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.1; WOW64; Trident/6.0; MATMJS)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6275,19 +5692,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/7.0; MATM)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6295,19 +5710,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/7.0; MATP)
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6315,19 +5728,17 @@
   user_agent: Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0; MATBJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6335,19 +5746,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; MATPJS; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6355,19 +5764,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; WOW64; Trident/7.0; TNJB; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6375,7 +5782,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.16299.248; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/Satellite A200;FBSN/Windows;FBSV/10.0.16299.371;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6384,7 +5790,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite A200
   os_family: Windows
   browser_family: Unknown
@@ -6392,7 +5798,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.14393.321; osmeta 8.3.41395199) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.41395199 Build/41395199 [FBAN/FBW;FBAV/67.0.0.13.140;FBBV/41468129;FBRV/0;FBDV/WindowsDevice;FBMD/Satellite A500;FBSN/Windows;FBSV/10.0.14393.321;FBSS/1;FBCR/;FBID/desktop;FBLC/en_GB;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6401,7 +5806,7 @@
     version: "67.0.0.13.140"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite A500
   os_family: Windows
   browser_family: Unknown
@@ -6409,7 +5814,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.786; osmeta 10.3.3308) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.3308 Build/3308 [FBAN/FBW;FBAV/140.0.0.232.179;FBBV/83145113;FBDV/WindowsDevice;FBMD/Satellite C650;FBSN/Windows;FBSV/10.0.16299.125;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6418,7 +5822,7 @@
     version: "140.0.0.232.179"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite C650
   os_family: Windows
   browser_family: Unknown
@@ -6426,7 +5830,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.10586.545; osmeta 8.3.35371798) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/8.3.35371798 Build/35371798 [FBAN/FBW;FBAV/61.0.0.46.152;FBBV/35404853;FBRV/0;FBDV/WindowsDevice;FBMD/Satellite C855;FBSN/Windows;FBSV/10.0.10586.545;FBSS/1;FBCR/;FBID/desktop;FBLC/en_US;FBOP/45]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6435,7 +5838,7 @@
     version: "61.0.0.46.152"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite C855
   os_family: Windows
   browser_family: Unknown
@@ -6443,7 +5846,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.674; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/Satellite L650;FBSN/Windows;FBSV/10.0.15063.729;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6452,7 +5854,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite L650
   os_family: Windows
   browser_family: Unknown
@@ -6460,7 +5862,6 @@
   user_agent: 'Mozilla/5.0 (Windows NT 10.0.15063.674; osmeta 10.3.2535) AppleWebKit/602.1.1 (KHTML, like Gecko) Version/9.0 Safari/602.1.1 osmeta/10.3.2535 Build/2535 [FBAN/FBW;FBAV/140.0.0.205.179;FBBV/74431143;FBDV/WindowsDevice;FBMD/Satellite S855;FBSN/Windows;FBSV/10.0.16299.64;FBSS/1;FBCR/;FBID/desktop;FBLC/pt_PT;FBOP/45;FBRV/0]'
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
@@ -6469,7 +5870,7 @@
     version: "140.0.0.205.179"
   device:
     type: desktop
-    brand: TS
+    brand: Toshiba
     model: Satellite S855
   os_family: Windows
   browser_family: Unknown

--- a/Tests/fixtures/feature_phone.yml
+++ b/Tests/fixtures/feature_phone.yml
@@ -5,13 +5,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: AI
+    brand: Airness
     model: AIR99
   os_family: Unknown
   browser_family: Unknown
@@ -21,13 +20,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.3.0.4"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: BQ
+    brand: BenQ
     model: CF61
   os_family: Unknown
   browser_family: Unknown
@@ -37,13 +35,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.3.0.7"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: CK
+    brand: Cricket
     model: A310
   os_family: Unknown
   browser_family: Unknown
@@ -53,7 +50,7 @@
   client: null
   device:
     type: feature phone
-    brand: EC
+    brand: Ericsson
     model: R380
   os_family: Unknown
   browser_family: Unknown
@@ -63,7 +60,7 @@
   client: null
   device:
     type: feature phone
-    brand: FL
+    brand: Fly
     model: DS123
   os_family: Unknown
   browser_family: Unknown
@@ -73,7 +70,7 @@
   client: null
   device:
     type: feature phone
-    brand: FL
+    brand: Fly
     model: E141TV PLUS
   os_family: Unknown
   browser_family: Unknown
@@ -83,7 +80,7 @@
   client: null
   device:
     type: feature phone
-    brand: FL
+    brand: Fly
     model: E158
   os_family: Unknown
   browser_family: Unknown
@@ -95,7 +92,7 @@
   client: null
   device:
     type: feature phone
-    brand: GI
+    brand: Gionee
     model: "50"
   os_family: Unknown
   browser_family: Unknown
@@ -105,7 +102,7 @@
   client: null
   device:
     type: feature phone
-    brand: GI
+    brand: Gionee
     model: S80
   os_family: Unknown
   browser_family: Unknown
@@ -115,7 +112,7 @@
   client: null
   device:
     type: feature phone
-    brand: KA
+    brand: Karbonn
     model: K222s
   os_family: Unknown
   browser_family: Unknown
@@ -125,7 +122,7 @@
   client: null
   device:
     type: feature phone
-    brand: KA
+    brand: Karbonn
     model: K595
   os_family: Unknown
   browser_family: Unknown
@@ -135,7 +132,7 @@
   client: null
   device:
     type: feature phone
-    brand: KA
+    brand: Karbonn
     model: K84
   os_family: Unknown
   browser_family: Unknown
@@ -145,13 +142,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: KD
+    brand: KDDI
     model: CA3H
   os_family: Unknown
   browser_family: Unknown
@@ -159,19 +155,17 @@
   user_agent: Mozilla/5.0 Opera/9.80 (KDDI-KC4A; BREW; Opera Mobi; U; ja) Presto/2.4.18 Version/10.00
   os:
     name: Brew
-    short_name: BMP
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "10.00"
     engine: Presto
     engine_version: "2.4.18"
   device:
     type: feature phone
-    brand: KD
+    brand: KDDI
     model: KC4A
   os_family: Brew
   browser_family: Opera
@@ -181,13 +175,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: KD
+    brand: KDDI
     model: SN3V
   os_family: Unknown
   browser_family: Unknown
@@ -197,13 +190,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: KD
+    brand: KDDI
     model: TS3W
   os_family: Unknown
   browser_family: Unknown
@@ -211,19 +203,17 @@
   user_agent: Mozilla/4.0 (Brew MP 1.0.4; U; en-us; Kyocera; NetFront/4.1/AMB) Sprint S2151-BST
   os:
     name: Brew
-    short_name: BMP
     version: "1.0.4"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.1"
     engine: NetFront
     engine_version: "4.1"
   device:
     type: feature phone
-    brand: KY
+    brand: Kyocera
     model: Coast
   os_family: Brew
   browser_family: NetFront
@@ -233,13 +223,12 @@
   client:
     type: browser
     name: Dorado
-    short_name: DO
     version: "1.0.0"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: L7
+    brand: Lephone
     model: K10
   os_family: Unknown
   browser_family: Nokia Browser
@@ -249,13 +238,12 @@
   client:
     type: browser
     name: Dorado
-    short_name: DO
     version: "1.0.0"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: L7
+    brand: Lephone
     model: K7
   os_family: Unknown
   browser_family: Nokia Browser
@@ -265,7 +253,7 @@
   client: null
   device:
     type: feature phone
-    brand: MR
+    brand: Motorola
     model: V360
   os_family: Unknown
   browser_family: Unknown
@@ -273,19 +261,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12; es-US; KIN.Two 1.0)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "6.12"
     engine: Trident
     engine_version: ""
   device:
     type: feature phone
-    brand: MS
+    brand: Microsoft
     model: Kin Two
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -293,19 +279,17 @@
   user_agent: 'Mozilla/5.0 (Sonim-XP3400/E343B_2100B00_N1900;U;REX/1.0;BREW/3.1.5;240*320;CTC/2.0) POLARIS/6.2'
   os:
     name: Brew
-    short_name: BMP
     version: "3.1.5"
     platform: ""
   client:
     type: browser
     name: Polaris
-    short_name: PO
     version: "6.2"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: OI
+    brand: Sonim
     model: XP3400
   os_family: Brew
   browser_family: Unknown
@@ -315,13 +299,12 @@
   client:
     type: browser
     name: Jig Browser
-    short_name: JI
     version: "7.3.7"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: PA
+    brand: Panasonic
     model: P902i
   os_family: Unknown
   browser_family: Unknown
@@ -331,13 +314,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SA
+    brand: Samsung
     model: E2152
   os_family: Unknown
   browser_family: NetFront
@@ -347,13 +329,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Aino
   os_family: Unknown
   browser_family: NetFront
@@ -363,13 +344,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Aino
   os_family: Unknown
   browser_family: NetFront
@@ -379,13 +359,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Cedar
   os_family: Unknown
   browser_family: NetFront
@@ -395,13 +374,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Elm
   os_family: Unknown
   browser_family: NetFront
@@ -411,13 +389,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Hazel
   os_family: Unknown
   browser_family: NetFront
@@ -427,13 +404,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Jalou
   os_family: Unknown
   browser_family: NetFront
@@ -443,13 +419,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Mix Walkman
   os_family: Unknown
   browser_family: Unknown
@@ -459,13 +434,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.311"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Mix Walkman
   os_family: Unknown
   browser_family: Unknown
@@ -475,13 +449,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Naite
   os_family: Unknown
   browser_family: NetFront
@@ -489,19 +462,17 @@
   user_agent: SonyEricssonP910i/R3A SEMC-Browser/Symbian/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.0
   os:
     name: Symbian^3
-    short_name: SY3
     version: ""
     platform: ""
   client:
     type: browser
     name: SEMC-Browser
-    short_name: SC
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: P910i
   os_family: Symbian
   browser_family: Unknown
@@ -509,19 +480,17 @@
   user_agent: Mozilla/5.0 (SymbianOS/9.2;U; Series60/5.0 SonyEricssonU1i/1.00;Profile/MIDP-2.1 Configuration/ CLDC-1.1)AppleWebKit/525 (KHTML, like Gecko) version/3.0Safari/525
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.0"
     engine: WebKit
     engine_version: "525"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Satio
   os_family: Symbian
   browser_family: Nokia Browser
@@ -529,19 +498,17 @@
   user_agent: SonyEricssonU1i/R1CA; Mozilla/5.0 (SymbianOS/9.4; U; Series60/5.0 Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 Safari/525
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.0"
     engine: WebKit
     engine_version: "525"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Satio
   os_family: Symbian
   browser_family: Nokia Browser
@@ -551,7 +518,7 @@
   client: null
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Spiro
   os_family: Unknown
   browser_family: Unknown
@@ -561,13 +528,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: txt
   os_family: Unknown
   browser_family: Unknown
@@ -577,13 +543,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: txt pro
   os_family: Unknown
   browser_family: Unknown
@@ -593,13 +558,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.342"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: txt pro
   os_family: Unknown
   browser_family: Unknown
@@ -607,19 +571,17 @@
   user_agent: Mozilla/5.0 (SymbianOS/9.2;U; Series60/5.0 SonyEricssonU5i/1.00;Profile/MIDP-2.1 Configuration/ CLDC-1.1)AppleWebKit/525 (KHTML, like Gecko) version/3.0Safari/525
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.0"
     engine: WebKit
     engine_version: "525"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Vivaz
   os_family: Symbian
   browser_family: Nokia Browser
@@ -627,19 +589,17 @@
   user_agent: Mozilla/5.0 (SymbianOS/9.2;U; Series60/5.0 SonyEricssonU8i/1.00;Profile/MIDP-2.1 Configuration/ CLDC-1.1)AppleWebKit/525 (KHTML, like Gecko) version/3.0Safari/525
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.0"
     engine: WebKit
     engine_version: "525"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Vivaz pro
   os_family: Symbian
   browser_family: Nokia Browser
@@ -649,13 +609,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Yendo
   os_family: Unknown
   browser_family: Unknown
@@ -665,13 +624,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: feature phone
-    brand: SE
+    brand: Sony Ericsson
     model: Zylo
   os_family: Unknown
   browser_family: NetFront
@@ -681,13 +639,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "7.2.6"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SG
+    brand: Sagem
     model: my411C-orange
   os_family: Unknown
   browser_family: Unknown
@@ -697,13 +654,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "7.2.6"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SG
+    brand: Sagem
     model: my411X
   os_family: Unknown
   browser_family: Unknown
@@ -713,13 +669,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "7.2.6"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SG
+    brand: Sagem
     model: my511X-orange
   os_family: Unknown
   browser_family: Unknown
@@ -729,13 +684,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.3"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SG
+    brand: Sagem
     model: myC5-2v
   os_family: Unknown
   browser_family: Unknown
@@ -745,13 +699,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.2.6"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: SG
+    brand: Sagem
     model: myV-55
   os_family: Unknown
   browser_family: Unknown
@@ -759,19 +712,17 @@
   user_agent: Mozilla/4.0 (BREW 3.1.5; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP6760
   os:
     name: Brew
-    short_name: BMP
     version: "3.1.5"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5.1"
     engine: NetFront
     engine_version: "3.5.1"
   device:
     type: feature phone
-    brand: SY
+    brand: Sanyo
     model: Incognito
   os_family: Brew
   browser_family: NetFront
@@ -779,19 +730,17 @@
   user_agent: Mozilla/4.0 (Brew MP 1.0.2; U; en-us; Sanyo; NetFront/3.5.1/AMB) Boost SCP6780
   os:
     name: Brew
-    short_name: BMP
     version: "1.0.2"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5.1"
     engine: NetFront
     engine_version: "3.5.1"
   device:
     type: feature phone
-    brand: SY
+    brand: Sanyo
     model: Innuendo
   os_family: Brew
   browser_family: NetFront
@@ -801,13 +750,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
   device:
     type: feature phone
-    brand: SY
+    brand: Sanyo
     model: Katana Eclipse X
   os_family: Unknown
   browser_family: NetFront
@@ -817,13 +765,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3"
     engine: NetFront
     engine_version: "3"
   device:
     type: feature phone
-    brand: SY
+    brand: Sanyo
     model: PM-8200
   os_family: Unknown
   browser_family: NetFront
@@ -833,7 +780,7 @@
   client: null
   device:
     type: feature phone
-    brand: TI
+    brand: TIANYU
     model: A930
   os_family: Unknown
   browser_family: Unknown
@@ -841,19 +788,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) 320x240; VZW; UTStar-XV6175; Window Mobile 6.1 Standard;
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: feature phone
-    brand: UT
+    brand: UTStarcom
     model: XV6175
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -863,13 +808,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.4"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: VK
+    brand: VK Mobile
     model: VK700
   os_family: Unknown
   browser_family: Unknown
@@ -879,13 +823,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.4"
     engine: ""
     engine_version: ""
   device:
     type: feature phone
-    brand: VK
+    brand: VK Mobile
     model: vk900
   os_family: Unknown
   browser_family: Unknown

--- a/Tests/fixtures/feed_reader.yml
+++ b/Tests/fixtures/feed_reader.yml
@@ -3,7 +3,6 @@
   user_agent: Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.21 (KHTML, like Gecko) akregator/4.11.5 Safari/537.21
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
@@ -20,7 +19,6 @@
   user_agent: Akregator/4.12.3; syndication SUSE
   os:
     name: SUSE
-    short_name: SSE
     version: ""
     platform: ""
   client:
@@ -63,7 +61,6 @@
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows)
   os:
     name: Windows
-    short_name: WIN
     version: ""
     platform: ""
   client:
@@ -80,7 +77,6 @@
   user_agent: FeedDemon/4.5 (http://www.feeddemon.com/; Microsoft Windows XP)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
@@ -97,7 +93,6 @@
   user_agent: FeeddlerPro/2.4 CFNetwork/672.0.8 Darwin/14.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "7.0"
     platform: ""
   client:
@@ -106,7 +101,7 @@
     version: "2.4"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -114,7 +109,6 @@
   user_agent: FeeddlerRSS/2.4 CFNetwork/548.1.4 Darwin/11.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "5.1"
     platform: ""
   client:
@@ -123,7 +117,7 @@
     version: "2.4"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -131,7 +125,6 @@
   user_agent: FeeddlerRSS 2.4 (iPad; iPhone OS 5.1.1; en_US)
   os:
     name: iOS
-    short_name: IOS
     version: "5.1.1"
     platform: ""
   client:
@@ -140,7 +133,7 @@
     version: "2.4"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Unknown
@@ -148,7 +141,6 @@
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/602.1 (KHTML, like Gecko) QuiteRSS/0.18.12 Safari/602.1
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
@@ -178,7 +170,6 @@
   user_agent: Liferea/1.6.4 (Linux; en_US.UTF-8; http://liferea.sf.net/)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
@@ -195,7 +186,6 @@
   user_agent: Liferea/1.10-RC1 (Linux; en_GB.UTF-8; http://liferea.sf.net/)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
@@ -212,7 +202,6 @@
   user_agent: Liferea/1.10.6 (Linux; en_US.UTF8; http://liferea.sf.net/) AppleWebKit (KHTML, like Gecko)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
@@ -229,7 +218,6 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) Version/6.0 NetNewsWire/4.0.0
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.2"
     platform: ""
   client:
@@ -238,7 +226,7 @@
     version: "4.0.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -246,7 +234,6 @@
   user_agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_2) AppleWebKit/537.74.9 (KHTML, like Gecko) NetNewsWire/3.3.2
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.2"
     platform: ""
   client:
@@ -255,7 +242,7 @@
     version: "3.3.2"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -276,7 +263,6 @@
   user_agent: NetNewsWire/4.0.0 (Mac OS X; http://netnewswireapp.com/mac/; gzip-happy)
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
@@ -285,7 +271,7 @@
     version: "4.0.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -293,7 +279,6 @@
   user_agent: Downcast/2.9.11 (Mac OS X Version 10.11.3 (Build 15D21))
   os:
     name: Mac
-    short_name: MAC
     version: "10.11.3"
     platform: ""
   client:
@@ -302,7 +287,7 @@
     version: "2.9.11"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -310,7 +295,6 @@
   user_agent: Downcast/2.9.11 (iPhone; iOS 9.2; Scale/2.00)
   os:
     name: iOS
-    short_name: IOS
     version: "9.2"
     platform: ""
   client:
@@ -319,7 +303,7 @@
     version: "2.9.11"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -327,7 +311,6 @@
   user_agent: newsbeuter/2.7 (Linux x86_64)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
@@ -344,7 +327,6 @@
   user_agent: NewsBlur iPhone App v3.6
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -353,7 +335,7 @@
     version: "3.6"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -361,7 +343,6 @@
   user_agent: NewsBlur iPad App v3.6
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -370,7 +351,7 @@
     version: "3.6"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Unknown
@@ -378,7 +359,6 @@
   user_agent: NewsBlur/4.0.1 CFNetwork/672.1.13 Darwin/14.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
@@ -387,7 +367,7 @@
     version: "4.0.1"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -395,7 +375,6 @@
   user_agent: newsbeuter/2.4 (Linux 3.2.0-23-generic; i686; http://www.newsbeuter.org/) libcurl/7.22.0 GnuTLS/2.12.14 zlib/1.2.3.4 libidn/1.23 librtmp/2.3
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
@@ -412,7 +391,6 @@
   user_agent: Pulp/1.5.2 (iPad; http://www.acrylicapps.com/pulp/)
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -421,7 +399,7 @@
     version: "1.5.2"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Unknown
@@ -429,7 +407,6 @@
   user_agent: ReadKit/2.4.0 (Mac OS X Version 10.9.2 (Build 13C64))
   os:
     name: Mac
-    short_name: MAC
     version: "10.9.2"
     platform: ""
   client:
@@ -438,7 +415,7 @@
     version: "2.4.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -446,7 +423,6 @@
   user_agent: 'ReadKit/7017 CFNetwork/673.2.1 Darwin/13.1.0 (x86_64) (MacBookPro10%2C1)'
   os:
     name: Mac
-    short_name: MAC
     version: "10.9"
     platform: x64
   client:
@@ -455,7 +431,7 @@
     version: "7017"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -463,7 +439,6 @@
   user_agent: Reeder/3.2 CFNetwork/672.1.12 Darwin/14.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
@@ -472,7 +447,7 @@
     version: "3.2"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -493,7 +468,6 @@
   user_agent: RssBandit/1.9.0.1002 (.NET CLR 2.0.50727.7512; WinNT 6.2.9200.0; http://www.rssbandit.org)
   os:
     name: Windows
-    short_name: WIN
     version: "NT"
     platform: ""
   client:
@@ -523,7 +497,6 @@
   user_agent: RSSOwl/2.2.1.201312301314 (Windows; U; en)
   os:
     name: Windows
-    short_name: WIN
     version: ""
     platform: ""
   client:

--- a/Tests/fixtures/mediaplayer.yml
+++ b/Tests/fixtures/mediaplayer.yml
@@ -16,7 +16,6 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Songbird/1.12.1 (20140112193149)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
@@ -33,7 +32,6 @@
   user_agent: Mozilla/5.0 (X11; U; Linux i686; en-US; rv:1.9.2.28) Gecko/20130316 Nightingale/1.12.2 (20140112193149)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
@@ -50,7 +48,6 @@
   user_agent: iTunes/10.2.1 (Macintosh; Intel Mac OS X 10.7) AppleWebKit/534.20.8
   os:
     name: Mac
-    short_name: MAC
     version: "10.7"
     platform: ""
   client:
@@ -59,7 +56,7 @@
     version: "10.2.1"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -67,7 +64,6 @@
   user_agent: iTunes/10.2.1 (Windows; Microsoft Windows 7 Enterprise Edition Service Pack 1 (Build 7601)) AppleWebKit/533.20.25
   os:
     name: Windows
-    short_name: WIN
     version: "7"
     platform: ""
   client:
@@ -89,7 +85,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S3850
   os_family: Unknown
   browser_family: Unknown
@@ -97,7 +93,6 @@
   user_agent: Deezer/5.4.21.97 (Android; 6.0; Mobile; fr) WIKO U FEEL
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -106,7 +101,7 @@
     version: "5.4.21.97"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: U Feel
   os_family: Android
   browser_family: Unknown
@@ -114,7 +109,6 @@
   user_agent: FlyCast/1.34 (BlackBerry; 8330/4.5.0.131 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/-1)
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: ""
     platform: ""
   client:
@@ -123,7 +117,7 @@
     version: "1.34"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry
   os_family: BlackBerry
   browser_family: Unknown
@@ -144,7 +138,6 @@
   user_agent: XBMC/9.04 r19840 (Mac OS X; Darwin 9.6.0; http://www.xbmc.org)
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
@@ -153,7 +146,7 @@
     version: "9.04"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -161,7 +154,6 @@
   user_agent: SubStream/0.7 CFNetwork/485.12.30 Darwin/10.4.0
   os:
     name: iOS
-    short_name: IOS
     version: "4.2"
     platform: ""
   client:
@@ -170,7 +162,7 @@
     version: "0.7"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -178,7 +170,6 @@
   user_agent: Samsung GT-I9505 stagefright/1.2 (Linux;Android 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -187,7 +178,7 @@
     version: "1.2"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Unknown
@@ -195,7 +186,6 @@
   user_agent: Kodi/14.0 (Macintosh; Intel Mac OS X 10_10_3) App_Bitness/64 Version/14.0-Git:2014-12-23-ad747d9-dirty
   os:
     name: Mac
-    short_name: MAC
     version: "10.10.3"
     platform: ""
   client:
@@ -204,7 +194,7 @@
     version: "14.0"
   device:
     type: desktop
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -212,7 +202,6 @@
   user_agent: GoogleChirp/1.0.1 (Linux; Android/5.0) GOOG/7 AppleWebKit/534.30 (KHTML, like Gecko)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:

--- a/Tests/fixtures/mobile_apps.yml
+++ b/Tests/fixtures/mobile_apps.yml
@@ -3,7 +3,6 @@
   user_agent: Pulse/4.0.5 (iPhone; iOS 7.0.6; Scale/2.00)
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.6"
     platform: ""
   client:
@@ -12,7 +11,7 @@
     version: "4.0.5"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -20,7 +19,6 @@
   user_agent: WhatsApp/2.6.4 iPhone_OS/4.3.3 Device/iPhone_4
   os:
     name: iOS
-    short_name: IOS
     version: "4.3.3"
     platform: ""
   client:
@@ -29,7 +27,7 @@
     version: "2.6.4"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -37,7 +35,6 @@
   user_agent: AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; MB886 Build/9.8.0Q-97_MB886_FFW-20)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -46,7 +43,7 @@
     version: "4.1.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB886
   os_family: Android
   browser_family: Unknown
@@ -54,7 +51,6 @@
   user_agent: com.google.android.youtube/2.4.4(Linux; U; Android 2.3.5; en_US; SCH-I500 Build/GINGERBREAD) gzip
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
@@ -63,7 +59,7 @@
     version: "2.4.4"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SCH-I500
   os_family: Android
   browser_family: Unknown
@@ -71,7 +67,6 @@
   user_agent: NS/3.3.1 (Linux; U; Android 5.0.1; en-in; phone/Nexus 5 Build/LRX22C; Density/480; gzip) com.google.android.apps.magazines/2014102707
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
@@ -80,7 +75,7 @@
     version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 5
   os_family: Android
   browser_family: Unknown
@@ -88,7 +83,6 @@
   user_agent: Mozilla/5.0 (iPad3,6; iPad; U; CPU OS 7_1 like Mac OS X; en_US) com.google.GooglePlus/33839 (KHTML, like Gecko) Mobile/P103AP (gzip)
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
@@ -97,7 +91,7 @@
     version: ""
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad 4
   os_family: iOS
   browser_family: Unknown
@@ -105,7 +99,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3_3 like Mac OS X) AppleWebKit/603.3.8 (KHTML, like Gecko) Mobile/14G60 [FBAN/MessengerForiOS;FBAV/132.0.0.41.90;FBBV/69171754;FBDV/iPhone8,4;FBMD/iPhone;FBSN/iOS;FBSV/10.3.3;FBSS/2;FBCR/Koodo;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0]'
   os:
     name: iOS
-    short_name: IOS
     version: "10.3.3"
     platform: ""
   client:
@@ -114,7 +107,7 @@
     version: "132.0.0.41.90"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone SE
   os_family: iOS
   browser_family: Unknown
@@ -122,7 +115,6 @@
   user_agent: 'Mozilla/5.0 (iPad; CPU OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 [FBAN/MessengerForiOS;FBAV/122.0.0.40.69;FBBV/61279955;FBDV/iPad4,1;FBMD/iPad;FBSN/iOS;FBSV/10.1.1;FBSS/2;FBCR/;FBID/tablet;FBLC/vi_VN;FBOP/5;FBRV/0]'
   os:
     name: iOS
-    short_name: IOS
     version: "10.1.1"
     platform: ""
   client:
@@ -131,7 +123,7 @@
     version: "122.0.0.40.69"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad Air
   os_family: iOS
   browser_family: Unknown
@@ -139,7 +131,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.1.2; Nexus 5X Build/N2G47F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/114.0.0.21.71;]'
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
@@ -148,7 +139,7 @@
     version: "114.0.0.21.71"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 5X
   os_family: Android
   browser_family: Unknown
@@ -156,7 +147,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; SM-T280 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Safari/537.36 [FB_IAB/MESSENGER;FBAV/112.0.0.17.70;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -165,7 +155,7 @@
     version: "112.0.0.17.70"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 7.0" WiFi
   os_family: Android
   browser_family: Unknown
@@ -173,7 +163,6 @@
   user_agent: '[FBAN/FB4A;FBAV/26.0.0.22.16;FBBV/6590638;FBDM/{density=1.5,width=791,height=480};FBLC/en_US;FBCR/SmarTone HK;FBMF/Sony;FBBD/Sony;FBPN/com.facebook.katana;FBDV/C1905;FBSV/4.1.2;FBOP/19;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -182,7 +171,7 @@
     version: "26.0.0.22.16"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M
   os_family: Android
   browser_family: Unknown
@@ -190,7 +179,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_2 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12D508 Safari Line/5.9.5
   os:
     name: iOS
-    short_name: IOS
     version: "8.2"
     platform: ""
   client:
@@ -199,7 +187,7 @@
     version: "5.9.5"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -207,7 +195,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 9_2_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13D15 Safari Line/5.10.0
   os:
     name: iOS
-    short_name: IOS
     version: "9.2.1"
     platform: ""
   client:
@@ -216,7 +203,7 @@
     version: "5.10.0"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -224,7 +211,6 @@
   user_agent: Podcat/8577 CFNetwork/711.3.18 Darwin/14.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "8.3"
     platform: ""
   client:
@@ -233,7 +219,7 @@
     version: "8577"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -241,7 +227,6 @@
   user_agent: Podcat/1.1.4.14639 (iPhone; de-DE; iPhone OS 9.2.1)
   os:
     name: iOS
-    short_name: IOS
     version: "9.2.1"
     platform: ""
   client:
@@ -250,7 +235,7 @@
     version: "1.1.4.14639"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -258,7 +243,6 @@
   user_agent: PodcastRepublic/18.0 (Linux; U; Android 8.0.0;OnePlus3T/OPR1.170623.032)
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
@@ -267,7 +251,7 @@
     version: "18.0"
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 3T
   os_family: Android
   browser_family: Unknown
@@ -275,7 +259,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 6.0; FEVER Build/MRA58K)'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -284,7 +267,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Fever
   os_family: Android
   browser_family: Unknown
@@ -292,7 +275,6 @@
   user_agent: Podcatcher Deluxe
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
@@ -309,7 +291,6 @@
   user_agent: iCatcher! Podcast Player/2.6.2
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -318,7 +299,7 @@
     version: "2.6.2"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -326,7 +307,6 @@
   user_agent: icatcher/4535 CFNetwork/672.1.14 Darwin/14.0.0
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
@@ -335,7 +315,7 @@
     version: "4535"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -343,7 +323,6 @@
   user_agent: Castro 2 Episode Download
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -352,7 +331,7 @@
     version: ""
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -360,7 +339,6 @@
   user_agent: Castro 2 2.1.2/646 Like iTunes
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -369,7 +347,7 @@
     version: "2.1.2"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -377,7 +355,6 @@
   user_agent: Player FM
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
@@ -394,7 +371,6 @@
   user_agent: okhttp/2.7.5
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
@@ -411,7 +387,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) News/582.1 Version/2.0
   os:
     name: iOS
-    short_name: IOS
     version: "10.0"
     platform: ""
   client:
@@ -420,7 +395,7 @@
     version: "2.0"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -428,7 +403,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_0 like Mac OS X) AppleWebKit/602.1.43 (KHTML, like Gecko) AppleNews/607 Version/2.0
   os:
     name: iOS
-    short_name: IOS
     version: "10.0"
     platform: ""
   client:
@@ -437,7 +411,7 @@
     version: "2.0"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -445,7 +419,6 @@
   user_agent: YelpWebView/1.5 Android/7.0 YelpApp/9.10.0 (x-screen-scale 1.0;)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -462,7 +435,6 @@
   user_agent: com.google.android.apps.searchlite/101032 (Linux; U; Android 8.1.0; ru_RU; M580; Build/O11019; Cronet/74.0.3729.182)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -479,7 +451,6 @@
   user_agent: CastBox/4.8.1 (fm.castbox.audiobook.radio.podcast; build:2; iOS 11.2.5)
   os:
     name: iOS
-    short_name: IOS
     version: "11.2.5"
     platform: ""
   client:
@@ -488,7 +459,7 @@
     version: "4.8.1"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown
@@ -496,7 +467,6 @@
   user_agent: Mozilla/5.0 (Android OS 5.1 / API-22 (HUAWEITIT-U02/C579B105); HUAWEI HUAWEI TIT-U02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36 UnityPlayer/2017.4.34f1
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -505,7 +475,7 @@
     version: "2017.4.34"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 Pro
   os_family: Android
   browser_family: Unknown
@@ -513,7 +483,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-T515 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.125 Safari/537.36 UCURSOS/v1.6_244-android
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -522,7 +491,7 @@
     version: "1.6"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" (2019)
   os_family: Android
   browser_family: Unknown
@@ -530,7 +499,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDEM10 Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 HeyTapBrowser/40.7.4.1
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -539,7 +507,7 @@
     version: "40.7.4.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2
   os_family: Android
   browser_family: Unknown
@@ -547,7 +515,6 @@
   user_agent: 'Mozilla/5.0 (2822MB; 720x1411; 320x319; 411x806; Samsung SM-A115F; 10) AppleWebKit/537.36 (KHTML, like Gecko)  ROBLOX Android App 2.448.411159 Phone Hybrid()  GooglePlayStore RobloxApp/2.448.411159 (GlobalDist; GooglePlayStore)'
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -556,7 +523,7 @@
     version: "2.448.411159"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A11
   os_family: Android
   browser_family: Unknown
@@ -564,7 +531,6 @@
   user_agent: Mozilla/5.0 (iPhone; iPhone12,1; CPU iPhone OS 14.0 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Mobile/9B176 ROBLOX iOS App 2.448.411159 Hybrid RobloxApp/2.448.411159 (GlobalDist; AppleAppStore)
   os:
     name: iOS
-    short_name: IOS
     version: "14.0"
     platform: ""
   client:
@@ -573,7 +539,7 @@
     version: "2.448.411159"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 11
   os_family: iOS
   browser_family: Unknown

--- a/Tests/fixtures/phablet.yml
+++ b/Tests/fixtures/phablet.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GI-626 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: A5
+    brand: altron
     model: GI-626
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5039D_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: 3L
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5039D_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: 3L
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5060D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: 5V
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5060D_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: 5V
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 9002X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 7"
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 9022X Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 8"
   os_family: Android
   browser_family: Chrome
@@ -143,7 +129,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBAV/239.0.0.52.149;FBBV/172924969;FBDV/iPhone12,3;FBMD/iPhone;FBSN/iOS;FBSV/13.0;FBSS/3;FBID/phone;FBLC/de_DE;FBOP/5;FBRV/174725516;FBCR/Telekom.de]'
   os:
     name: iOS
-    short_name: IOS
     version: "13.0"
     platform: ""
   client:
@@ -152,7 +137,7 @@
     version: "239.0.0.52.149"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 11 Pro
   os_family: iOS
   browser_family: Unknown
@@ -160,19 +145,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 596; 10.20.2; 11PRO)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 11 Pro
   os_family: iOS
   browser_family: Safari
@@ -180,7 +163,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 Instagram 112.0.0.17.121 (iPhone12,5; iOS 13_0; de_DE; de-DE; scale=3.00; 1242x2688; 173391461)
   os:
     name: iOS
-    short_name: IOS
     version: "13.0"
     platform: ""
   client:
@@ -189,7 +171,7 @@
     version: "112.0.0.17.121"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 11 Pro Max
   os_family: iOS
   browser_family: Unknown
@@ -197,19 +179,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_1_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.0; 11PROMAX)
   os:
     name: iOS
-    short_name: IOS
     version: "13.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 11 Pro Max
   os_family: iOS
   browser_family: Safari
@@ -217,19 +197,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_1_1 like Mac OS X) AppleWebKit/602.2.14 (KHTML, like Gecko) Mobile/14B100 NAVER(inapp; search; 550; 7.6.0; 6PLUS)
   os:
     name: iOS
-    short_name: IOS
     version: "10.1.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "602.2.14"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 6 Plus
   os_family: iOS
   browser_family: Safari
@@ -237,19 +215,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.1.34 (KHTML, like Gecko) Version/11.0 Mobile/15D100 Safari/604.1 NAVER(inapp; search; 690; 10.17.0; 6SPLUS)
   os:
     name: iOS
-    short_name: IOS
     version: "11.2.6"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "11.0"
     engine: WebKit
     engine_version: "604.1.34"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 6s Plus
   os_family: iOS
   browser_family: Safari
@@ -257,19 +233,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 592; 10.1.2; 7PLUS)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 7 Plus
   os_family: iOS
   browser_family: Safari
@@ -277,19 +251,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 595; 10.17.0; 8PLUS)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone 8 Plus
   os_family: iOS
   browser_family: Safari
@@ -297,7 +269,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1 Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone12,8;FBMD/iPhone;FBSN/iOS;FBSV/13.3.1;FBSS/3;FBID/phone;FBLC/ro_RO;FBOP/5;FBCR/]'
   os:
     name: iOS
-    short_name: IOS
     version: "13.4.1"
     platform: ""
   client:
@@ -306,7 +277,7 @@
     version: ""
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone SE (2020)
   os_family: iOS
   browser_family: Unknown
@@ -314,7 +285,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 11_1 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) Mobile/15B86 [FBAN/FBIOS;FBAV/144.0.0.55.89;FBBV/74129168;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/11.1;FBSS/3;FBCR/AT&T;FBID/phone;FBLC/en_US;FBOP/5;FBRV/74129168]'
   os:
     name: iOS
-    short_name: IOS
     version: "11.1"
     platform: ""
   client:
@@ -323,7 +293,7 @@
     version: "144.0.0.55.89"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone X
   os_family: iOS
   browser_family: Unknown
@@ -331,7 +301,6 @@
   user_agent: FBAN/FBIOS;FBAV/182.0.0.42.80;FBBV/118457561;FBDV/iPhone10,3;FBMD/iPhone;FBSN/iOS;FBSV/11.4.1;FBSS/3;FBCR/Sprint;FBID/phone;FBLC/en_US;FBOP/5;FBRV/0;FBIA/FBIOS
   os:
     name: iOS
-    short_name: IOS
     version: "11.4.1"
     platform: ""
   client:
@@ -340,7 +309,7 @@
     version: "182.0.0.42.80"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone X
   os_family: iOS
   browser_family: Unknown
@@ -348,19 +317,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.2; X)
   os:
     name: iOS
-    short_name: IOS
     version: "13.4.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone X
   os_family: iOS
   browser_family: Safari
@@ -368,7 +335,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16A366 [FBAN/FBIOS;FBDV/iPhone11,6;FBMD/iPhone;FBSN/iOS;FBSV/12.0;FBSS/3;FBCR/Vodafone.de;FBID/phone;FBLC/de_DE;FBOP/5;FBRV/0]'
   os:
     name: iOS
-    short_name: IOS
     version: "12.0"
     platform: ""
   client:
@@ -377,7 +343,7 @@
     version: ""
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone XS Max
   os_family: iOS
   browser_family: Unknown
@@ -385,19 +351,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 690; 10.18.2; XSMAX)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: phablet
-    brand: AP
+    brand: Apple
     model: iPhone XS Max
   os_family: iOS
   browser_family: Safari
@@ -405,19 +369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; ME371MG Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad
   os_family: Android
   browser_family: Chrome
@@ -425,19 +387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; K012 Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad 7
   os_family: Android
   browser_family: Chrome
@@ -445,19 +405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; K00E Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad 7
   os_family: Android
   browser_family: Chrome
@@ -465,19 +423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; K00Z Build/JSS15Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad 7 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -485,19 +441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K016 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad 8
   os_family: Android
   browser_family: Chrome
@@ -505,19 +459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; K00G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AU
+    brand: Asus
     model: Fonepad Note 6
   os_family: Android
   browser_family: Chrome
@@ -525,19 +477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; M300 Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: AW
+    brand: Aiwa
     model: M300
   os_family: Android
   browser_family: Chrome
@@ -545,19 +495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BV6100 Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: B2
+    brand: Blackview
     model: BV6100
   os_family: Android
   browser_family: Chrome
@@ -565,19 +513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; REVVLPLUS C3701A Build/143.02.171026.3701A-TMO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: CO
+    brand: Coolpad
     model: REVVL Plus
   os_family: Android
   browser_family: Chrome
@@ -585,19 +531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AS260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: DX
+    brand: DEXP
     model: 5.85" AS260
   os_family: Android
   browser_family: Chrome
@@ -605,7 +549,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GN810 Build/JZO54K) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.6.1 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -614,7 +557,7 @@
     version: "6.6.1"
   device:
     type: phablet
-    brand: GI
+    brand: Gionee
     model: GN810
   os_family: Android
   browser_family: Unknown
@@ -622,19 +565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Nexus 6 Build/LRX21D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: GO
+    brand: Google
     model: Nexus 6
   os_family: Android
   browser_family: Chrome
@@ -642,19 +583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Nexus 6P Build/MDA83) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: GO
+    brand: Google
     model: Nexus 6P
   os_family: Android
   browser_family: Chrome
@@ -662,19 +601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE720T Build/PKQ1.190302.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HI
+    brand: Hisense
     model: U30
   os_family: Android
   browser_family: Chrome
@@ -682,13 +619,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP Slate 6 Voice Tab Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -702,19 +637,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; fr-gb; HTC_One_max Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: HT
+    brand: HTC
     model: One max
   os_family: Android
   browser_family: Android Browser
@@ -722,19 +655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; HTC_One_max Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HT
+    brand: HTC
     model: One max
   os_family: Android
   browser_family: Chrome
@@ -742,19 +673,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; HTC One max Build/JSS15J) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.6.428 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.6.428"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: HT
+    brand: HTC
     model: One max
   os_family: Android
   browser_family: Unknown
@@ -762,19 +691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; MT2L03 Build/HuaweiMT2L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HU
+    brand: Huawei
     model: Ascend Mate 2
   os_family: Android
   browser_family: Chrome
@@ -782,19 +709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; HUAWEI MT2L03 Build/HuaweiMT2L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HU
+    brand: Huawei
     model: Ascend Mate 2
   os_family: Android
   browser_family: Chrome
@@ -802,19 +727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; HUAWEI MT7-L09 Build/HuaweiMT7-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HU
+    brand: Huawei
     model: Ascend Mate 7
   os_family: Android
   browser_family: Chrome
@@ -822,19 +745,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; fr-fr; Infinix X690 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: IF
+    brand: Infinix
     model: Note 7
   os_family: Android
   browser_family: Chrome
@@ -842,19 +763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X656) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: IF
+    brand: Infinix
     model: Note 7 Lite
   os_family: Android
   browser_family: Chrome
@@ -862,19 +781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQW603) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: LS
+    brand: MLS
     model: Phab 6.0"
   os_family: Android
   browser_family: Chrome
@@ -882,19 +799,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; m1 note Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M1 Note
   os_family: Android
   browser_family: Android Browser
@@ -902,19 +817,17 @@
   user_agent: m2 note/4.5 Linux/3.10.65 Android/5.1 Release/07.29.2015 Browser/Chrome40.0.2214.114 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M2 Note
   os_family: Android
   browser_family: Chrome
@@ -922,19 +835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MZ-m2 note Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "40.0.2214.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M2 Note
   os_family: Android
   browser_family: Chrome
@@ -942,19 +853,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; MZ-M571C Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "40.0.2214.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M2 Note
   os_family: Android
   browser_family: Chrome
@@ -962,19 +871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; M571C Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.114 Mobile Safari/537.36 LieBaoFast/3.17.4
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: LieBaoFast
-    short_name: LF
     version: "3.17.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M2 Note
   os_family: Android
   browser_family: Chrome
@@ -982,7 +889,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; m2 note) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 baidubrowser/5.3.4.0 (Baidu; P1 4.3.1) tieba/6.7.2 BMW
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -991,7 +897,7 @@
     version: "6.7.2"
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M2 Note
   os_family: Android
   browser_family: Unknown
@@ -999,19 +905,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; M681C Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M3 Note
   os_family: Android
   browser_family: Android Browser
@@ -1019,19 +923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; m3 note Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M3 Note
   os_family: Android
   browser_family: Chrome
@@ -1039,19 +941,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; zh-cn; M621C Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M5 Note
   os_family: Android
   browser_family: Unknown
@@ -1059,19 +959,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; MZ-M6 Note Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/45.0.2454.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M6 Note
   os_family: Android
   browser_family: Chrome
@@ -1079,19 +977,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M721C Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.110"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: M6 Note
   os_family: Android
   browser_family: Chrome
@@ -1099,19 +995,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; meizu note8 Build/OPM1.171019.026)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: Note 8
   os_family: Android
   browser_family: Android Browser
@@ -1119,19 +1013,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; meizu note9 Build/PKQ1.181203.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: M1
+    brand: Meizu
     model: Note 9
   os_family: Android
   browser_family: Android Browser
@@ -1139,7 +1031,6 @@
   user_agent: '[FBAN/FB4A;FBAV/83.0.0.20.71;FBBV/32723423;FBDM/{density=1.5,width=480,height=800};FBLC/it_IT;FBCR/vodafone IT;FBMF/MEDIACOM;FBBD/MTK-6580M;FBPN/com.facebook.katana;FBDV/M-PPxB400;FBSV/6.0;FBOP/1;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
@@ -1148,7 +1039,7 @@
     version: "83.0.0.20.71"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo B400
   os_family: Android
   browser_family: Unknown
@@ -1156,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; M-PP2G530 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G530
   os_family: Android
   browser_family: Chrome
@@ -1176,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-PPAG550 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G550
   os_family: Android
   browser_family: Chrome
@@ -1196,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; M-PPG700 Build/PhonePad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G700
   os_family: Android
   browser_family: Android Browser
@@ -1216,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxS531 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S531
   os_family: Android
   browser_family: Chrome
@@ -1236,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S550 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S550
   os_family: Android
   browser_family: Android Browser
@@ -1256,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxS551U Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S551U
   os_family: Android
   browser_family: Chrome
@@ -1276,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S650 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S650
   os_family: Android
   browser_family: Android Browser
@@ -1296,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S650C Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S650
   os_family: Android
   browser_family: Android Browser
@@ -1316,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; M-MP75S23G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Mobile
   os_family: Android
   browser_family: Android Browser
@@ -1336,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1; M-MP720M Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Mobile
   os_family: Android
   browser_family: Chrome
@@ -1356,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1; M-MP721M Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Mobile
   os_family: Android
   browser_family: Chrome
@@ -1376,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP7S2A3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -1396,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP7S2D3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -1416,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP7S2B3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -1436,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP7S2K3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -1456,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ar-eg; M-MP5303G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad Mini Mobile
   os_family: Android
   browser_family: Android Browser
@@ -1476,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 640 XL Dual SIM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 640 XL
   os_family: Windows
   browser_family: Internet Explorer
@@ -1496,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 640 XL Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/533.1
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 640 XL
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1516,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; RM-1096) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15063
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "15.15063"
     engine: Edge
     engine_version: "15.15063"
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 640 XL
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1536,19 +1389,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 10.0; en-IN; Microsoft; RM-1065_1008) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 640 XL
   os_family: Windows Mobile
   browser_family: Unknown
@@ -1556,13 +1407,12 @@
   user_agent: Windows Phone Ad Client/6.2.960.0 (Silverlight; MS_ORMMA_1_0; Windows Phone OS 10.0.13384.0; Microsoft; RM-1067_1005)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0.13384.0"
     platform: ""
   client: null
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 640 XL
   os_family: Windows Mobile
   browser_family: Unknown
@@ -1570,19 +1420,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 950 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/14.14295
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "14.14295"
     engine: Edge
     engine_version: "14.14295"
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 950 XL
   os_family: Windows
   browser_family: Internet Explorer
@@ -1590,19 +1438,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 950 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15031
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "15.15031"
     engine: Edge
     engine_version: "15.15031"
   device:
     type: phablet
-    brand: MS
+    brand: Microsoft
     model: Lumia 950 XL
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1610,7 +1456,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; N1T Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.0.54_r1169949.561 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -1619,7 +1464,7 @@
     version: "6.2.0.54.r1169949.561"
   device:
     type: phablet
-    brand: OP
+    brand: OPPO
     model: N1T
   os_family: Android
   browser_family: Unknown
@@ -1627,19 +1472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-F9000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Fold
   os_family: Android
   browser_family: Chrome
@@ -1647,19 +1490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-F900U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Fold
   os_family: Android
   browser_family: Chrome
@@ -1667,19 +1508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-F907B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Fold
   os_family: Android
   browser_family: Chrome
@@ -1687,19 +1526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-F907N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Fold
   os_family: Android
   browser_family: Chrome
@@ -1707,19 +1544,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-F900F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Fold
   os_family: Android
   browser_family: Chrome
@@ -1727,19 +1562,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; GT-I9080 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand
   os_family: Android
   browser_family: Android Browser
@@ -1747,19 +1580,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; GT-I9128I Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.4.484 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.4.484"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand
   os_family: Android
   browser_family: Unknown
@@ -1767,19 +1598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-G710 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand 2
   os_family: Android
   browser_family: Chrome
@@ -1787,19 +1616,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG SM-G7105 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand 2
   os_family: Android
   browser_family: Chrome
@@ -1807,19 +1634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G7102 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand 2
   os_family: Android
   browser_family: Chrome
@@ -1827,19 +1652,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G710L Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand 2
   os_family: Android
   browser_family: Chrome
@@ -1847,19 +1670,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; pl-pl; GT-I9082 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Duos
   os_family: Android
   browser_family: Android Browser
@@ -1867,19 +1688,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; th-th; GT-I9082L Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Duos
   os_family: Android
   browser_family: Android Browser
@@ -1887,19 +1706,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; tr-tr; GT-I9060 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Neo
   os_family: Android
   browser_family: Android Browser
@@ -1907,19 +1724,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pt-br; GT-I9063T Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Neo Duos
   os_family: Android
   browser_family: Android Browser
@@ -1927,19 +1742,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; SAMSUNG-GT-I9168_TD Release/1.15.2014 Browser/AppleWebKit/534.30 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Neo+
   os_family: Android
   browser_family: Android Browser
@@ -1947,19 +1760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G5308W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -1967,19 +1778,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G530BT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -1987,19 +1796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G530M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2007,19 +1814,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G530MU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2027,19 +1832,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-US; SM-G5306W Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.3.1199 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.3.1199"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Unknown
@@ -2047,19 +1850,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-S920L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2067,19 +1868,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-G530H Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2087,19 +1886,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; SM-G530F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.4.2.893
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.4.2.893"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Unknown
@@ -2107,19 +1904,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SAMSUNG-SM-G530AZ Build/LMY48B
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Android Browser
@@ -2127,19 +1922,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-G530T Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Android Browser
@@ -2147,19 +1940,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-G530W Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Android Browser
@@ -2167,19 +1958,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G530R7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2187,19 +1976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G5309W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2207,19 +1994,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G530P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2227,19 +2012,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG-SM-G530A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2247,19 +2030,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G530R4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2267,19 +2048,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G531F Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2287,19 +2066,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G531H Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -2307,19 +2084,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G532F Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.2 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime Plus
   os_family: Android
   browser_family: Chrome
@@ -2327,19 +2102,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; SM-G531Y Build/LMY48B AppleWebKit/537.36 KHTML, like Gecko Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime VE Duos
   os_family: Android
   browser_family: Chrome
@@ -2347,19 +2120,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; SM-G531BT AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime VE Duos
   os_family: Android
   browser_family: Chrome
@@ -2367,19 +2138,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; SM-G531M AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime VE Duos
   os_family: Android
   browser_family: Chrome
@@ -2387,19 +2156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G532M Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Prime
   os_family: Android
   browser_family: Chrome
@@ -2407,19 +2174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G532G Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.2 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Prime
   os_family: Android
   browser_family: Chrome
@@ -2427,19 +2192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G532MT Build/MMB29T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Prime (TV)
   os_family: Android
   browser_family: Chrome
@@ -2447,19 +2210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G750F Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 2
   os_family: Android
   browser_family: Chrome
@@ -2467,19 +2228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G750H Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 2
   os_family: Android
   browser_family: Chrome
@@ -2487,19 +2246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G7508Q Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 2
   os_family: Android
   browser_family: Chrome
@@ -2507,19 +2264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG-SM-G750A Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 2
   os_family: Android
   browser_family: Chrome
@@ -2527,19 +2282,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG-SM-G7509 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 2
   os_family: Android
   browser_family: Chrome
@@ -2547,19 +2300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9152 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 5.8
   os_family: Android
   browser_family: Chrome
@@ -2567,19 +2318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG GT-I9152 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 5.8
   os_family: Android
   browser_family: Chrome
@@ -2587,19 +2336,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; GT-I9158 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.1.401 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.1.401"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 5.8
   os_family: Android
   browser_family: Unknown
@@ -2607,19 +2354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9205 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 6.3
   os_family: Android
   browser_family: Chrome
@@ -2627,19 +2372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-gb; SAMSUNG GT-I9200 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Mega 6.3
   os_family: Android
   browser_family: Chrome
@@ -2647,19 +2390,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; xx-xx; GT-N7000 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2667,19 +2408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; pl-pl; GT-N7000 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2687,19 +2426,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; sl-si; GT-N7000 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2707,19 +2444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; GT-N7000 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "29.0.1547.72"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Chrome
@@ -2727,19 +2462,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; el-gr; GT-N7000 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2747,19 +2480,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; sk-sk; GT-N7000 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2767,19 +2498,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; pl-pl; GT-N7000 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2787,19 +2516,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; GT-N7000 Build/JOP40D; CyanogenMod-JellyBeer-v3.55) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note
   os_family: Android
   browser_family: Android Browser
@@ -2807,19 +2534,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N970F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2827,19 +2552,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N970U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2847,19 +2570,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N970X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2867,19 +2588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N9700) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2887,19 +2606,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N970U1) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2907,19 +2624,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N970W) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2927,19 +2642,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N971N/KSU1ASJF) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10
   os_family: Android
   browser_family: Chrome
@@ -2947,19 +2660,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N770X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -2967,19 +2678,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N770F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -2987,19 +2696,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N9750) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3007,19 +2714,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N975F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3027,19 +2732,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N975U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3047,19 +2750,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N975U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3067,19 +2768,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N975W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3087,19 +2786,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-N976V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3107,19 +2804,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SC-01M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3127,19 +2822,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N975X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3147,19 +2840,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N975XU) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3167,19 +2858,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N9760) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3187,19 +2876,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-N976N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3207,19 +2894,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N976U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3227,19 +2912,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N976Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3247,19 +2930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV45) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10+
   os_family: Android
   browser_family: Chrome
@@ -3267,19 +2948,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N980F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20
   os_family: Android
   browser_family: Chrome
@@ -3287,19 +2966,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-N980F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20
   os_family: Android
   browser_family: Chrome
@@ -3307,19 +2984,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-N981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 5G
   os_family: Android
   browser_family: Chrome
@@ -3327,19 +3002,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N981N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 5G
   os_family: Android
   browser_family: Chrome
@@ -3347,19 +3020,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N981U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 5G
   os_family: Android
   browser_family: Chrome
@@ -3367,19 +3038,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N981U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 5G
   os_family: Android
   browser_family: Chrome
@@ -3387,19 +3056,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N981W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 5G
   os_family: Android
   browser_family: Chrome
@@ -3407,19 +3074,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-N985F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 Ultra
   os_family: Android
   browser_family: Chrome
@@ -3427,19 +3092,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N986B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 Ultra 5G
   os_family: Android
   browser_family: Chrome
@@ -3447,19 +3110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-N986N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 Ultra 5G
   os_family: Android
   browser_family: Chrome
@@ -3467,19 +3128,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-N986B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.1 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 Ultra 5G
   os_family: Android
   browser_family: Chrome
@@ -3487,19 +3146,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; zh-cn; SAMSUNG-SM-N9008V_TD Release/11.15.2013 Browser/AppleWebKit537.36 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Android Browser
@@ -3507,7 +3164,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SM-N9009 Build/JSS15J) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/5.1 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -3516,7 +3172,7 @@
     version: "5.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Unknown
@@ -3524,19 +3180,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SM-N9008V Build/JSS15J) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/4.3.16.2 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.3.16.2"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Baidu
@@ -3544,19 +3198,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-N900V Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.58 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.58"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3564,19 +3216,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-N900W8 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3584,19 +3234,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-N900K Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3604,19 +3252,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-N900P Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3624,19 +3270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-ca; SM-N900W8 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3644,19 +3288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG SM-N900T Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3664,19 +3306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG SM-N900V Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3684,19 +3324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG-SM-N900A Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3704,19 +3342,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; ja-jp; SC-01F Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3724,19 +3360,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SM-N9006 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Unknown
@@ -3744,7 +3378,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SM-N9008V Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MicroMessenger/5.2.380
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -3753,7 +3386,7 @@
     version: "5.2.380"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Unknown
@@ -3761,19 +3394,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-N9005 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3781,19 +3412,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-N9000Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3801,19 +3430,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-N900T Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3821,19 +3448,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-N900S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3841,19 +3466,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-N9005 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3861,19 +3484,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-us; SAMSUNG SM-N900 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Chrome
@@ -3881,7 +3502,6 @@
   user_agent: Samsung SM-N900T stagefright/1.2 (Linux;Android 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -3890,7 +3510,7 @@
     version: "1.2"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Unknown
@@ -3898,19 +3518,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; SCL22 Build/LRX21V)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3
   os_family: Android
   browser_family: Android Browser
@@ -3918,19 +3536,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; SM-N9002 Build/JSS15J) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Duos
   os_family: Android
   browser_family: Unknown
@@ -3938,19 +3554,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-9005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 LTE
   os_family: Android
   browser_family: Chrome
@@ -3958,19 +3572,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; ko-kr; SM-N750L Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 NAVER(inapp; search; 270; 5.3.5)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Neo
   os_family: Android
   browser_family: Android Browser
@@ -3978,19 +3590,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-N7500Q Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Neo
   os_family: Android
   browser_family: Chrome
@@ -3998,19 +3608,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; ar-ae; SAMSUNG SM-N7505 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Neo
   os_family: Android
   browser_family: Chrome
@@ -4018,19 +3626,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; fr-fr; SAMSUNG SM-N750 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Neo
   os_family: Android
   browser_family: Chrome
@@ -4038,19 +3644,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; fr-fr; SAMSUNG SM-N7502 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 3 Neo Duos
   os_family: Android
   browser_family: Chrome
@@ -4058,19 +3662,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; N9100 Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4
   os_family: Android
   browser_family: Chrome
@@ -4078,7 +3680,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.4; SM-N910F Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/24.0.0.30.15;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -4087,7 +3688,7 @@
     version: "24.0.0.30.15"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4
   os_family: Android
   browser_family: Unknown
@@ -4095,19 +3696,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SM-910U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4
   os_family: Android
   browser_family: Chrome
@@ -4115,19 +3714,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; de-ch; SAMSUNG SM-N915FY Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "34.0.1847.76"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4 Edge
   os_family: Android
   browser_family: Chrome
@@ -4135,19 +3732,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.0.1; SM-N916S Build/LRX22C
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4 LTE
   os_family: Android
   browser_family: Android Browser
@@ -4155,19 +3750,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-N916K Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4 LTE
   os_family: Android
   browser_family: Android Browser
@@ -4175,19 +3768,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; SM-N916L Build/MMB29K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 4 LTE
   os_family: Android
   browser_family: Opera
@@ -4195,19 +3786,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-N920V Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Android Browser
@@ -4215,19 +3804,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-N920T Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4235,19 +3822,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-N920X Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4255,19 +3840,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 5.1.1; SM-N920F Build/LMY47X; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Opera
@@ -4275,19 +3858,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-N920I Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.4 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4295,19 +3876,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-N920S Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.4 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4315,19 +3894,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N920C Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4335,19 +3912,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N920K Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4355,19 +3930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N920R7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4375,19 +3948,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-N9200 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4395,19 +3966,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-N920L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4415,19 +3984,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-N920G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4435,19 +4002,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-N920R6 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4455,19 +4020,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-N920R4) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4475,19 +4038,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-N920W8) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -4495,19 +4056,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; es-LA; SM-N920P Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.9.1193 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.9.1193"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Unknown
@@ -4515,19 +4074,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N9208 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5 Duos
   os_family: Android
   browser_family: Chrome
@@ -4535,19 +4092,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4555,19 +4110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4575,19 +4128,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4595,19 +4146,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N9300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4615,19 +4164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4635,19 +4182,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 YaBrowser/19.3.3.285.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.3.3.285.00"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Unknown
@@ -4655,19 +4200,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SCV34 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -4675,19 +4218,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-N950U1 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8
   os_family: Android
   browser_family: Chrome
@@ -4695,19 +4236,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-N950F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8
   os_family: Android
   browser_family: Chrome
@@ -4715,19 +4254,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SCV37 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8
   os_family: Android
   browser_family: Chrome
@@ -4735,19 +4272,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-N950F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8
   os_family: Android
   browser_family: Chrome
@@ -4755,19 +4290,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SC-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8
   os_family: Android
   browser_family: Chrome
@@ -4775,19 +4308,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 9
   os_family: Android
   browser_family: Chrome
@@ -4795,19 +4326,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 9
   os_family: Android
   browser_family: Chrome
@@ -4815,19 +4344,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-N960F Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 9
   os_family: Android
   browser_family: Chrome
@@ -4835,19 +4362,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SC-01G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Edge
   os_family: Android
   browser_family: Chrome
@@ -4855,19 +4380,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; SM-N935F Build/PPR1.180610.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/43.1.2254.140112
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.1.2254.140112"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Fan Edition
   os_family: Android
   browser_family: Opera
@@ -4875,19 +4398,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; SM-N935S Build/PPR1.180610.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/43.1.2254.140112
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.1.2254.140112"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Fan Edition
   os_family: Android
   browser_family: Opera
@@ -4895,19 +4416,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-N935L Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.2.1188 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Fan Edition
   os_family: Android
   browser_family: Unknown
@@ -4915,19 +4434,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-N935K Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/71.0.3578.99 UCBrowser/12.9.7.1179 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1179"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Fan Edition
   os_family: Android
   browser_family: Unknown
@@ -4935,19 +4452,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SPH-L900 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -4955,19 +4470,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-ch; GT-N7100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -4975,19 +4488,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; SCH-I605 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -4995,19 +4506,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; SCH-R950 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 USCC-R950
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -5015,19 +4524,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SCH-N719 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -5035,19 +4542,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.5; fr-fr; N7100 Build/MocorDroid4.0.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II
   os_family: Android
   browser_family: Android Browser
@@ -5055,19 +4560,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; GT-N7105T Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II LTE
   os_family: Android
   browser_family: Android Browser
@@ -5075,19 +4578,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; GT-N7105 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note II LTE
   os_family: Android
   browser_family: Chrome
@@ -5095,7 +4596,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; XM50t Build/19.0.C.2.59) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.4 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -5104,7 +4604,7 @@
     version: "6.4"
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra
   os_family: Android
   browser_family: Unknown
@@ -5112,19 +4612,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D5303 Build/19.0.1.A.0.207) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra
   os_family: Android
   browser_family: Chrome
@@ -5132,19 +4630,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D5306 Build/19.0.1.A.0.223) AppleWebKit/537.36 (KHTML like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra
   os_family: Android
   browser_family: Chrome
@@ -5152,7 +4648,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; XM50h Build/19.1.1.C.0.56) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 baiduboxapp/5.0 (Baidu; P1 4.4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
@@ -5161,7 +4656,7 @@
     version: "5.0"
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra
   os_family: Android
   browser_family: Unknown
@@ -5169,19 +4664,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; D5316 Build/19.4.A.0.182) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra
   os_family: Android
   browser_family: Chrome
@@ -5189,19 +4682,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; D5322 Build/19.1.1.C.0.56) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.131 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.131"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia T2 Ultra Dual
   os_family: Android
   browser_family: Chrome
@@ -5209,19 +4700,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-ca; SonyC6806 Build/14.1.B.1.510) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Android Browser
@@ -5229,19 +4718,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; XL39h Build/14.1.B.2.257) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 V1_AND_SQ_4.5.0_5_YYB_D
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Android Browser
@@ -5249,19 +4736,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C6806 Build/14.1.B.1.532) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -5269,19 +4754,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C6802 Build/14.2.A.1.136) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -5289,19 +4772,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C6833 Build/14.3.A.0.757) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -5309,19 +4790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SOL24 Build/14.3.C.0.300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -5329,19 +4808,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; pt-br; C6843 Build/14.4.A.0.108) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Unknown
@@ -5349,19 +4826,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z Ultra) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -5369,19 +4844,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZUR722M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SS
+    brand: SWISSMOBILITY
     model: Z72 go
   os_family: Android
   browser_family: Chrome
@@ -5389,19 +4862,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Phablet 5,3 Q Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: T3
+    brand: Trevi
     model: Phablet 5.3 Q
   os_family: Android
   browser_family: Chrome
@@ -5409,19 +4880,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Trevi_REVERSE_5.5Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: T3
+    brand: Trevi
     model: Phablet 5.5 Q REVERSE
   os_family: Android
   browser_family: Chrome
@@ -5429,19 +4898,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; Trevi PHABLET 6 S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: T3
+    brand: Trevi
     model: Phablet 6 S
   os_family: Android
   browser_family: Android Browser
@@ -5449,19 +4916,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HM NOTE 1TD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Hongmi Note 1TD
   os_family: Android
   browser_family: Android Browser
@@ -5469,19 +4934,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-us; MI NOTE LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: MI Note LTE
   os_family: Android
   browser_family: Android Browser
@@ -5489,19 +4952,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; ru; MI_NOTE_Pro Build/LRX22G) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/9.7.0.520 Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: MI Note Pro
   os_family: Android
   browser_family: Unknown
@@ -5509,19 +4970,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HM NOTE 1W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note
   os_family: Android
   browser_family: Android Browser
@@ -5529,19 +4988,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; HM NOTE 1W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.0.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.0.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note
   os_family: Android
   browser_family: Android Browser
@@ -5549,19 +5006,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; HM NOTE 1W MIUI/V8.0.1.0.KHDMIDG)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note
   os_family: Android
   browser_family: Android Browser
@@ -5569,19 +5024,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HM NOTE 1W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note
   os_family: Android
   browser_family: Chrome
@@ -5589,19 +5042,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; Redmi Note 2 MIUI/V8.0.1.0.0.LHMMIDG)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 2
   os_family: Android
   browser_family: Android Browser
@@ -5609,19 +5060,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Redmi Note 2 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36 LieBaoFast/3.17.4
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: LieBaoFast
-    short_name: LF
     version: "3.17.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 2
   os_family: Android
   browser_family: Chrome
@@ -5629,19 +5078,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; Redmi Note 2 Build/LRX22G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 SogouMSE,SogouMobileBrowser/3.8.5
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "3.8.5"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 2
   os_family: Android
   browser_family: Safari
@@ -5649,19 +5096,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 5.0.2; en-US; Redmi_Note_2) U2/1.0.0 UCBrowser/9.7.0.520 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: ""
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 2
   os_family: Android
   browser_family: Unknown
@@ -5669,19 +5114,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 5.1.1; en-US; Redmi_Note_3) U2/1.0.0 UCBrowser/9.7.0.520 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: ""
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 3
   os_family: Android
   browser_family: Unknown
@@ -5689,19 +5132,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HM NOTE 1LTE Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: Android
   browser_family: Chrome
@@ -5709,19 +5150,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HM NOTE 1LTEW Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 MxBrowser/4.3.6.2000
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.3.6.2000"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: Android
   browser_family: Unknown
@@ -5729,19 +5168,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; HM NOTE 1LTEGLOBAL Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: Android
   browser_family: Chrome
@@ -5749,19 +5186,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; HM NOTE 1LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: Android
   browser_family: Chrome
@@ -5769,19 +5204,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-tw; HM NOTE 1LTEW Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.0.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.0.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: Android
   browser_family: Android Browser
@@ -5789,19 +5222,17 @@
   user_agent: UCWEB/2.0(Linux; U; Opera Mini/7.1.32052/30.3697; en-US; HM NOTE 1S Build/KTU84P) U2/1.0.0 UCBrowser/10.5.2.582 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 4G
   os_family: GNU/Linux
   browser_family: Opera
@@ -5809,19 +5240,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Redmi Note 5 Pro Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -5829,19 +5258,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Redmi Note 5 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -5849,19 +5276,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; Redmi Note 5 pro Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1143"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 5 Pro
   os_family: Android
   browser_family: Unknown
@@ -5869,19 +5294,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Redmi Note 5A Prime Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 5A Prime
   os_family: Android
   browser_family: Chrome
@@ -5889,19 +5312,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Redmi Note 6 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 6 Pro
   os_family: Android
   browser_family: Chrome
@@ -5909,19 +5330,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; de-de; Redmi Note 6 Pro Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.2.5-g
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "10.2.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 6 Pro
   os_family: Android
   browser_family: Android Browser
@@ -5929,19 +5348,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; Redmi Note 7 Pro Build/PKQ1.181203.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.1.1071 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.1.1071"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 7 Pro
   os_family: Android
   browser_family: Unknown
@@ -5949,19 +5366,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; Redmi Note 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 YaApp_Android/11.41 YaSearchBrowser/11.41 BroPP/1.0 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 8 Pro
   os_family: Android
   browser_family: Chrome
@@ -5969,19 +5384,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2003J15SC Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36 (Mobile; afma-sdk-a-v202117037.202117037.0)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: XI
+    brand: Xiaomi
     model: Redmi Note 9
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/portable_media_player.yml
+++ b/Tests/fixtures/portable_media_player.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (iPod; U; CPU iPhone OS 4_2_1 like Mac OS X; ja-jp) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8C148
   os:
     name: iOS
-    short_name: IOS
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: portable media player
-    brand: AP
+    brand: Apple
     model: iPod Touch
   os_family: iOS
   browser_family: Safari
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (iPod; U; CPU iPhone OS 4_3_0 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/4B2086
   os:
     name: iOS
-    short_name: IOS
     version: "4.3.0"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: portable media player
-    brand: AP
+    brand: Apple
     model: iPod Touch
   os_family: iOS
   browser_family: Safari
@@ -43,7 +39,6 @@
   user_agent: Mozilla/5.0 (iPod touch; CPU iPhone OS 9_3_5 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G36 Instagram 9.7.0 (iPod5,1; iPhone OS
   os:
     name: iOS
-    short_name: IOS
     version: "9.3.5"
     platform: ""
   client:
@@ -52,7 +47,7 @@
     version: "9.7.0"
   device:
     type: portable media player
-    brand: AP
+    brand: Apple
     model: iPod Touch 5
   os_family: iOS
   browser_family: Unknown
@@ -60,19 +55,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; fr-fr; COWON D3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: portable media player
-    brand: CW
+    brand: Cowon
     model: D3
   os_family: Android
   browser_family: Android Browser
@@ -80,19 +73,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; COWON Z2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: portable media player
-    brand: CW
+    brand: Cowon
     model: Z2
   os_family: Android
   browser_family: Android Browser
@@ -100,19 +91,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12; Microsoft ZuneHD 4.3)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "6.12"
     engine: Trident
     engine_version: ""
   device:
     type: portable media player
-    brand: MS
+    brand: Microsoft
     model: Zune HD
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -120,19 +109,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; ja-jp; Panasonic SV-MV100 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: portable media player
-    brand: PA
+    brand: Panasonic
     model: SV-MV100
   os_family: Android
   browser_family: Android Browser
@@ -140,19 +127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ko-kr; YP-GB1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: portable media player
-    brand: SA
+    brand: Samsung
     model: Galaxy Player 4.0
   os_family: Android
   browser_family: Android Browser
@@ -160,19 +145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; YP-GI1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: portable media player
-    brand: SA
+    brand: Samsung
     model: Galaxy Player 4.2
   os_family: Android
   browser_family: Android Browser
@@ -180,19 +163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; HMT390Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: portable media player
-    brand: XR
+    brand: Xoro
     model: HMT 390Q
   os_family: Android
   browser_family: Chrome
@@ -200,19 +181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HMT400 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: portable media player
-    brand: XR
+    brand: Xoro
     model: HMT 400
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smart_display.yml
+++ b/Tests/fixtures/smart_display.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; DA220HQL Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smart display
-    brand: AC
+    brand: Acer
     model: DA220HQL
   os_family: Android
   browser_family: Android Browser
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; DA241HL Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smart display
-    brand: AC
+    brand: Acer
     model: DA241HL
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; VSD220 Build/IMM76D.UI23ED12_VSC) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smart display
-    brand: VS
+    brand: ViewSonic
     model: VSD220
   os_family: Android
   browser_family: Android Browser

--- a/Tests/fixtures/smart_speaker.yml
+++ b/Tests/fixtures/smart_speaker.yml
@@ -3,13 +3,12 @@
   user_agent: AppleCoreMedia/1.0.0.15F80 (HomePod; U; CPU OS 11_4 like Mac OS X; fr_fr)
   os:
     name: iOS
-    short_name: IOS
     version: "11.4"
     platform: ""
   client: null
   device:
     type: smart speaker
-    brand: AP
+    brand: Apple
     model: HomePod
   os_family: iOS
   browser_family: Unknown
@@ -17,19 +16,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; AEOBC Build/LVY48F)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smart speaker
-    brand: KN
+    brand: Amazon
     model: Echo
   os_family: Android
   browser_family: Android Browser
@@ -37,19 +34,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AEOKN Build/LVY48F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smart speaker
-    brand: KN
+    brand: Amazon
     model: Echo
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-1.yml
+++ b/Tests/fixtures/smartphone-1.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5061 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: "5061"
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; i7U Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I Lite i7U
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; i4U Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I4U
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; i55D Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I55D
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; i55K Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I55K
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; i5E Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I5E
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; i5K Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I5K
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; I7D Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: I7D
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ADVAN M4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: M4
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ADVAN S40 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S40
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S45E Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S45E
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S4Z Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S4Z
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; S50H Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S50H
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S5E_NXT Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S5E NXT
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; S5J+ Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S5J+
   os_family: Android
   browser_family: Android Browser
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; S7D Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: S7D
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Alpha Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Alpha
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Atom Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Atom
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Bro Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Bro
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HEAT3 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Heat 3
   os_family: Android
   browser_family: Chrome
@@ -403,7 +363,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; HEAT4 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36[FBAN/EMA;FBLC/en_GB;FBAV/77.0.0.3.186;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -412,7 +371,7 @@
     version: "77.0.0.3.186"
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Heat 4
   os_family: Android
   browser_family: Unknown
@@ -420,19 +379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Hot 1 Mini+ Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.4.2.995 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.4.2.995"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Hot 1 Mini+
   os_family: Android
   browser_family: Unknown
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Hot 1 X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.5.0.1015 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.5.0.1015"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Hot 1 X
   os_family: Android
   browser_family: Unknown
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Hot 2 X Build/MRA58K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Hot 2 X
   os_family: Android
   browser_family: Chrome
@@ -480,19 +433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HOT5 Mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Hot 5 Mini
   os_family: Android
   browser_family: Chrome
@@ -500,19 +451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Madrid Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Madrid
   os_family: Android
   browser_family: Chrome
@@ -520,19 +469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_RIO Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Rio
   os_family: Android
   browser_family: Chrome
@@ -540,19 +487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Rio_Pro Build/HDAllCall_Rio_Pro) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Rio Pro
   os_family: Android
   browser_family: Chrome
@@ -560,19 +505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AllCall_Rio_S Build/HDAllCall_Rio_S) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Rio S
   os_family: Android
   browser_family: Chrome
@@ -580,19 +523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Rio_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Rio X
   os_family: Android
   browser_family: Chrome
@@ -600,19 +541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AllCall_S1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: S1
   os_family: Android
   browser_family: Chrome
@@ -620,19 +559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AllCall_S1_X Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: S1 X
   os_family: Android
   browser_family: Chrome
@@ -640,19 +577,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Allegro
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -660,19 +595,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Acer; Allegro; bouygues)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Allegro
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -680,19 +613,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) acer_E100
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: beTouch E100
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -700,19 +631,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) acer_F900
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: F900
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -720,19 +649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; V360 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid E1 Duo
   os_family: Android
   browser_family: Chrome
@@ -740,19 +667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; V370 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid E2 Duo
   os_family: Android
   browser_family: Chrome
@@ -760,19 +685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; E39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid E700
   os_family: Android
   browser_family: Chrome
@@ -780,7 +703,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; E39 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/24.0.0.30.15;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -789,7 +711,7 @@
     version: "24.0.0.30.15"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid E700
   os_family: Android
   browser_family: Unknown
@@ -797,19 +719,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; Acer E320 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Express
   os_family: Android
   browser_family: Android Browser
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; Acer E320-orange Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Express
   os_family: Android
   browser_family: Android Browser
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S55 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/49.2.2361.134358
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "49.2.2361.134358"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Jade
   os_family: Android
   browser_family: Opera
@@ -857,19 +773,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; ACER INC.; M220) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid M220
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -877,19 +791,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; ACERINC; TM01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid M330
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -897,19 +809,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; E310 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 ACER_E310/1.300.05
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Mini
   os_family: Android
   browser_family: Android Browser
@@ -917,19 +827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; S510 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid S1
   os_family: Android
   browser_family: Chrome
@@ -937,19 +845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; S520 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid S2
   os_family: Android
   browser_family: Chrome
@@ -957,19 +863,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Acer-Z110 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z110
   os_family: Android
   browser_family: Android Browser
@@ -977,19 +881,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr_FR; Z130 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z3
   os_family: Android
   browser_family: Android Browser
@@ -997,19 +899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Z160 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z4 Duo
   os_family: Android
   browser_family: Chrome
@@ -1017,19 +917,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; Z150 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z5 Duo
   os_family: Android
   browser_family: Unknown
@@ -1037,19 +935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Z500 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z500
   os_family: Android
   browser_family: Chrome
@@ -1057,19 +953,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Z520 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z520
   os_family: Android
   browser_family: Chrome
@@ -1077,19 +971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T02 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z530
   os_family: Android
   browser_family: Chrome
@@ -1097,19 +989,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T03 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z630
   os_family: Android
   browser_family: Chrome
@@ -1117,19 +1007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T04 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Z630S
   os_family: Android
   browser_family: Chrome
@@ -1137,19 +1025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T06 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Zest
   os_family: Android
   browser_family: Chrome
@@ -1157,19 +1043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T07 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Zest 4G
   os_family: Android
   browser_family: Chrome
@@ -1177,19 +1061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T08 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Liquid Zest Plus
   os_family: Android
   browser_family: Chrome
@@ -1197,19 +1079,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) Acer_P400 1.023h.00
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: neoTouch P400
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1217,19 +1097,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.O; windows CE; IEMobile 8.12; MSIEMobile 6.0) acer_S200
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: neoTouch S200
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1239,13 +1117,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "4.1.20"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: Pro80
   os_family: Unknown
   browser_family: Unknown
@@ -1253,19 +1130,17 @@
   user_agent: AcerTD600_TD/1.0 Android/2.2 (Linux; Android 2.2) Release/12.20.2010 Browser/WAP 2.0 AppleWebKit/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: AC
+    brand: Acer
     model: TD600
   os_family: Android
   browser_family: Android Browser
@@ -1273,19 +1148,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Hollogram HI 4934 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100502010
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AD
+    brand: Advance
     model: Hollogram HI 4934
   os_family: Android
   browser_family: Chrome
@@ -1293,19 +1166,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HOLLOGRAM HL5446 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AD
+    brand: Advance
     model: Hollogram HL5446
   os_family: Android
   browser_family: Chrome
@@ -1313,19 +1184,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HL6246 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AD
+    brand: Advance
     model: Hollogram HL6246
   os_family: Android
   browser_family: Chrome
@@ -1333,19 +1202,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BUZZ 1 Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AE
+    brand: Ace
     model: Buzz 1 Lite
   os_family: Android
   browser_family: Chrome
@@ -1353,19 +1220,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BUZZ 1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AE
+    brand: Ace
     model: Buzz 1 Plus
   os_family: Android
   browser_family: Chrome
@@ -1373,19 +1238,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM530 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -1393,19 +1256,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AM405 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: AM405
   os_family: Android
   browser_family: Chrome
@@ -1413,19 +1274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AM415 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: AM415
   os_family: Android
   browser_family: Chrome
@@ -1433,19 +1292,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM518 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: C1
   os_family: Android
   browser_family: Chrome
@@ -1453,19 +1310,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM515 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: D1
   os_family: Android
   browser_family: Chrome
@@ -1473,19 +1328,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM508) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Fuego
   os_family: Android
   browser_family: Chrome
@@ -1493,19 +1346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AM527 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Geo
   os_family: Android
   browser_family: Chrome
@@ -1513,19 +1364,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM350 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Jack Pro
   os_family: Android
   browser_family: Chrome
@@ -1533,19 +1382,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM535 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: P1
   os_family: Android
   browser_family: Chrome
@@ -1553,19 +1400,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AM523 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Plus
   os_family: Android
   browser_family: Chrome
@@ -1573,19 +1418,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM520 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Pro
   os_family: Android
   browser_family: Chrome
@@ -1593,19 +1436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AM402 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Pronto
   os_family: Android
   browser_family: Chrome
@@ -1613,19 +1454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AM450 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Swift
   os_family: Android
   browser_family: Chrome
@@ -1633,19 +1472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AM407 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Tigo
   os_family: Android
   browser_family: Chrome
@@ -1653,19 +1490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AM355 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Tigo
   os_family: Android
   browser_family: Chrome
@@ -1673,19 +1508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM410 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Unico
   os_family: Android
   browser_family: Chrome
@@ -1693,19 +1526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AM509 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AG
+    brand: AMGOO
     model: Uno
   os_family: Android
   browser_family: Chrome
@@ -1713,19 +1544,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ECO E2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100502010
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: Eco E2
   os_family: Android
   browser_family: Chrome
@@ -1733,19 +1562,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GLORY_G5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36 OPR/30.0.1856.93524
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "30.0.1856.93524"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: Glory G5
   os_family: Android
   browser_family: Opera
@@ -1753,19 +1580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GLORY L3 Build/Android4.4.2-2015.07.08) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 wkbrowser 4.0.4 413
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: Glory L3
   os_family: Android
   browser_family: Chrome
@@ -1773,19 +1598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GLORY O2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: Glory O2
   os_family: Android
   browser_family: Chrome
@@ -1793,19 +1616,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X6 METAL Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: iLike
   os_family: Android
   browser_family: Chrome
@@ -1813,19 +1634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AKAI K40 Build/AKAI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: K40
   os_family: Android
   browser_family: Chrome
@@ -1833,19 +1652,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AKAI LEON QUADRA Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: LEON QUADRA
   os_family: Android
   browser_family: Chrome
@@ -1853,19 +1670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AKAI_NEO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AK
+    brand: Akai
     model: NEO
   os_family: Android
   browser_family: Chrome
@@ -1873,19 +1688,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1893,19 +1706,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1913,19 +1724,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1933,19 +1742,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1953,19 +1760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1973,19 +1778,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1993,19 +1796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2013,19 +1814,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033X_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2033,19 +1832,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033D_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2053,19 +1850,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033F_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2073,19 +1868,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2093,19 +1886,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5033J Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -2113,19 +1904,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; 5033D_RU Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.0.1187 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.0.1187"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "1"
   os_family: Android
   browser_family: Unknown
@@ -2133,19 +1922,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; 5009D_RU Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C
   os_family: Android
   browser_family: Android Browser
@@ -2153,19 +1940,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5009D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C
   os_family: Android
   browser_family: Chrome
@@ -2173,19 +1958,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5009A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C
   os_family: Android
   browser_family: Chrome
@@ -2193,19 +1976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5003G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C (2019)
   os_family: Android
   browser_family: Chrome
@@ -2213,19 +1994,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5003D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C (2019)
   os_family: Android
   browser_family: Chrome
@@ -2233,19 +2012,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5003D_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C (2019)
   os_family: Android
   browser_family: Chrome
@@ -2253,19 +2030,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5003A Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C (2019)
   os_family: Android
   browser_family: Chrome
@@ -2273,19 +2048,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5003D_EEA) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1C (2019)
   os_family: Android
   browser_family: Chrome
@@ -2293,19 +2066,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5024A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S
   os_family: Android
   browser_family: Chrome
@@ -2313,19 +2084,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ru-ru; 5024D_RU Build/PPR1.180610.011;) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S
   os_family: Android
   browser_family: Chrome
@@ -2333,19 +2102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5024J Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S
   os_family: Android
   browser_family: Chrome
@@ -2353,19 +2120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5024D_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.2.2672.49907
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.2.2672.49907"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S
   os_family: Android
   browser_family: Opera
@@ -2373,19 +2138,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 5028Y_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S
   os_family: Android
   browser_family: Chrome
@@ -2393,19 +2156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 5028A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1S (2020)
   os_family: Android
   browser_family: Chrome
@@ -2413,19 +2174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5001A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1V
   os_family: Android
   browser_family: Chrome
@@ -2433,19 +2192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 5007A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1V (2020)
   os_family: Android
   browser_family: Chrome
@@ -2453,19 +2210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059A Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2473,19 +2228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059X Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2493,19 +2246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059D Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2513,19 +2264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059Y Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2533,19 +2282,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2553,19 +2300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Chrome
@@ -2573,19 +2318,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; 5059D_RU Build/O11019 AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1178 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1178"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X
   os_family: Android
   browser_family: Unknown
@@ -2593,19 +2336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5008U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X (2019)
   os_family: Android
   browser_family: Chrome
@@ -2613,19 +2354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5008D_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X (2019)
   os_family: Android
   browser_family: Chrome
@@ -2633,19 +2372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5008Y_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X (2019)
   os_family: Android
   browser_family: Chrome
@@ -2653,19 +2390,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5008Y_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 1X (2019)
   os_family: Android
   browser_family: Chrome
@@ -2673,19 +2408,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5052D Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2693,19 +2426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5053Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2713,19 +2444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5053K_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2733,19 +2462,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5053K_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2753,19 +2480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5053Y_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2773,19 +2498,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5052Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2793,19 +2516,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; 5052D_RU Build/O11019 AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.5.0.1015 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.5.0.1015"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Unknown
@@ -2813,19 +2534,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5053A Build/PKQ1.190407.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2833,19 +2552,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 5029E Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3 (2020)
   os_family: Android
   browser_family: Chrome
@@ -2853,19 +2570,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; 5026J Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3C
   os_family: Android
   browser_family: Android Browser
@@ -2873,19 +2588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5026D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3C
   os_family: Android
   browser_family: Chrome
@@ -2893,19 +2606,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5026A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3C
   os_family: Android
   browser_family: Chrome
@@ -2913,19 +2624,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5034D Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3L
   os_family: Android
   browser_family: Chrome
@@ -2933,19 +2642,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; 5034D_RU Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.3.1144 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.3.1144"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3L
   os_family: Android
   browser_family: Unknown
@@ -2953,19 +2660,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5099A Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -2973,19 +2678,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5099I Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -2993,19 +2696,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5099U Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -3013,19 +2714,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5099Y Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -3033,19 +2732,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5099D Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -3053,19 +2750,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; 5099D_RU Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Opera
@@ -3073,19 +2768,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5032W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3V
   os_family: Android
   browser_family: Chrome
@@ -3093,19 +2786,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 5058I Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X
   os_family: Android
   browser_family: Chrome
@@ -3113,19 +2804,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 5058A Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X
   os_family: Android
   browser_family: Chrome
@@ -3133,19 +2822,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 5058I_RU Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X
   os_family: Android
   browser_family: Chrome
@@ -3153,19 +2840,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 5058Y Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X
   os_family: Android
   browser_family: Chrome
@@ -3173,19 +2858,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5048Y_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X (2019)
   os_family: Android
   browser_family: Chrome
@@ -3193,19 +2876,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5048A Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X (2019)
   os_family: Android
   browser_family: Chrome
@@ -3213,19 +2894,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5048U Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X (2019)
   os_family: Android
   browser_family: Chrome
@@ -3233,19 +2912,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; 5048Y_RU Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 OPR/46.0.2254.145391
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "46.0.2254.145391"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: 3X (2019)
   os_family: Android
   browser_family: Opera
@@ -3253,19 +2930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5086A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "5"
   os_family: Android
   browser_family: Chrome
@@ -3273,19 +2948,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5086D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "5"
   os_family: Android
   browser_family: Chrome
@@ -3293,19 +2966,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5086Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "5"
   os_family: Android
   browser_family: Chrome
@@ -3313,19 +2984,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 6062W Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -3333,19 +3002,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A501DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -3353,19 +3020,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A503DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A1X
   os_family: Android
   browser_family: Chrome
@@ -3373,19 +3038,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5046I Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3393,19 +3056,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5046Y Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3413,19 +3074,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5046J Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3433,19 +3092,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5046D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3453,19 +3110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5046U Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3473,19 +3128,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5046A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3493,19 +3146,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5046T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -3513,19 +3164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 Plus
   os_family: Android
   browser_family: Chrome
@@ -3533,19 +3182,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5011A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 Plus
   os_family: Android
   browser_family: Chrome
@@ -3553,19 +3200,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049E Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 Plus
   os_family: Android
   browser_family: Chrome
@@ -3573,19 +3218,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 Plus
   os_family: Android
   browser_family: Chrome
@@ -3593,19 +3236,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3613,19 +3254,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008J Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3633,19 +3272,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3653,19 +3290,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3673,19 +3308,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3693,19 +3326,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3713,19 +3344,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008I Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3733,19 +3362,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9008N Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A3 XL
   os_family: Android
   browser_family: Chrome
@@ -3753,19 +3380,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5046G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A30
   os_family: Android
   browser_family: Chrome
@@ -3773,19 +3398,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5046S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A30
   os_family: Android
   browser_family: Chrome
@@ -3793,19 +3416,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049Z Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A30 Fierce
   os_family: Android
   browser_family: Chrome
@@ -3813,19 +3434,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A30 Plus
   os_family: Android
   browser_family: Chrome
@@ -3833,19 +3452,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085B Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -3853,19 +3470,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085Q Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -3873,19 +3488,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3893,19 +3506,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085I Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3913,19 +3524,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085Y Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3933,19 +3542,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3953,19 +3560,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085J Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3973,19 +3578,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085H Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 LED
   os_family: Android
   browser_family: Chrome
@@ -3993,19 +3596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5085N Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A5 Max LED
   os_family: Android
   browser_family: Chrome
@@ -4013,19 +3614,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5085G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A50
   os_family: Android
   browser_family: Chrome
@@ -4033,19 +3632,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5085O Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A50
   os_family: Android
   browser_family: Chrome
@@ -4053,19 +3650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5090I Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -4073,19 +3668,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5090A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -4093,19 +3686,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5090Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -4113,19 +3704,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5059S Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Avalon V
   os_family: Android
   browser_family: Chrome
@@ -4133,19 +3722,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; ONE TOUCH 4007D Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 4007D
   os_family: Android
   browser_family: Android Browser
@@ -4153,19 +3740,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.6; en-US; ONE_TOUCH_4007D) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 4007D
   os_family: Android
   browser_family: Unknown
@@ -4173,19 +3758,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 4010A Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 4010A
   os_family: Android
   browser_family: Android Browser
@@ -4193,19 +3776,17 @@
   user_agent: Mozilla/5.0 (Mobile; ALCATEL ONE TOUCH 4012A; rv:18.1) Gecko/18.1 Firefox/18.1
   os:
     name: Firefox OS
-    short_name: FOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "18.1"
     engine: Gecko
     engine_version: "18.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: ONE TOUCH 4012A
   os_family: Firefox OS
   browser_family: Firefox
@@ -4213,19 +3794,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; ONE_TOUCH_4033E) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.460"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 4033E
   os_family: Android
   browser_family: Unknown
@@ -4233,19 +3812,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL ONE TOUCH 5020A Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Mobile Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 5020A
   os_family: Android
   browser_family: Opera
@@ -4253,19 +3830,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ALCATEL ONE TOUCH 5035D Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 5035D
   os_family: Android
   browser_family: Chrome
@@ -4273,19 +3848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ALCATEL ONE TOUCH 5035X Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 5035X
   os_family: Android
   browser_family: Chrome
@@ -4295,13 +3868,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.377"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 585
   os_family: Unknown
   browser_family: Unknown
@@ -4309,19 +3881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ALCATEL ONE TOUCH 6033X Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 6033X
   os_family: Android
   browser_family: Chrome
@@ -4329,19 +3899,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-re; ALCATEL_one_touch_908F_Orange Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 908F Orange
   os_family: Android
   browser_family: Android Browser
@@ -4349,19 +3917,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 918 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 918
   os_family: Android
   browser_family: Android Browser
@@ -4369,19 +3935,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 918A Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 918A
   os_family: Android
   browser_family: Android Browser
@@ -4389,19 +3953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 918S Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 918S
   os_family: Android
   browser_family: Android Browser
@@ -4409,19 +3971,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ONE_TOUCH_960C Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 960C
   os_family: Android
   browser_family: Android Browser
@@ -4429,19 +3989,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; ALCATEL ONE TOUCH 985 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 985
   os_family: Android
   browser_family: Android Browser
@@ -4449,19 +4007,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; ALCATEL one touch 990C+ Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 990C+
   os_family: Android
   browser_family: Android Browser
@@ -4469,19 +4025,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-es; ALCATEL ONE TOUCH 991 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 991
   os_family: Android
   browser_family: Android Browser
@@ -4489,19 +4043,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.6; fr-FR; ALCATEL_ONE_TOUCH_991) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 991
   os_family: Android
   browser_family: Unknown
@@ -4509,19 +4061,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; pl-pl; ALCATEL ONE TOUCH 991D Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 991D
   os_family: Android
   browser_family: Android Browser
@@ -4529,19 +4079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; it-it; ALCATEL ONE TOUCH 993D Build/ICECREAM) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 993D
   os_family: Android
   browser_family: Android Browser
@@ -4549,19 +4097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; sr-rs; ALCATEL_one_touch_995 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 995
   os_family: Android
   browser_family: Android Browser
@@ -4569,19 +4115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ALCATEL ONE TOUCH 997D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 997D
   os_family: Android
   browser_family: Android Browser
@@ -4589,19 +4133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ALCATEL ONE TOUCH 997D Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch 997D
   os_family: Android
   browser_family: Chrome
@@ -4609,19 +4151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5027B Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Dawn
   os_family: Android
   browser_family: Chrome
@@ -4629,19 +4169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH Fierce Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce
   os_family: Android
   browser_family: Chrome
@@ -4649,19 +4187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040T Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce 2
   os_family: Android
   browser_family: Chrome
@@ -4669,19 +4205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040R Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce 2
   os_family: Android
   browser_family: Chrome
@@ -4689,19 +4223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056W Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce 4
   os_family: Android
   browser_family: Chrome
@@ -4709,19 +4241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056N Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce 4
   os_family: Android
   browser_family: Chrome
@@ -4729,19 +4259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5054N Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Fierce XL
   os_family: Android
   browser_family: Chrome
@@ -4749,19 +4277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7048A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Go Play
   os_family: Android
   browser_family: Chrome
@@ -4769,19 +4295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7048S Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Go Play
   os_family: Android
   browser_family: Chrome
@@ -4789,19 +4313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7048W Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Go Play
   os_family: Android
   browser_family: Chrome
@@ -4809,19 +4331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7048X Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Go Play
   os_family: Android
   browser_family: Chrome
@@ -4829,19 +4349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 8030Y Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Hero 2
   os_family: Android
   browser_family: Chrome
@@ -4849,19 +4367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7055A Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Hero 2C
   os_family: Android
   browser_family: Chrome
@@ -4869,19 +4385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 6037Y Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2
   os_family: Android
   browser_family: Chrome
@@ -4889,19 +4403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 6037B Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2
   os_family: Android
   browser_family: Chrome
@@ -4909,19 +4421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 6037K Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2
   os_family: Android
   browser_family: Chrome
@@ -4929,19 +4439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6016X Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini
   os_family: Android
   browser_family: Chrome
@@ -4949,19 +4457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6016D Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -4969,19 +4475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6016E Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -4989,19 +4493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6036A Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini S
   os_family: Android
   browser_family: Chrome
@@ -5009,19 +4511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6036X Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini S
   os_family: Android
   browser_family: Chrome
@@ -5029,19 +4529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6036Y Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2 mini S
   os_family: Android
   browser_family: Chrome
@@ -5049,19 +4547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 6050Y Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 2S
   os_family: Android
   browser_family: Chrome
@@ -5069,19 +4565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 6039H Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3
   os_family: Android
   browser_family: Chrome
@@ -5089,19 +4583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6039Y Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3
   os_family: Android
   browser_family: Chrome
@@ -5109,19 +4601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6039K Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3
   os_family: Android
   browser_family: Chrome
@@ -5129,7 +4619,6 @@
   user_agent: PodcastRepublic/18.0 (Linux; U; Android 6.0.1;idol3/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -5138,7 +4627,7 @@
     version: "18.0"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3
   os_family: Android
   browser_family: Unknown
@@ -5146,19 +4635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 6045I Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5166,19 +4653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 6045B Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5186,19 +4671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 6045F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5206,19 +4689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 6045X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5226,19 +4707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6045Y Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5246,19 +4725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6045O Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5266,19 +4743,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; 6055K Build/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Android Browser
@@ -5286,19 +4761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055H Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5306,19 +4779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055I Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5326,19 +4797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055Y Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5346,19 +4815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055A Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5366,19 +4833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Alcatel 6055U Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5386,19 +4851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055B Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5406,19 +4869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055D Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5426,19 +4887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6055Z Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4
   os_family: Android
   browser_family: Chrome
@@ -5446,19 +4905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 6070K Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 4S
   os_family: Android
   browser_family: Chrome
@@ -5466,19 +4923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 6058A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 5
   os_family: Android
   browser_family: Chrome
@@ -5486,19 +4941,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 6058X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 5
   os_family: Android
   browser_family: Chrome
@@ -5506,19 +4959,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 6058D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 5
   os_family: Android
   browser_family: Chrome
@@ -5526,19 +4977,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 6060S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol 5S
   os_family: Android
   browser_family: Chrome
@@ -5546,19 +4995,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 6043D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol X+
   os_family: Android
   browser_family: Chrome
@@ -5566,19 +5013,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 6043A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Idol X+
   os_family: Android
   browser_family: Chrome
@@ -5586,19 +5031,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056I Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Optus X Smart
   os_family: Android
   browser_family: Chrome
@@ -5606,19 +5049,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4014D Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 2
   os_family: Android
   browser_family: Chrome
@@ -5626,19 +5067,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5646,19 +5085,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5666,19 +5103,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5686,19 +5121,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009K Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5706,19 +5139,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5726,19 +5157,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5746,19 +5175,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5"
   os_family: Android
   browser_family: Chrome
@@ -5766,19 +5193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -5786,19 +5211,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4009E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 3.5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -5806,19 +5229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4003A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5826,19 +5247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4003J Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5846,19 +5265,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4013E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5866,19 +5283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4013J Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5886,19 +5301,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4013K Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5906,19 +5319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4013X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5926,19 +5337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4114E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5946,19 +5355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4014A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5966,19 +5373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4014K Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -5986,19 +5391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4014M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -6006,19 +5409,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4014X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -6026,19 +5427,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4014E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -6046,19 +5445,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; es-us; 4013M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4"
   os_family: Android
   browser_family: Chrome
@@ -6066,19 +5463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4028A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6086,19 +5481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4028J Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6106,19 +5499,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4028S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6126,19 +5517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4027A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6146,19 +5535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4027N Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6166,19 +5553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4027D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6186,19 +5571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4028E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6206,19 +5589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-us; 4027X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6226,19 +5607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5019D Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6246,19 +5625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5017A Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6266,19 +5643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5017E Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6286,19 +5661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5017D Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6306,19 +5679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5017O Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6326,19 +5697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5017X Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6346,19 +5715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5017B Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 4.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6366,19 +5733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6386,19 +5751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6406,19 +5769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017E Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6426,19 +5787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017F Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6446,19 +5805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017S Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6466,19 +5823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4017X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 3.5"
   os_family: Android
   browser_family: Chrome
@@ -6486,19 +5841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4034D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6506,19 +5859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4034A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6526,19 +5877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4034E Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6546,19 +5895,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4034G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6566,19 +5913,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4034X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6586,19 +5931,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 4034L_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4"
   os_family: Android
   browser_family: Chrome
@@ -6606,19 +5949,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 4060W Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6626,19 +5967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 4060S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/42.0.2311.154 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "42.0.2311.154"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 4.5"
   os_family: Android
   browser_family: Chrome
@@ -6646,19 +5985,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5010E Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6666,19 +6003,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5010G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6686,19 +6021,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5010S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6706,19 +6039,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5010U Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6726,19 +6057,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5010X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6746,19 +6075,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6766,19 +6093,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045F Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6786,19 +6111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6806,19 +6129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045I Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6826,19 +6147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045J Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6846,19 +6165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5045Y Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6866,19 +6183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5145A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6886,19 +6201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5041D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5.0"
   os_family: Android
   browser_family: Chrome
@@ -6906,19 +6219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5012G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5.5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6926,19 +6237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5012D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5.5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6946,19 +6255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5012F Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 5.5" 3G
   os_family: Android
   browser_family: Chrome
@@ -6966,19 +6273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 8050X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 3G
   os_family: Android
   browser_family: Chrome
@@ -6986,19 +6291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; es-mx; 8050G Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 3G
   os_family: Android
   browser_family: Chrome
@@ -7006,19 +6309,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; 8050D Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 3G Dual SIM
   os_family: Android
   browser_family: Android Browser
@@ -7026,19 +6327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 8050E Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 3G Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7046,19 +6345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 9001D Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 4G
   os_family: Android
   browser_family: Chrome
@@ -7066,19 +6363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5098S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 4G
   os_family: Android
   browser_family: Chrome
@@ -7086,19 +6381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 9001I Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 4G
   os_family: Android
   browser_family: Chrome
@@ -7106,19 +6399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 9001X Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 6" 4G
   os_family: Android
   browser_family: Chrome
@@ -7126,19 +6417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5023F Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 Plus Power
   os_family: Android
   browser_family: Chrome
@@ -7146,19 +6435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5023E Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 Plus Power
   os_family: Android
   browser_family: Chrome
@@ -7166,19 +6453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A571VL Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi Avion 4G LTE
   os_family: Android
   browser_family: Chrome
@@ -7186,19 +6471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A570BL Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi Avion LTE
   os_family: Android
   browser_family: Chrome
@@ -7206,19 +6489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4024D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi First
   os_family: Android
   browser_family: Chrome
@@ -7226,19 +6507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4024E Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Chrome/36.0.1985.135 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi First
   os_family: Android
   browser_family: Chrome
@@ -7246,19 +6525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4024X Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Chrome/36.0.1985.135 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi First
   os_family: Android
   browser_family: Chrome
@@ -7266,19 +6543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A464BG Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi Glitz
   os_family: Android
   browser_family: Chrome
@@ -7286,19 +6561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A621BL Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi Glory
   os_family: Android
   browser_family: Chrome
@@ -7306,19 +6579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5098O Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi Theatre
   os_family: Android
   browser_family: Chrome
@@ -7326,19 +6597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 4045A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4"
   os_family: Android
   browser_family: Chrome
@@ -7346,19 +6615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 4045X Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4"
   os_family: Android
   browser_family: Chrome
@@ -7366,19 +6633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 4045D Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7386,19 +6651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 4045E Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7406,19 +6669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 5042F Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5"
   os_family: Android
   browser_family: Chrome
@@ -7426,19 +6687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 5042G Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5"
   os_family: Android
   browser_family: Chrome
@@ -7446,19 +6705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 5042W Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5"
   os_family: Android
   browser_family: Chrome
@@ -7466,19 +6723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 5042X Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5"
   os_family: Android
   browser_family: Chrome
@@ -7486,19 +6741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 5042D Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7506,19 +6759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 5042E Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 4.5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7526,19 +6777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7043Y Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5"
   os_family: Android
   browser_family: Chrome
@@ -7546,19 +6795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7044A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5"
   os_family: Android
   browser_family: Chrome
@@ -7566,19 +6813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7044X Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5"
   os_family: Android
   browser_family: Chrome
@@ -7586,19 +6831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7043A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5"
   os_family: Android
   browser_family: Chrome
@@ -7606,19 +6849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7043E Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7626,19 +6867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 7043K Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 2 5" Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7646,19 +6885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5015X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3
   os_family: Android
   browser_family: Chrome
@@ -7666,19 +6903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065X Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3
   os_family: Android
   browser_family: Chrome
@@ -7686,19 +6921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065X Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3
   os_family: Android
   browser_family: Chrome
@@ -7706,19 +6939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5016A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7726,19 +6957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5015A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7746,19 +6975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5015E Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7766,19 +6993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5016J Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7786,19 +7011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5116J Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7806,19 +7029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065D Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7826,19 +7047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065A Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7846,19 +7065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065W Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5"
   os_family: Android
   browser_family: Chrome
@@ -7866,19 +7083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5025E Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -7886,19 +7101,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; de-de;  5025D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5.5"
   os_family: Android
   browser_family: Chrome
@@ -7906,19 +7119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; 5054T Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.5.1146 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.5.1146"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 5.5"
   os_family: Android
   browser_family: Unknown
@@ -7926,19 +7137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5015D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 3 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7946,19 +7155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051M Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -7966,19 +7173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051X Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -7986,19 +7191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051A Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -8006,19 +7209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051E Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -8026,19 +7227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051J Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -8046,19 +7245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051T Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -8066,19 +7263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051W Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4
   os_family: Android
   browser_family: Chrome
@@ -8086,19 +7281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 7070X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4 6"
   os_family: Android
   browser_family: Chrome
@@ -8106,19 +7299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5051D Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8126,19 +7317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056T Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8146,19 +7335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056D Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8166,19 +7353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056U Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8186,19 +7371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056G Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8206,19 +7389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056E Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8226,19 +7407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056J Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8246,19 +7425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056M Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8266,19 +7443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5056A Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4+
   os_family: Android
   browser_family: Chrome
@@ -8286,19 +7461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5095K Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4S
   os_family: Android
   browser_family: Chrome
@@ -8306,19 +7479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5095I Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4S
   os_family: Android
   browser_family: Chrome
@@ -8326,19 +7497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5095Y Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop 4S
   os_family: Android
   browser_family: Chrome
@@ -8346,19 +7515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4015A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1
   os_family: Android
   browser_family: Chrome
@@ -8366,19 +7533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4016A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1
   os_family: Android
   browser_family: Chrome
@@ -8386,19 +7551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4015X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1
   os_family: Android
   browser_family: Chrome
@@ -8406,19 +7569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ALCATEL 4015T Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1
   os_family: Android
   browser_family: Chrome
@@ -8426,19 +7587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4016D Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8446,19 +7605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4015D Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8466,19 +7623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH 4015N Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8486,19 +7641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4016X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C1 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8506,19 +7659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4032A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C2
   os_family: Android
   browser_family: Chrome
@@ -8526,19 +7677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4032X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C2
   os_family: Android
   browser_family: Chrome
@@ -8546,19 +7695,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-at; 4032D Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C2 Dual SIM
   os_family: Android
   browser_family: Android Browser
@@ -8566,19 +7713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; 4032E Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C2 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8586,19 +7731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5036D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C5 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8606,19 +7749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH 7041X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7
   os_family: Android
   browser_family: Chrome
@@ -8626,19 +7767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH 7040K Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7
   os_family: Android
   browser_family: Chrome
@@ -8646,19 +7785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040A Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7
   os_family: Android
   browser_family: Chrome
@@ -8666,19 +7803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040F Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7
   os_family: Android
   browser_family: Chrome
@@ -8686,19 +7821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 7042a Build/LMY48Y) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7
   os_family: Android
   browser_family: Chrome
@@ -8706,19 +7839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH 7041D Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8726,19 +7857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040D Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8746,19 +7875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040E Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop C7 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8766,19 +7893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 SVN/01001
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8786,19 +7911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8806,19 +7929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8826,19 +7947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8846,19 +7965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8866,19 +7983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4018X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D1
   os_family: Android
   browser_family: Chrome
@@ -8886,19 +8001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4035X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D3
   os_family: Android
   browser_family: Chrome
@@ -8906,19 +8019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4035Y Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D3
   os_family: Android
   browser_family: Chrome
@@ -8926,19 +8037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4035D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D3
   os_family: Android
   browser_family: Chrome
@@ -8946,19 +8055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 4035A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D3
   os_family: Android
   browser_family: Chrome
@@ -8966,19 +8073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 5038D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D5
   os_family: Android
   browser_family: Chrome
@@ -8986,19 +8091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 5038X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D5
   os_family: Android
   browser_family: Chrome
@@ -9006,19 +8109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 5038A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D5
   os_family: Android
   browser_family: Chrome
@@ -9026,19 +8127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 5038E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop D5
   os_family: Android
   browser_family: Chrome
@@ -9046,19 +8145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 5057M Build/MHC19Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop Mirage
   os_family: Android
   browser_family: Chrome
@@ -9066,19 +8163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 5050A Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop S3
   os_family: Android
   browser_family: Chrome
@@ -9086,19 +8181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 5050S Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop S3
   os_family: Android
   browser_family: Chrome
@@ -9106,19 +8199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 5050X Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop S3
   os_family: Android
   browser_family: Chrome
@@ -9126,19 +8217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; 5050Y Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop S3
   os_family: Android
   browser_family: Chrome
@@ -9146,19 +8235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7045Y Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop S7
   os_family: Android
   browser_family: Chrome
@@ -9166,19 +8253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 5022E Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop Star
   os_family: Android
   browser_family: Chrome
@@ -9186,19 +8271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; en-us; 5022D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop Star
   os_family: Android
   browser_family: Chrome
@@ -9206,19 +8289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; en-us; 5070D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop Star
   os_family: Android
   browser_family: Chrome
@@ -9226,19 +8307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 6044D Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch Pop Up
   os_family: Android
   browser_family: Chrome
@@ -9246,19 +8325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 7053D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: One Touch X1
   os_family: Android
   browser_family: Chrome
@@ -9266,19 +8343,17 @@
   user_agent: Mozilla/5.0 (Mobile; ALCATELOneTouch4012X/SVN 01011S; rv:18.1) Gecko/18.1 Firefox/18.1
   os:
     name: Firefox OS
-    short_name: FOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "18.1"
     engine: Gecko
     engine_version: "18.1"
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: OneTouch4012X
   os_family: Firefox OS
   browser_family: Firefox
@@ -9288,13 +8363,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.1.234"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: ot-807d
   os_family: Unknown
   browser_family: Unknown
@@ -9302,19 +8376,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; A466BG Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Pixi Unite
   os_family: Android
   browser_family: Android Browser
@@ -9322,19 +8394,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; A574BL Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Raven
   os_family: Android
   browser_family: Chrome
@@ -9342,19 +8412,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5049W Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Revvl
   os_family: Android
   browser_family: Chrome
@@ -9362,19 +8430,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080U Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9382,19 +8448,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9402,19 +8466,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080Q Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9422,19 +8484,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9442,19 +8502,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9462,19 +8520,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5080F Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Shine Lite
   os_family: Android
   browser_family: Chrome
@@ -9482,19 +8538,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5041C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: TETRA
   os_family: Android
   browser_family: Chrome
@@ -9502,19 +8556,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TIMXL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: TIM XL
   os_family: Android
   browser_family: Chrome
@@ -9522,19 +8574,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 5065N Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: TRU
   os_family: Android
   browser_family: Chrome
@@ -9542,19 +8592,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4049D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -9562,19 +8610,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4049E Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -9582,19 +8628,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4049G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -9602,19 +8646,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4049M Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -9622,19 +8664,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4049X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -9642,19 +8682,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9662,19 +8700,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044D Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9682,19 +8718,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044I Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9702,19 +8736,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044K Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9722,19 +8754,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044Y Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9742,19 +8772,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044T Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9762,19 +8790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5044O Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9782,19 +8808,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5044P Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5
   os_family: Android
   browser_family: Chrome
@@ -9802,19 +8826,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 3G
   os_family: Android
   browser_family: Chrome
@@ -9822,19 +8844,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 3G
   os_family: Android
   browser_family: Chrome
@@ -9842,19 +8862,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 3G
   os_family: Android
   browser_family: Chrome
@@ -9862,19 +8880,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047N Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 3G
   os_family: Android
   browser_family: Chrome
@@ -9882,19 +8898,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5047D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 HD
   os_family: Android
   browser_family: Chrome
@@ -9902,19 +8916,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5047Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 HD
   os_family: Android
   browser_family: Chrome
@@ -9922,19 +8934,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5047I Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 HD
   os_family: Android
   browser_family: Chrome
@@ -9942,19 +8952,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5047U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 HD
   os_family: Android
   browser_family: Chrome
@@ -9962,19 +8970,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 Lite
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-10.yml
+++ b/Tests/fixtures/smartphone-10.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hammer Titan 2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Titan 2
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; myPhone_INFINITY_II_LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: INFINITY II LTE
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; myA17 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: myA17
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; myPhone_Pocket_18x9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Pocket 18x9
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; myPhone_Q-Smart_III) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Q-Smart III
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NUVO Blue ND40 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N0
+    brand: Nuvo
     model: ND40
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; NUVO Green ND 45 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: N0
+    brand: Nuvo
     model: ND45
   os_family: Android
   browser_family: Android Browser
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; NUVO_NS35 Build/MocorDroid) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.13.2.1208 U3/0.8.0 Mobile Safari/534.30
   os:
     name: MocorDroid
-    short_name: MCD
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.2.1208"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: N0
+    brand: Nuvo
     model: NS35
   os_family: Android
   browser_family: Unknown
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0; zh-CN; NOAIN A900S Build/GRK39F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.2.559 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.2.559"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: N1
+    brand: Noain
     model: A900S
   os_family: Android
   browser_family: Unknown
@@ -183,7 +165,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; NOAIN A913 Build/NOAINNOAIN) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/042_0.4_diordna_458_084/NIAON_71_2.2.4_319A+NIAON/1000418d/E29E98703F45BF1A99367DD1C0738595%7C836550000196968/1'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -192,7 +173,7 @@
     version: "042"
   device:
     type: smartphone
-    brand: N1
+    brand: Noain
     model: A913
   os_family: Android
   browser_family: Unknown
@@ -200,19 +181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; NOAIN_M15 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: N1
+    brand: Noain
     model: M15
   os_family: Android
   browser_family: Unknown
@@ -220,19 +199,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; NOAIN M6 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.598 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.598"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: N1
+    brand: Noain
     model: M6
   os_family: Android
   browser_family: Unknown
@@ -240,19 +217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Robin Build/Robin_Nougat_108; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N2
+    brand: Nextbit
     model: Robin
   os_family: Android
   browser_family: Chrome
@@ -260,19 +235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Robin) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N2
+    brand: Nextbit
     model: Robin
   os_family: Android
   browser_family: Chrome
@@ -280,19 +253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Navon_Infinity) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Infinity
   os_family: Android
   browser_family: Chrome
@@ -300,19 +271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme Chief) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Chief
   os_family: Android
   browser_family: Chrome
@@ -320,19 +289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme_Fine) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Fine
   os_family: Android
   browser_family: Chrome
@@ -340,19 +307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme_Fine_Mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Fine Mini
   os_family: Android
   browser_family: Chrome
@@ -360,19 +325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme Fine Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Fine Plus
   os_family: Android
   browser_family: Chrome
@@ -380,19 +343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Superme_Max Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Max
   os_family: Android
   browser_family: Chrome
@@ -400,19 +361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Pro
   os_family: Android
   browser_family: Chrome
@@ -420,19 +379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Navon Supreme Pure Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Pure
   os_family: Android
   browser_family: Chrome
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Supreme_Pure_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N3
+    brand: Navon
     model: Supreme Pure Plus
   os_family: Android
   browser_family: Chrome
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MTN-L860 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N4
+    brand: MTN
     model: Sm@rt Mini L860
   os_family: Android
   browser_family: Chrome
@@ -480,19 +433,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; MTN-S620 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N4
+    brand: MTN
     model: Sm@rt Mini S620
   os_family: Android
   browser_family: Chrome
@@ -500,19 +451,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 5.0; NOA C25 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: C25
   os_family: Android
   browser_family: Android Browser
@@ -520,19 +469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA CORE FORTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Core Forte
   os_family: Android
   browser_family: Chrome
@@ -540,19 +487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA_E1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: E1
   os_family: Android
   browser_family: Chrome
@@ -560,19 +505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; noa_G1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: G1
   os_family: Android
   browser_family: Chrome
@@ -580,19 +523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA_H10 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H10
   os_family: Android
   browser_family: Chrome
@@ -600,19 +541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; NOA H10le Build/NMF26O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H10LE
   os_family: Android
   browser_family: Chrome
@@ -620,19 +559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA_H2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H2
   os_family: Android
   browser_family: Chrome
@@ -640,19 +577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NOA H4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H4
   os_family: Android
   browser_family: Chrome
@@ -660,19 +595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NOA H42 Build/Sumvier_China) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H42
   os_family: Android
   browser_family: Chrome
@@ -680,19 +613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NOA H43 Build/XXX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H43
   os_family: Android
   browser_family: Chrome
@@ -700,19 +631,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; NOA_H44 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H44
   os_family: Android
   browser_family: Android Browser
@@ -720,19 +649,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; NOA_H44SE Build/LRX21M)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H44SE
   os_family: Android
   browser_family: Android Browser
@@ -740,19 +667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA H4se) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H4SE
   os_family: Android
   browser_family: Chrome
@@ -760,19 +685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA_H5 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H5
   os_family: Android
   browser_family: Chrome
@@ -780,19 +703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA H6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H6
   os_family: Android
   browser_family: Chrome
@@ -800,19 +721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NOA_H8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H8
   os_family: Android
   browser_family: Chrome
@@ -820,19 +739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA_H9 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: H9
   os_family: Android
   browser_family: Chrome
@@ -840,19 +757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HummerLE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Hummer LE
   os_family: Android
   browser_family: Chrome
@@ -860,19 +775,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; NOA Hummer Lite AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Hummer Lite
   os_family: Android
   browser_family: Chrome
@@ -880,19 +793,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; NOA LOOP AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Loop
   os_family: Android
   browser_family: Chrome
@@ -900,19 +811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA_Mg12 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: MG12
   os_family: Android
   browser_family: Chrome
@@ -920,19 +829,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; NOA N2 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: N2
   os_family: Android
   browser_family: Android Browser
@@ -940,19 +847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOA NEXT Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Next
   os_family: Android
   browser_family: Chrome
@@ -960,19 +865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NextSE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Next SE
   os_family: Android
   browser_family: Chrome
@@ -980,19 +883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA_VISION_H3 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Vision H3
   os_family: Android
   browser_family: Chrome
@@ -1000,19 +901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOA_VISION_H3SE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N5
+    brand: NOA
     model: Vision H3SE
   os_family: Android
   browser_family: Chrome
@@ -1020,19 +919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nobby S300 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N6
+    brand: Nobby
     model: S300
   os_family: Android
   browser_family: Chrome
@@ -1040,19 +937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nobby S300 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N6
+    brand: Nobby
     model: S300 Pro
   os_family: Android
   browser_family: Chrome
@@ -1060,19 +955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nobby S500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N6
+    brand: Nobby
     model: S500
   os_family: Android
   browser_family: Chrome
@@ -1080,19 +973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nobby X800) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N6
+    brand: Nobby
     model: X800
   os_family: Android
   browser_family: Chrome
@@ -1100,19 +991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NLS-MT90 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N9
+    brand: Newland
     model: MT90 Orca
   os_family: Android
   browser_family: Chrome
@@ -1120,19 +1009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NOBLEX N401 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NB
+    brand: Noblex
     model: N401
   os_family: Android
   browser_family: Chrome
@@ -1140,19 +1027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; NOBLEX N451 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NB
+    brand: Noblex
     model: N451
   os_family: Android
   browser_family: Chrome
@@ -1160,19 +1045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; NBX-NB1012 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NB
+    brand: Noblex
     model: NB1012
   os_family: Android
   browser_family: Chrome
@@ -1180,19 +1063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NBX-T8A1IE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NB
+    brand: Noblex
     model: T8A1IE
   os_family: Android
   browser_family: Chrome
@@ -1200,19 +1081,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-us; Neffos C5/S100)AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: C5
   os_family: Android
   browser_family: Chrome
@@ -1220,19 +1099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Neffos C5 Max Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: C5 Max
   os_family: Android
   browser_family: Chrome
@@ -1240,19 +1117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; TP601A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: C5L
   os_family: Android
   browser_family: Chrome
@@ -1260,19 +1135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Neffos_C9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: C9
   os_family: Android
   browser_family: Chrome
@@ -1280,19 +1153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Neffos_C9A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: C9A
   os_family: Android
   browser_family: Chrome
@@ -1300,19 +1171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Neffos N1 Build/N4F26M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 ZenKit/1.39.8.2-internalNewdesign-Zen
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: N1
   os_family: Android
   browser_family: Chrome
@@ -1320,19 +1189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Neffos X1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: X1
   os_family: Android
   browser_family: Chrome
@@ -1340,19 +1207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Neffos X1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: X1
   os_family: Android
   browser_family: Chrome
@@ -1360,19 +1225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Neffos X1 Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: X1 Lite
   os_family: Android
   browser_family: Chrome
@@ -1380,19 +1243,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Neffos X20 Pro Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: X20 Pro
   os_family: Android
   browser_family: Android Browser
@@ -1400,19 +1261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Neffos_X9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: X9
   os_family: Android
   browser_family: Chrome
@@ -1420,19 +1279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Neffos Y5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: Y5
   os_family: Android
   browser_family: Chrome
@@ -1440,19 +1297,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; Neffos Y50 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.979.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.979.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: Y50
   os_family: Android
   browser_family: Unknown
@@ -1460,19 +1315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Neffos Y5L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: Y5L
   os_family: Android
   browser_family: Chrome
@@ -1480,19 +1333,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.1.2; Neffos Y5s Build/N2G47H
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NF
+    brand: Neffos
     model: Y5s
   os_family: Android
   browser_family: Android Browser
@@ -1502,13 +1353,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "QO3C"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Coffee
   os_family: Unknown
   browser_family: Unknown
@@ -1516,19 +1366,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-ch; Dynamic_Fun Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Dynamic Fun
   os_family: Android
   browser_family: Android Browser
@@ -1536,7 +1384,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; Dynamic_Maxi Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -1545,7 +1392,7 @@
     version: "3.4.16.1149292"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Dynamic Maxi
   os_family: Android
   browser_family: Unknown
@@ -1553,19 +1400,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Dynamic Racing 2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Dynamic Racing 2
   os_family: Android
   browser_family: Chrome
@@ -1573,19 +1418,17 @@
   user_agent: NGM Dynamic Racing 3/V2 Linux/3.0.13 Android/4.2 Release/02.15.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Dynamic Racing 3
   os_family: Android
   browser_family: Android Browser
@@ -1593,19 +1436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; NGM Dynamic Star Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Dynamic Star
   os_family: Android
   browser_family: Chrome
@@ -1613,19 +1454,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; Forward_Active Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Active
   os_family: Android
   browser_family: Android Browser
@@ -1633,19 +1472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ForwardEndurance Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Endurance
   os_family: Android
   browser_family: Chrome
@@ -1653,19 +1490,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ro-ro; Forward_Prime Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Prime
   os_family: Android
   browser_family: Android Browser
@@ -1673,19 +1508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ForwardXtreme Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Xtreme
   os_family: Android
   browser_family: Chrome
@@ -1693,7 +1526,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; Forward_Young Build/NGM_JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -1702,7 +1534,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Young
   os_family: Android
   browser_family: Unknown
@@ -1710,19 +1542,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ForwardZero Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Forward Zero
   os_family: Android
   browser_family: Chrome
@@ -1730,19 +1560,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; NGM LegendXL Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: LegendXL
   os_family: Android
   browser_family: Android Browser
@@ -1750,19 +1578,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; NGM Orion Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Orion
   os_family: Android
   browser_family: Android Browser
@@ -1770,19 +1596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NGM Spirit Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Spirit
   os_family: Android
   browser_family: Chrome
@@ -1790,19 +1614,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NGM Time Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Time
   os_family: Android
   browser_family: Chrome
@@ -1810,19 +1632,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; NGM Vanity Smart Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: Vanity Smart
   os_family: Android
   browser_family: Android Browser
@@ -1830,19 +1650,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ca; NGM_WINN Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: NG
+    brand: NGM
     model: WINN
   os_family: Android
   browser_family: Android Browser
@@ -1850,13 +1668,12 @@
   user_agent: Mozilla/5.0 (Nokia; Qt; MeeGo)
   os:
     name: MeeGo
-    short_name: SMG
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: ""
   os_family: Other Mobile
   browser_family: Unknown
@@ -1864,19 +1681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 1 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -1884,19 +1699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 1 Plus
   os_family: Android
   browser_family: Chrome
@@ -1904,19 +1717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1035 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -1924,19 +1735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 2.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "2.1"
   os_family: Android
   browser_family: Chrome
@@ -1944,19 +1753,17 @@
   user_agent: Nokia2323c-2/2.0 (08.20) Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 2323 Classic
   os_family: Symbian
   browser_family: Nokia Browser
@@ -1964,19 +1771,17 @@
   user_agent: Nokia2700c-2/2.0 (07.15) Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 2700 Classic
   os_family: Symbian
   browser_family: Nokia Browser
@@ -1984,19 +1789,17 @@
   user_agent: Nokia2730c-1/2.0 (10.47) Profile/MIDP-2.1 Configuration/CLDC-1.1 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; Nokia2730c-1) U2/1.0.0 UCBrowser/9.5.0.449 U2/1.0.0 Mobile UNTRUSTED/1.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.449"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 2730 Classic
   os_family: Symbian
   browser_family: Unknown
@@ -2004,19 +1807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1032 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2024,19 +1825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 3.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "3.1"
   os_family: Android
   browser_family: Chrome
@@ -2044,19 +1843,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Nokia 3.1 Plus Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 3.1 Plus
   os_family: Android
   browser_family: Android Browser
@@ -2064,19 +1861,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; Nokia 4.2 Build/QKQ1.191008.001)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "4.2"
   os_family: Android
   browser_family: Android Browser
@@ -2084,19 +1879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1024 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "5"
   os_family: Android
   browser_family: Chrome
@@ -2104,19 +1897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Nokia 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "5.1"
   os_family: Android
   browser_family: Chrome
@@ -2124,19 +1915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 5.1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 5.1 Plus
   os_family: Android
   browser_family: Chrome
@@ -2144,19 +1933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 5.1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 5.1 Plus
   os_family: Android
   browser_family: Chrome
@@ -2164,19 +1951,17 @@
   user_agent: iBrowser/Mini2.8 (Nokia5130c-2/07.97)
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: IBrowse
-    short_name: IB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 5130 XpressMusic
   os_family: Symbian
   browser_family: Unknown
@@ -2184,19 +1969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1003 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6"
   os_family: Android
   browser_family: Chrome
@@ -2204,19 +1987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1054) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6"
   os_family: Android
   browser_family: Chrome
@@ -2224,19 +2005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TA-1021 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Kiwi Chrome/69.0.3477.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Kiwi
-    short_name: KW
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6"
   os_family: Android
   browser_family: Chrome
@@ -2244,19 +2023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 6.1 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6.1"
   os_family: Android
   browser_family: Chrome
@@ -2264,19 +2041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 6.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6.1"
   os_family: Android
   browser_family: Chrome
@@ -2284,19 +2059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TA-1041 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -2304,19 +2077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 7.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "7.1"
   os_family: Android
   browser_family: Chrome
@@ -2324,19 +2095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 7.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "7.1"
   os_family: Android
   browser_family: Chrome
@@ -2344,19 +2113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TA-1004 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "8"
   os_family: Android
   browser_family: Chrome
@@ -2364,19 +2131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TA-1052 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "8"
   os_family: Android
   browser_family: Chrome
@@ -2384,19 +2149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 8.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "8.1"
   os_family: Android
   browser_family: Chrome
@@ -2404,19 +2167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 8.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "8.1"
   os_family: Android
   browser_family: Chrome
@@ -2424,19 +2185,17 @@
   user_agent: NOKIA-RH-17/V F100V1403.nep.0 UP.Browser/4.1.26l1.c.2.100
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "4.1.26"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "2280"
   os_family: Symbian
   browser_family: Unknown
@@ -2444,19 +2203,17 @@
   user_agent: Nokia2720a-2/2.0 (09.85) Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "2720"
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2464,19 +2221,17 @@
   user_agent: NOKIA-RH-48/V J190V0600.nep.0 UP.Browser/6.2.2.1.c.1.102 (GUI) MMP/2.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.2.1"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "3105"
   os_family: Symbian
   browser_family: Unknown
@@ -2484,19 +2239,17 @@
   user_agent: NOKIA-RM-11/V H190V0700.nep.0 UP.Browser/6.2.2.1.c.1.102 (GUI) MMP/2.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.2.1"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "3205"
   os_family: Symbian
   browser_family: Unknown
@@ -2504,19 +2257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 6.1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 6.1 Plus
   os_family: Android
   browser_family: Chrome
@@ -2524,19 +2275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 6.1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 6.1 Plus
   os_family: Android
   browser_family: Chrome
@@ -2544,19 +2293,17 @@
   user_agent: Nokia6120c/3.83; Profile/MIDP-2.0 Configuration/CLDC-1.1 Google
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 6120 Classic
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2564,19 +2311,17 @@
   user_agent: NOKIA-RH-27/V H190V0800.nep.0 UP.Browser/6.2.2.1.c.1.102 (GUI) MMP/2.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.2.1"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6225"
   os_family: Symbian
   browser_family: Unknown
@@ -2584,19 +2329,17 @@
   user_agent: NOKIA-RH-34/V H190V0800.nep.0 UP.Browser/6.2.2.1.c.1.102 (GUI) MMP/2.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.2.1"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "6585"
   os_family: Symbian
   browser_family: Unknown
@@ -2604,19 +2347,17 @@
   user_agent: UCWEB/2.0 (Symbian; U; S60 V3; ru; NOKIA6700s) U2/1.0.0 UCBrowser/9.0.1.317 U2/1.0.0 Mobile
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "V3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.1.317"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 6700 Slide
   os_family: Symbian
   browser_family: Unknown
@@ -2624,19 +2365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 7 plus Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 7 plus
   os_family: Android
   browser_family: Chrome
@@ -2644,19 +2383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nokia 7 plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 7 plus
   os_family: Android
   browser_family: Chrome
@@ -2664,19 +2401,17 @@
   user_agent: OneBrowser/3.1 (Nokia7230/06.90)
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "3.1"
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: "7230"
   os_family: Symbian
   browser_family: Unknown
@@ -2684,19 +2419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 8 Sirocco Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 8 Sirocco
   os_family: Android
   browser_family: Chrome
@@ -2704,19 +2437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nokia 8 Sirocco) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 8 Sirocco
   os_family: Android
   browser_family: Chrome
@@ -2724,19 +2455,17 @@
   user_agent: Mozilla/5.0 (Symbian; U; Nokia808 PureView; xx) AppleWebKit/534.3 (KHTML, like Gecko) MiniBrowserMobile/4.0 Mobile Safari/534.3
   os:
     name: Symbian OS
-    short_name: SYS
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: WebKit
     engine_version: "534.3"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: 808 PureView
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2744,19 +2473,17 @@
   user_agent: Nokia210/2.0 (04.12) Profile/MIDP-2.1 Configuration/CLDC-1.1 UCWEB/2.0 (Java; U; MIDP-2.0; en-US; Nokia210) U2/1.0.0 UCBrowser/9.3.0.326 U2/1.0.0 Mobile
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.0.326"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 210
   os_family: Symbian
   browser_family: Unknown
@@ -2764,19 +2491,17 @@
   user_agent: Mozilla/5.0 (Series40; Nokia306/03.63; Profile/MIDP-2.1 Configuration/CLDC-1.1) Gecko/20100401 S40OviBrowser/3.9.0.0.22
   os:
     name: Symbian OS Series 40
-    short_name: S40
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Ovi Browser
-    short_name: NV
     version: "3.9.0.0.22"
     engine: Gecko
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 306
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2784,19 +2509,17 @@
   user_agent: UCWEB/2.0 (Java; U; MIDP-2.0; ru; nokiaasha500dualsim) U2/1.0.0 UCBrowser/9.2.0.311 U2/1.0.0 Mobile UNTRUSTED/1.0
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.311"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 500
   os_family: Symbian
   browser_family: Unknown
@@ -2804,19 +2527,17 @@
   user_agent: Mozilla/5.0 (Symbian/3; Series60/5.3 Nokia500/111.021.0028; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/535.1 (KHTML, like Gecko) NokiaBrowser/8.3.1.4 Mobile Safari/535.1 3gpp-gba
   os:
     name: Symbian^3
-    short_name: SY3
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "8.3.1.4"
     engine: WebKit
     engine_version: "535.1"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 500
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2824,19 +2545,17 @@
   user_agent: Mozilla/5.0 (Symbian/3; Series60/5.2 Nokia500/010.029; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/533.4 (KHTML, like Gecko) NokiaBrowser/7.3.1.37 Mobile Safari/533.4 3gpp-gba
   os:
     name: Symbian^3
-    short_name: SY3
     version: "Anna"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.3.1.37"
     engine: WebKit
     engine_version: "533.4"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 500
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2844,19 +2563,17 @@
   user_agent: UCWEB/2.0 (Java; U; MIDP-2.0; en-US; Nokia501) U2/1.0.0 UCBrowser/9.5.0.449 U2/1.0.0 Mobile
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.449"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Asha 501
   os_family: Symbian
   browser_family: Unknown
@@ -2864,19 +2581,17 @@
   user_agent: OneBrowser/3.0 (NokiaC2-00/03.42)
   os:
     name: Symbian
-    short_name: SYM
     version: ""
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "3.0"
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: C2
   os_family: Symbian
   browser_family: Unknown
@@ -2884,19 +2599,17 @@
   user_agent: UCWEB/2.0 (Symbian; U; S60 V3; en-US; NOKIAE5-00u) U2/1.0.0 UCBrowser/9.2.0.336 U2/1.0.0 Mobile
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "V3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.336"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: E5
   os_family: Symbian
   browser_family: Unknown
@@ -2904,19 +2617,17 @@
   user_agent: Mozilla/5.0 (Symbian/3; Series60/5.3 NokiaE7-00/111.040.1511; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/535.1 (KHTML, like Gecko) NokiaBrowser/8.3.1.4 Mobile Safari/535.1
   os:
     name: Symbian^3
-    short_name: SY3
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "8.3.1.4"
     engine: WebKit
     engine_version: "535.1"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: E7
   os_family: Symbian
   browser_family: Nokia Browser
@@ -2924,19 +2635,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; 909) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1020
   os_family: Windows
   browser_family: Internet Explorer
@@ -2944,19 +2653,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; 909)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1020
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -2964,19 +2671,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; id300)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1020
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -2984,19 +2689,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; 909) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1020
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3004,19 +2707,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; NOKIA; Lumia 1520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.71 Mobile Safari/537.36 Edge/12.0
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "12.0"
     engine: Edge
     engine_version: "12.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1520
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3024,19 +2725,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; 1520.1) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 1520.1
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3044,19 +2743,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 520)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 520
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3064,19 +2761,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; RM-915; Vodafone ES) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 520
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3084,19 +2779,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; en-US; NOKIA; RM-914_im_mea3_394) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 520
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3104,19 +2797,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; NOKIA; Nokia 520T; CMCC) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 520T
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3124,19 +2815,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; RM-997) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 526
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3144,19 +2833,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 610; Vodafone)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 610
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3164,19 +2851,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 620)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 620
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3184,19 +2869,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-846_eu_euro2_357) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 620
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3204,19 +2887,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.1; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; RM-976_1166)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 630
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3224,19 +2905,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-976_1166) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 630
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3244,19 +2923,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-978_1034) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 630
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3264,19 +2941,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 10.0; xx; NOKIA; RM-978_1012) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 630
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3284,19 +2959,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-974_1080) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 635
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3304,19 +2977,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-975_1080) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 635
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3324,19 +2995,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; WebView/3.0; NOKIA; RM-1027) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 636
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3344,19 +3013,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; 710)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 710
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3364,19 +3031,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.0; xx; NOKIA; RM-885_im_india_249) U2/1.0.0 UCBrowser/4.1.0.504 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.1.0.504"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 720
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3384,19 +3049,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Nokia 720T; CMCC) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 720T
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3404,19 +3067,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-1038_1009) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 735
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3424,19 +3085,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-1039_1009) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 735
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3444,19 +3103,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Nokia; 800)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 800
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3464,19 +3121,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Nokia; 800C; Orange)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 800C
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3484,19 +3139,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Trident/3.1; XBLWP7; ZuneWP7; Nokia 820)
   os:
     name: Windows Phone
-    short_name: WPH
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 820
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3504,19 +3157,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Nokia; 900)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 900
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3524,19 +3175,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Lumia 900)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 900
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3544,19 +3193,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; NOKIA; Nokia 900)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 900
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3564,19 +3211,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows NT 6.2; Trident/3.1; XBLWP7; ZuneWP7; Nokia 920)
   os:
     name: Windows Phone
-    short_name: WPH
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 920
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3584,19 +3229,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 920)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 920
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3604,19 +3247,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 8.0.10328.0; Trident/5.0; IEMobile/9.0; CuteBrowser/3.0.0; NOKIA; RM-822_apac_prc_204)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0.10328.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 920
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3624,19 +3265,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; xx; NOKIA; RM-821_im_india_443) U2/1.0.0 UCBrowser/4.2.0.524 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.0.524"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 920
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3644,19 +3283,17 @@
   user_agent: MQQBrowser/1.0/Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; NOKIA; RM-910apacprc200)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "1.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 925
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3664,19 +3301,17 @@
   user_agent: MQQBrowser/3.6/Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; NOKIA; RM-892apachongko)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "3.6"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 925
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3684,19 +3319,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Nokia 925) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 925
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3704,19 +3337,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; RM-893) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 925
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3724,19 +3355,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; RM-910) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 925
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3744,19 +3373,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; Lumia 928) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 928
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3764,19 +3391,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.1; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; RM-1045_1012)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 930
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3784,19 +3409,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; NOKIA; RM-1045_1012) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia 930
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3804,19 +3427,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; Lumia 929)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Lumia Icon
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3824,19 +3445,17 @@
   user_agent: NokiaN73-2/3.0-630.0.2 Series60/3.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "3.0"
     platform: ""
   client:
     type: browser
     name: Nokia OSS Browser
-    short_name: 'NO'
     version: "3.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: N73
   os_family: Symbian
   browser_family: Nokia Browser
@@ -3844,19 +3463,17 @@
   user_agent: Mozilla/5.0 (Symbian/3; Series60/5.2 NokiaN8-00/014.002; Profile/MIDP-2.1 Configuration/CLDC-1.1; en-us) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.6.4 3gpp-gba
   os:
     name: Symbian^3
-    short_name: SY3
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.2.6.4"
     engine: WebKit
     engine_version: "525"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: N8
   os_family: Symbian
   browser_family: Nokia Browser
@@ -3864,19 +3481,17 @@
   user_agent: Mozilla/5.0 (MeeGo; NokiaN9) AppleWebKit/534.13 (KHTML, like Gecko) NokiaBrowser/8.5.0 Mobile Safari/534.13
   os:
     name: MeeGo
-    short_name: SMG
     version: ""
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "8.5.0"
     engine: WebKit
     engine_version: "534.13"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: N9
   os_family: Other Mobile
   browser_family: Nokia Browser
@@ -3884,19 +3499,17 @@
   user_agent: Mozilla/5.0 (X11; U; Linux armv7l; pt-PT; rv:1.9.2.3pre) Gecko/20100723 Firefox/3.5 Maemo Browser 1.7.4.8 RX-51 N900
   os:
     name: Maemo
-    short_name: MAE
     version: ""
     platform: ARM
   client:
     type: browser
     name: MicroB
-    short_name: MB
     version: "1.7.4.8"
     engine: Gecko
     engine_version: "1.9.2.3"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: N900
   os_family: Other Mobile
   browser_family: Firefox
@@ -3904,19 +3517,17 @@
   user_agent: Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 Nokia5230/21.0.004; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/525 (KHTML, like Gecko) Version/3.0 BrowserNG/7.2.5.2 3gpp-gba
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "7.2.5.2"
     engine: WebKit
     engine_version: "525"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: Nuron
   os_family: Symbian
   browser_family: Nokia Browser
@@ -3924,19 +3535,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Nokia_X Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.8.0.435 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.0.435"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: X
   os_family: Android
   browser_family: Unknown
@@ -3944,19 +3553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Nokia_XL Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36 NokiaBrowser/1.2.0.12
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "1.2.0.12"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NK
+    brand: Nokia
     model: XL
   os_family: Android
   browser_family: Nokia Browser
@@ -3964,19 +3571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NUU_A1 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -3984,19 +3589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NUU_A3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -4004,19 +3607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A6L-C Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: A6L-C
   os_family: Android
   browser_family: Chrome
@@ -4024,19 +3625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A6L-G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: A6L-G
   os_family: Android
   browser_family: Chrome
@@ -4044,19 +3643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; S6001L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: G2
   os_family: Android
   browser_family: Chrome
@@ -4064,19 +3661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; N5702L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: G3
   os_family: Android
   browser_family: Chrome
@@ -4084,19 +3679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NUU_M3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: M3
   os_family: Android
   browser_family: Chrome
@@ -4104,19 +3697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; N5001L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: N5001L
   os_family: Android
   browser_family: Chrome
@@ -4124,19 +3715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NUU_X5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NL
+    brand: NUU Mobile
     model: X5
   os_family: Android
   browser_family: Chrome
@@ -4144,19 +3733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NOMI 3 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -4164,19 +3751,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; NOMI 3\x81I Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: 3\x81I
   os_family: Android
   browser_family: Unknown
@@ -4184,7 +3769,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; NOMI 3S Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -4193,7 +3777,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: 3S
   os_family: Android
   browser_family: Unknown
@@ -4201,19 +3785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Nomi_i4510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.32 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.32"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Beat M
   os_family: Android
   browser_family: Chrome
@@ -4221,19 +3803,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; i5012 Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.8.855 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.8.855"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Evo M2
   os_family: Android
   browser_family: Unknown
@@ -4241,19 +3821,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; i5013 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1155"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Evo M2
   os_family: Android
   browser_family: Unknown
@@ -4261,19 +3839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; i5014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Evo M4
   os_family: Android
   browser_family: Chrome
@@ -4281,19 +3857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; i5032 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.1.1191 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.1.1191"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Evo X2
   os_family: Android
   browser_family: Unknown
@@ -4301,19 +3875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; i5050 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.8.1140 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.8.1140"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Evo Z
   os_family: Android
   browser_family: Unknown
@@ -4321,19 +3893,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; NOMI L003 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: L003
   os_family: Android
   browser_family: Unknown
@@ -4341,19 +3911,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; NOMI_L008 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: L008
   os_family: Android
   browser_family: Unknown
@@ -4361,19 +3929,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; NOMI N1 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: N1
   os_family: Android
   browser_family: Unknown
@@ -4381,19 +3947,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; i5510 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Space M
   os_family: Android
   browser_family: Android Browser
@@ -4401,19 +3965,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; i5532 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NM
+    brand: Nomi
     model: Space X2
   os_family: Android
   browser_family: Unknown
@@ -4421,19 +3983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS5002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5002
   os_family: Android
   browser_family: Chrome
@@ -4441,19 +4001,17 @@
   user_agent: Mozilla/5.0 (Linux;Android 5.1;NS5003 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5003
   os_family: Android
   browser_family: Chrome
@@ -4461,19 +4019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS5005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5005
   os_family: Android
   browser_family: Chrome
@@ -4481,19 +4037,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; NS5006 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5006
   os_family: Android
   browser_family: Android Browser
@@ -4501,19 +4055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS5008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5008
   os_family: Android
   browser_family: Chrome
@@ -4521,19 +4073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS5502) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5502
   os_family: Android
   browser_family: Chrome
@@ -4541,19 +4091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NS 5511) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 OPR/55.0.2719.50560
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "55.0.2719.50560"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS5511
   os_family: Android
   browser_family: Opera
@@ -4561,19 +4109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NS6 Build/LMY47I; wv)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'NO'
+    brand: Nous
     model: NS6
   os_family: Android
   browser_family: Android Browser
@@ -4581,19 +4127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NIM-450D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NU
+    brand: NeuImage
     model: 450D
   os_family: Android
   browser_family: Chrome
@@ -4601,19 +4145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NIM-550O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NU
+    brand: NeuImage
     model: 550O
   os_family: Android
   browser_family: Chrome
@@ -4621,19 +4163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NIM-600Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NU
+    brand: NeuImage
     model: 600Q
   os_family: Android
   browser_family: Chrome
@@ -4641,19 +4181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Snexian Mi430 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: NX
+    brand: Nexian
     model: Mi430
   os_family: Android
   browser_family: Android Browser
@@ -4661,13 +4199,12 @@
   user_agent: NexianNX-G730/MTK Release/10.01.2009 Browser/MAUI Profile/MIDP2.0 Configuration/CLDC-1
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: NX
+    brand: Nexian
     model: NX-G730
   os_family: Real-time OS
   browser_family: Unknown
@@ -4675,13 +4212,12 @@
   user_agent: NexianNX-G868T/MTK Release/10.1.2009 Browser/MAUI Profile/MIDP-2.0Configuration/CLDC-1.0
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: NX
+    brand: Nexian
     model: NX-G868T
   os_family: Real-time OS
   browser_family: Unknown
@@ -4689,13 +4225,12 @@
   user_agent: NexianNX-M5760/MTK Release/28.05.2012 Browser/MAUI Profile
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: NX
+    brand: Nexian
     model: NX-M5760
   os_family: Real-time OS
   browser_family: Unknown
@@ -4703,19 +4238,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NYX_A1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -4723,19 +4256,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; es-us;  NYX_Blink Build/MRA58K;wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/ 4.0 Chrome/44.0.2403.119 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Blink
   os_family: Android
   browser_family: Chrome
@@ -4743,19 +4274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NYX_EGO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Ego
   os_family: Android
   browser_family: Chrome
@@ -4763,19 +4292,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NYX_FENIX Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Fenix
   os_family: Android
   browser_family: Chrome
@@ -4783,19 +4310,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; NYX_FLY Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Fly
   os_family: Android
   browser_family: Chrome
@@ -4803,19 +4328,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; NYX_FLY_II Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Fly II
   os_family: Android
   browser_family: Chrome
@@ -4823,19 +4346,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; NYX_FLY_MINI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Fly Mini
   os_family: Android
   browser_family: Chrome
@@ -4843,19 +4364,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NYX_HIT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Hit
   os_family: Android
   browser_family: Chrome
@@ -4863,19 +4382,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NYX_JAK Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Jak
   os_family: Android
   browser_family: Chrome
@@ -4883,19 +4400,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; NYX_JOIN Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Join
   os_family: Android
   browser_family: Chrome
@@ -4903,19 +4418,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; NYX_NOBA Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Noba
   os_family: Android
   browser_family: Chrome
@@ -4923,19 +4436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NYX_NOBA_II Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Noba II
   os_family: Android
   browser_family: Chrome
@@ -4943,19 +4454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; es-us; NYX_ORBIS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Orbis
   os_family: Android
   browser_family: Chrome
@@ -4963,19 +4472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NYX REX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Rex
   os_family: Android
   browser_family: Chrome
@@ -4983,19 +4490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NYX_REX Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Rex
   os_family: Android
   browser_family: Chrome
@@ -5003,19 +4508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NYX_SHADE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Shade
   os_family: Android
   browser_family: Chrome
@@ -5023,19 +4526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; NYX_SKY Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Sky
   os_family: Android
   browser_family: Chrome
@@ -5043,19 +4544,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; es-us; NYX_SPARK Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Spark
   os_family: Android
   browser_family: Android Browser
@@ -5063,19 +4562,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; NYX_VOX Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Vox
   os_family: Android
   browser_family: Chrome
@@ -5083,19 +4580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NYX_ZEUZ_HD Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: NY
+    brand: NYX Mobile
     model: Zeus HD
   os_family: Android
   browser_family: Chrome
@@ -5103,19 +4598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NEO6_LTE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O1
+    brand: Odys
     model: Neo 6 LTE
   os_family: Android
   browser_family: Chrome
@@ -5123,19 +4616,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-cn; OWWO 1S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: 1S
   os_family: Android
   browser_family: Unknown
@@ -5143,19 +4634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; OWWO 4S Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: 4S
   os_family: Android
   browser_family: Chrome
@@ -5163,19 +4652,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-cn; OWWO 5S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: 5S
   os_family: Android
   browser_family: Unknown
@@ -5183,19 +4670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; OWWO 7S Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: 7S
   os_family: Android
   browser_family: Chrome
@@ -5203,19 +4688,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; OWWOQ7 Build/KOT49H) AppleWebKit/534.24 (KHTML like Gecko) Version/4.0 Mobile Safari/534.24
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: Q7
   os_family: Android
   browser_family: Android Browser
@@ -5223,19 +4706,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; OWWO Q8 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: O2
+    brand: Owwo
     model: Q8
   os_family: Android
   browser_family: Unknown
@@ -5243,19 +4724,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; O+ 360 ALPHA PLUS 2.0 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: 360 Alpha Plus 2.0
   os_family: Android
   browser_family: Android Browser
@@ -5263,19 +4742,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; O+_AIR Build/OplusO+_AIR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Air
   os_family: Android
   browser_family: Chrome
@@ -5283,19 +4760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; O+ Crunch Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Crunch
   os_family: Android
   browser_family: Chrome
@@ -5303,19 +4778,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; O+ Ultra Build/Oplus_Ultra) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Ultra
   os_family: Android
   browser_family: Chrome
@@ -5323,19 +4796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; O+ Ultra 2.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Ultra 2.0
   os_family: Android
   browser_family: Chrome
@@ -5343,19 +4814,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; O+ Upsized Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Upsized
   os_family: Android
   browser_family: Chrome
@@ -5363,19 +4832,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; O+ Venti 4G Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O3
+    brand: O+
     model: Venti 4G
   os_family: Android
   browser_family: Chrome
@@ -5383,19 +4850,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; RC501L Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O5
+    brand: Orbic
     model: Slim
   os_family: Android
   browser_family: Chrome
@@ -5403,19 +4868,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; RC555L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: O5
+    brand: Orbic
     model: Wonder
   os_family: Android
   browser_family: Chrome
@@ -5423,19 +4886,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; Obi_S454) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Alligator
   os_family: Android
   browser_family: Unknown
@@ -5443,19 +4904,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; S503 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.582 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.582"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Boa
   os_family: Android
   browser_family: Unknown
@@ -5463,19 +4922,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; S503+ Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.1.5.890 U3/0.8.0 Mobile Safari/534.3
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.1.5.890"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Boa Plus
   os_family: Android
   browser_family: Unknown
@@ -5483,19 +4940,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S550 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.90 YaBrowser/16.11.0.649.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.11.0.649.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Crane
   os_family: Android
   browser_family: Unknown
@@ -5503,19 +4958,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; S451 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Flacon
   os_family: Android
   browser_family: Android Browser
@@ -5523,19 +4976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; falcon Build/LMY48Y; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Flacon
   os_family: Android
   browser_family: Chrome
@@ -5543,19 +4994,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; S453 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.8.855 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.8.855"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Fox
   os_family: Android
   browser_family: Unknown
@@ -5563,19 +5012,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Obi_S551 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.1.2.540 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.2.540"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Hornbill
   os_family: Android
   browser_family: Unknown
@@ -5583,19 +5030,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; S502 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.7.0.636 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.0.636"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Leopard
   os_family: Android
   browser_family: Unknown
@@ -5603,19 +5048,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Obi_S520 Build/KOT49H) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/10.3.0.622 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.0.622"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Octopus
   os_family: Android
   browser_family: Unknown
@@ -5623,19 +5066,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; S507 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Pelican
   os_family: Android
   browser_family: Chrome
@@ -5643,19 +5084,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; S452+ Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.7.8.710 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.8.710"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Python
   os_family: Android
   browser_family: Unknown
@@ -5663,19 +5102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SJ1.5 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: SJ1.5
   os_family: Android
   browser_family: Chrome
@@ -5683,19 +5120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SJ2.6 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: SJ2.6
   os_family: Android
   browser_family: Chrome
@@ -5703,19 +5138,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S400 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Skipper
   os_family: Android
   browser_family: Chrome
@@ -5723,19 +5156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 Mobile UCBrowser/3.4.3.532
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.4.3.532"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OB
+    brand: Obi
     model: Wolverine
   os_family: Android
   browser_family: Unknown
@@ -5743,19 +5174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; C15 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: C15 Pro
   os_family: Android
   browser_family: Chrome
@@ -5763,19 +5192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; C16_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: C16 Pro
   os_family: Android
   browser_family: Chrome
@@ -5783,19 +5210,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; K10000 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.0.1288 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.0.1288"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K10000
   os_family: Android
   browser_family: Unknown
@@ -5803,19 +5228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K10000 Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K10000 Max
   os_family: Android
   browser_family: Chrome
@@ -5823,19 +5246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K10000 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K10000 Pro
   os_family: Android
   browser_family: Chrome
@@ -5843,19 +5264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; K4000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K4000
   os_family: Android
   browser_family: Chrome
@@ -5863,19 +5282,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K4000_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K4000 Lite
   os_family: Android
   browser_family: Chrome
@@ -5883,19 +5300,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; K4000 Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.10.1159 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.10.1159"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K4000 Plus
   os_family: Android
   browser_family: Unknown
@@ -5903,19 +5318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; K4000_PRO Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.0.2672.49578
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.0.2672.49578"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K4000 Pro
   os_family: Android
   browser_family: Opera
@@ -5923,19 +5336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K5000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K5000
   os_family: Android
   browser_family: Chrome
@@ -5943,19 +5354,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; K6000 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.3.1144 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.3.1144"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K6000
   os_family: Android
   browser_family: Unknown
@@ -5963,19 +5372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K6000 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K6000 Plus
   os_family: Android
   browser_family: Chrome
@@ -5983,19 +5390,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; K6000 Pro Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.0.1288 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.0.1288"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K6000 Pro
   os_family: Android
   browser_family: Unknown
@@ -6003,19 +5408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; K7000 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.14.0.1221 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.14.0.1221"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K7000
   os_family: Android
   browser_family: Unknown
@@ -6023,19 +5426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; U20_Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.106 YaBrowser/18.9.1.2199.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.9.1.2199.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: U20 Plus
   os_family: Android
   browser_family: Unknown
@@ -6043,19 +5444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Y4800) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: Y4800
   os_family: Android
   browser_family: Chrome
@@ -6063,19 +5462,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XP6700 Build/6A.0.0-03-4.4.2-10.03.53.02-KR-ATT-C-01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OI
+    brand: Sonim
     model: XP6700
   os_family: Android
   browser_family: Chrome
@@ -6083,19 +5480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; XP7700 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OI
+    brand: Sonim
     model: XP7700
   os_family: Android
   browser_family: Chrome
@@ -6103,19 +5498,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; OUKI Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: ""
   os_family: Android
   browser_family: Android Browser
@@ -6123,19 +5516,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Ouki_A18 Build/MocorDroid2.3.5) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "530"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: A18
   os_family: Android
   browser_family: Unknown
@@ -6143,19 +5534,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; OUKI G5 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: G5
   os_family: Android
   browser_family: Android Browser
@@ -6163,7 +5552,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; OK A35 Build/OUKIA35) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -6172,7 +5560,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OK A35
   os_family: Android
   browser_family: Unknown
@@ -6180,7 +5568,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; OKA16S Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 baiduboxapp/042_0.4_diordna_008_084/spla_01_4.0.4_S61AKO/7300079a/B33017ECEA7CB97DA650D2B6D21DCC2F%7C704974110985368/1'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
@@ -6189,7 +5576,7 @@
     version: "042"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OKA16S
   os_family: Android
   browser_family: Unknown
@@ -6197,19 +5584,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; OKA50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.1.0.527 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.0.527"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OKA50
   os_family: Android
   browser_family: Unknown
@@ -6217,7 +5602,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; OKA50TD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -6226,7 +5610,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OKA50TD
   os_family: Android
   browser_family: Unknown
@@ -6234,19 +5618,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; OKU3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OKU3
   os_family: Android
   browser_family: Android Browser
@@ -6254,19 +5636,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; OUKI OKU3 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OK
+    brand: Ouki
     model: OKU3
   os_family: Android
   browser_family: Unknown
@@ -6274,19 +5654,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ONE A2005 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -6294,19 +5672,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ONE A2003 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -6314,19 +5690,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ONE A2003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -6334,19 +5708,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ONE A2005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -6354,19 +5726,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ONE A2001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -6374,19 +5744,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; OnePlus 3 Build/MOB31K)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6394,19 +5762,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; ONEPLUS A3000 MIUI/7.1.20)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6414,19 +5780,17 @@
   user_agent: 2.1.0 (Linux; U; Android 7.0; ONEPLUS A3000 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6434,19 +5798,17 @@
   user_agent: 2.1.0 (Linux; U; Android 7.0; ONEPLUS A3003 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6454,19 +5816,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; du_oneplus3 Build/N6F26Q)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6474,19 +5834,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; Next-OS OnePlus3 Build/N6F26Q)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "3"
   os_family: Android
   browser_family: Android Browser
@@ -6494,19 +5852,17 @@
   user_agent: 2.1.0 (Linux; U; Android 7.0; ONEPLUS A3010 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 3T
   os_family: Android
   browser_family: Android Browser
@@ -6514,19 +5870,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ONEPLUS A5000 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "5"
   os_family: Android
   browser_family: Chrome
@@ -6534,19 +5888,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ONEPLUS A5010 Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 5T
   os_family: Android
   browser_family: Chrome
@@ -6554,19 +5906,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ONEPLUS A6013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 6T
   os_family: Android
   browser_family: Chrome
@@ -6574,19 +5924,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ONEPLUS A6010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 6T
   os_family: Android
   browser_family: Chrome
@@ -6594,19 +5942,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1903) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -6614,19 +5960,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1900) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -6634,19 +5978,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1901) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -6654,19 +5996,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; GM1905) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "7"
   os_family: Android
   browser_family: Chrome
@@ -6674,19 +6014,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7 Pro
   os_family: Android
   browser_family: Chrome
@@ -6694,19 +6032,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7 Pro
   os_family: Android
   browser_family: Chrome
@@ -6714,19 +6050,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1915) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7 Pro
   os_family: Android
   browser_family: Chrome
@@ -6734,19 +6068,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM1917) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7 Pro
   os_family: Android
   browser_family: Chrome
@@ -6754,7 +6086,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 9; GM1911 Build/PKQ1.190110.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/222.0.0.48.113;]'
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
@@ -6763,7 +6094,7 @@
     version: "222.0.0.48.113"
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7 Pro
   os_family: Android
   browser_family: Unknown
@@ -6771,19 +6102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1901) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T
   os_family: Android
   browser_family: Chrome
@@ -6791,19 +6120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1903) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T
   os_family: Android
   browser_family: Chrome
@@ -6811,19 +6138,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1900) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T
   os_family: Android
   browser_family: Chrome
@@ -6831,19 +6156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1913) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T Pro
   os_family: Android
   browser_family: Chrome
@@ -6851,19 +6174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T Pro
   os_family: Android
   browser_family: Chrome
@@ -6871,19 +6192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1911 Build/QKQ1.190716.003; wv) AppleWebKit/537.36 (KHTML, likeGecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T Pro
   os_family: Android
   browser_family: Chrome
@@ -6891,19 +6210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; GM1920) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -6911,19 +6228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HD1925 Build/QKQ1.190716.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 7T Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -6931,19 +6246,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; IN2013 Build/QKQ1.191222.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "8"
   os_family: Android
   browser_family: Android Browser
@@ -6951,19 +6264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; IN2017 Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "8"
   os_family: Android
   browser_family: Chrome
@@ -6971,19 +6282,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; IN2010 Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: "8"
   os_family: Android
   browser_family: Unknown
@@ -6991,19 +6300,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; IN2020 Build/QKQ1.191222.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 8 Pro
   os_family: Android
   browser_family: Android Browser
@@ -7011,19 +6318,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; IN2023 Build/QKQ1.191222.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: 8 Pro
   os_family: Android
   browser_family: Android Browser
@@ -7031,19 +6336,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; AC2003 Build/QKQ1.200412.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: Nord 5G
   os_family: Android
   browser_family: Android Browser
@@ -7051,19 +6354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; AC2001 Build/QKQ1.200412.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: Nord 5G
   os_family: Android
   browser_family: Chrome
@@ -7071,19 +6372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; A0001 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: One
   os_family: Android
   browser_family: Chrome
@@ -7091,19 +6390,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ONE E1003 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: X
   os_family: Android
   browser_family: Chrome
@@ -7111,19 +6408,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ONE E1001 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: X
   os_family: Android
   browser_family: Chrome
@@ -7131,19 +6426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ONE E1005 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: X
   os_family: Android
   browser_family: Chrome
@@ -7151,19 +6444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ONE E1003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 'ON'
+    brand: OnePlus
     model: X
   os_family: Android
   browser_family: Chrome
@@ -7171,19 +6462,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; OPSSON D1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: D1
   os_family: Android
   browser_family: Android Browser
@@ -7191,19 +6480,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; OPSSON iMO1000 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: iMO1000
   os_family: Android
   browser_family: Android Browser
@@ -7211,19 +6498,17 @@
   user_agent: OPSSON-OPSSON-iMO1000/1.0 Linux/3.0.13 Android/4.0.4 Release/01.18.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: iMO1000
   os_family: Android
   browser_family: Android Browser
@@ -7231,19 +6516,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-CN; IUSAI i500 Build/GRK39F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.1.0.527 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.0.527"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: Iusai i500
   os_family: Android
   browser_family: Unknown
@@ -7251,7 +6534,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; IUSAI US16 Build/MocorDroid4.1.2) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/5.0 (Baidu; P1 4.1.2)
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.1.2"
     platform: ""
   client:
@@ -7260,7 +6542,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: Iusai US16
   os_family: Android
   browser_family: Unknown
@@ -7268,19 +6550,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; zh-CN; IUSAI US8) U2/1.0.0 UCBrowser/9.0.1.294 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.1.294"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: Iusai US8
   os_family: Android
   browser_family: Unknown
@@ -7288,7 +6568,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; IUSAI X2 Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/5.0 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -7297,7 +6576,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: Iusai X2
   os_family: Android
   browser_family: Unknown
@@ -7305,19 +6584,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; OPSSON IVO 8800 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: IVO 8800
   os_family: Android
   browser_family: Unknown
@@ -7325,19 +6602,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; OPSSON IVO6622 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: IVO6622
   os_family: Android
   browser_family: Android Browser
@@ -7345,19 +6620,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; OPSSON IVO6655 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: IVO6655
   os_family: Android
   browser_family: Chrome
@@ -7365,19 +6638,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-CN; OPSSON_Q3 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OO
+    brand: Opsson
     model: Q3
   os_family: Android
   browser_family: Unknown
@@ -7385,19 +6656,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCHM10 Build/PKQ1.190714.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A11
   os_family: Android
   browser_family: Chrome
@@ -7405,19 +6674,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCHM00 Build/PKQ1.190714.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A11x
   os_family: Android
   browser_family: Chrome
@@ -7425,19 +6692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH2077) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A12
   os_family: Android
   browser_family: Chrome
@@ -7445,19 +6710,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; arm; CPH2083) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.2.70.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.2.70.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A12
   os_family: Android
   browser_family: Unknown
@@ -7465,19 +6728,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1923) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A1K
   os_family: Android
   browser_family: Chrome
@@ -7485,19 +6746,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PADM00 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -7505,19 +6764,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1837) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -7525,19 +6782,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PADT00 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/039980 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3
   os_family: Android
   browser_family: Unknown
@@ -7545,19 +6800,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; arm_64; CPH2015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaApp_Android/20.73 YaSearchBrowser/20.73 BroPP/1.0 SA/1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A31
   os_family: Android
   browser_family: Chrome
@@ -7565,19 +6818,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH2031) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A31
   os_family: Android
   browser_family: Chrome
@@ -7585,19 +6836,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH2073) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A31
   os_family: Android
   browser_family: Chrome
@@ -7605,19 +6854,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH2081) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A31
   os_family: Android
   browser_family: Chrome
@@ -7625,19 +6872,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; OB-OPPO A31c Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A31c
   os_family: Android
   browser_family: Android Browser
@@ -7645,19 +6890,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDVM00 Build/QKQ1.200614.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A32
   os_family: Android
   browser_family: Chrome
@@ -7665,19 +6908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A37f) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A37f
   os_family: Android
   browser_family: Chrome
@@ -7685,7 +6926,6 @@
   user_agent: '[FBAN/FB4A;FBAV/167.0.0.33.94;FBBV/101783969;FBDM/{density=2.0,width=720,height=1280};FBLC/en_GB;FBRV/0;FBCR/StarHub Mobile;FBMF/OPPO;FBBD/OPPO;FBPN/com.facebook.katana;FBDV/A37f;FBSV/5.1.1;FBOP/1;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ARM
   client:
@@ -7694,7 +6934,7 @@
     version: "167.0.0.33.94"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A37f
   os_family: Android
   browser_family: Unknown
@@ -7702,19 +6942,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A37f Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Mobile Safari/537.36 OPR/37.0.2192.11
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "37.0.2192.11"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A37f
   os_family: Android
   browser_family: Opera
@@ -7722,7 +6960,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; A37fw Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/172.0.0.66.93;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -7731,7 +6968,7 @@
     version: "172.0.0.66.93"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A37fw
   os_family: Android
   browser_family: Unknown
@@ -7739,19 +6976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CPH1605 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A39
   os_family: Android
   browser_family: Chrome
@@ -7759,19 +6994,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1805) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3s
   os_family: Android
   browser_family: Chrome
@@ -7779,19 +7012,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; CPH1803 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3s
   os_family: Android
   browser_family: Chrome
@@ -7799,19 +7030,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; CPH1853 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3s
   os_family: Android
   browser_family: Chrome
@@ -7819,19 +7048,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBBM30 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A3s
   os_family: Android
   browser_family: Chrome
@@ -7839,7 +7066,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; PBAM00 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044208 Mobile Safari/537.36 MicroMessenger/6.7.2.1340(0x2607023A) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
@@ -7848,7 +7074,7 @@
     version: "6.7.2.1340(0x2607023A)"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5
   os_family: Android
   browser_family: Unknown
@@ -7856,19 +7082,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-us; PBBT30 Build/JSS15J) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5
   os_family: Android
   browser_family: Android Browser
@@ -7876,19 +7100,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1809 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -7896,19 +7118,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBAT00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -7916,19 +7136,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1943 Build/PKQ1.190714.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5 (2020)
   os_family: Android
   browser_family: Chrome
@@ -7936,19 +7154,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; CPH1931 Build/PKQ1.190714.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.134 Mobile Safari/537.36 OppoBrowser/25.5.1.9
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "25.5.1.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5 (2020)
   os_family: Android
   browser_family: Unknown
@@ -7956,19 +7172,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; CPH1933 Build/PKQ1.190714.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.2.1184 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.2.1184"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5 (2020)
   os_family: Android
   browser_family: Unknown
@@ -7976,19 +7190,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2061) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A52
   os_family: Android
   browser_family: Chrome
@@ -7996,19 +7208,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDAM10 Build/QKQ1.200114.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A52
   os_family: Android
   browser_family: Chrome
@@ -8016,19 +7226,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2069) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.4.366.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.4.366.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A52
   os_family: Android
   browser_family: Unknown
@@ -8036,19 +7244,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2127) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A53
   os_family: Android
   browser_family: Chrome
@@ -8056,19 +7262,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CPH1701 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A57
   os_family: Android
   browser_family: Chrome
@@ -8076,19 +7280,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1912) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5S
   os_family: Android
   browser_family: Chrome
@@ -8096,19 +7298,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5S
   os_family: Android
   browser_family: Chrome
@@ -8116,19 +7316,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; CPH1909 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5S
   os_family: Android
   browser_family: Unknown
@@ -8136,19 +7334,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1905) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -8156,19 +7352,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBFM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -8176,19 +7370,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; CPH1901 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -8196,19 +7388,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; PBFT00 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.4.987 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.4.987"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7
   os_family: Android
   browser_family: Unknown
@@ -8216,19 +7406,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1717 Build/N4F26M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A71
   os_family: Android
   browser_family: Chrome
@@ -8236,19 +7424,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-us; CPH1801 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.134 Mobile Safari/537.36 OppoBrowser/1.0.0
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A71
   os_family: Android
   browser_family: Unknown
@@ -8256,19 +7442,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDYT20 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A72
   os_family: Android
   browser_family: Chrome
@@ -8276,19 +7460,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; PDYM20 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.2.1092 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.2.1092"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A72
   os_family: Android
   browser_family: Unknown
@@ -8296,19 +7478,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; CPH2067) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.0.101.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.0.101.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A72
   os_family: Android
   browser_family: Unknown
@@ -8316,19 +7496,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CPH1715 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A77
   os_family: Android
   browser_family: Chrome
@@ -8336,19 +7514,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PCDM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7n
   os_family: Android
   browser_family: Chrome
@@ -8356,19 +7532,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PCDT00 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7n
   os_family: Android
   browser_family: Chrome
@@ -8376,19 +7550,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBBT00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7x
   os_family: Android
   browser_family: Chrome
@@ -8396,19 +7568,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBBM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7x
   os_family: Android
   browser_family: Chrome
@@ -8416,19 +7586,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PDBM00 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A8
   os_family: Android
   browser_family: Chrome
@@ -8436,19 +7604,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-us; CPH1729 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.134 Mobile Safari/537.36 OppoBrowser/1.0.0
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A83
   os_family: Android
   browser_family: Unknown
@@ -8456,19 +7622,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; CPH1827 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A83 (2018)
   os_family: Android
   browser_family: Chrome
@@ -8476,19 +7640,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCAT10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9
   os_family: Android
   browser_family: Chrome
@@ -8496,19 +7658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1937) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9 (2020)
   os_family: Android
   browser_family: Chrome
@@ -8516,19 +7676,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCHM30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9 (2020)
   os_family: Android
   browser_family: Chrome
@@ -8536,19 +7694,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1941) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9 (2020)
   os_family: Android
   browser_family: Chrome
@@ -8556,19 +7712,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; CPH1938 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1153 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1153"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9 (EN)
   os_family: Android
   browser_family: Unknown
@@ -8576,19 +7730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCPM00 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A91
   os_family: Android
   browser_family: Chrome
@@ -8596,19 +7748,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A91
   os_family: Android
   browser_family: Chrome
@@ -8616,19 +7766,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2021) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A91
   os_family: Android
   browser_family: Chrome
@@ -8636,19 +7784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2059) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A92
   os_family: Android
   browser_family: Chrome
@@ -8656,19 +7802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDKT00 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A92s
   os_family: Android
   browser_family: Chrome
@@ -8676,19 +7820,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDKM00 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A93s
   os_family: Android
   browser_family: Chrome
@@ -8696,19 +7838,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-us; PCEM00 Build/JSS15J) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9x
   os_family: Android
   browser_family: Android Browser
@@ -8716,19 +7856,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCET00 Build/PPR1.180610.011; xx-xx) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A9x
   os_family: Android
   browser_family: Chrome
@@ -8736,19 +7874,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1851 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: AX5
   os_family: Android
   browser_family: Chrome
@@ -8756,19 +7892,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1920) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: AX5s
   os_family: Android
   browser_family: Chrome
@@ -8776,19 +7910,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1903) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: AX7
   os_family: Android
   browser_family: Chrome
@@ -8796,19 +7928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X9009 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Mobile Safari/537.36 OPR/37.0.2192.105
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "37.0.2192.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F1 Plus
   os_family: Android
   browser_family: Opera
@@ -8816,19 +7946,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1911) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F11
   os_family: Android
   browser_family: Chrome
@@ -8836,19 +7964,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1969) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F11 Pro
   os_family: Android
   browser_family: Chrome
@@ -8856,19 +7982,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH1987) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F11 Pro
   os_family: Android
   browser_family: Chrome
@@ -8876,19 +8000,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A1601 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F1s
   os_family: Android
   browser_family: Chrome
@@ -8896,19 +8018,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A1601) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F1s
   os_family: Android
   browser_family: Chrome
@@ -8916,19 +8036,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CPH1609 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 mCent/0.13.1027
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: mCent
-    short_name: M1
     version: "0.13.1027"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F3
   os_family: Android
   browser_family: Chrome
@@ -8936,19 +8054,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CPH1613 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F3 Plus
   os_family: Android
   browser_family: Chrome
@@ -8956,19 +8072,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1723 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F5
   os_family: Android
   browser_family: Chrome
@@ -8976,19 +8090,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1727 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F5
   os_family: Android
   browser_family: Chrome
@@ -8996,19 +8108,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1725 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F5 Youth
   os_family: Android
   browser_family: Chrome
@@ -9016,19 +8126,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1859 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F7
   os_family: Android
   browser_family: Chrome
@@ -9036,19 +8144,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; CPH1821 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F7
   os_family: Android
   browser_family: Chrome
@@ -9056,19 +8162,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-us; CPH1819 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.134 Mobile Safari/537.36 OppoBrowser/1.0.0
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "1.0.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F7
   os_family: Android
   browser_family: Unknown
@@ -9076,19 +8180,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1881 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F9
   os_family: Android
   browser_family: Chrome
@@ -9096,19 +8198,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1825) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F9
   os_family: Android
   browser_family: Chrome
@@ -9116,19 +8216,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1823) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: F9 Pro
   os_family: Android
   browser_family: Chrome
@@ -9136,19 +8234,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; X909 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 5
   os_family: Android
   browser_family: Chrome
@@ -9156,19 +8252,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; zh-CN; X909T) U2/1.0.0 UCBrowser/9.6.2.404 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 5
   os_family: Android
   browser_family: Unknown
@@ -9176,19 +8270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; R827 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 5 Mini
   os_family: Android
   browser_family: Chrome
@@ -9196,19 +8288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; R827T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 5 Mini
   os_family: Android
   browser_family: Chrome
@@ -9216,19 +8306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; X9076 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7
   os_family: Android
   browser_family: Chrome
@@ -9236,19 +8324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; X9070 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7
   os_family: Android
   browser_family: Chrome
@@ -9256,7 +8342,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; X9077 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -9265,7 +8350,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7
   os_family: Android
   browser_family: Unknown
@@ -9273,7 +8358,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; X9007 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.9 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -9282,7 +8366,7 @@
     version: "4.9"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7a
   os_family: Android
   browser_family: Unknown
@@ -9290,19 +8374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; X9006 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7a
   os_family: Android
   browser_family: Chrome
@@ -9310,7 +8392,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; X9000 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.50_raae3e65.580 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -9319,7 +8400,7 @@
     version: "6.2.2.50.raae3e65.580"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find 7a
   os_family: Android
   browser_family: Unknown
@@ -9327,19 +8408,17 @@
   user_agent: 'OPPO_R815T/1.0 Linux/3.4.0 Android/4.2.1  Release/12.24.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1;'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Clover
   os_family: Android
   browser_family: Android Browser
@@ -9347,19 +8426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; R815 Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Clover
   os_family: Android
   browser_family: Chrome
@@ -9367,19 +8444,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; R815T Build/JOP40D) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Clover
   os_family: Android
   browser_family: Unknown
@@ -9387,19 +8462,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; R815W Build/JOP40D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.2.404 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Clover
   os_family: Android
   browser_family: Unknown
@@ -9407,19 +8480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; R8111 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Melody
   os_family: Android
   browser_family: Chrome
@@ -9427,19 +8498,17 @@
   user_agent: OPPO_R821T/1.0 Linux/3.4.5 Android/4.2.2 Release/03.26.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Muse
   os_family: Android
   browser_family: Android Browser
@@ -9447,19 +8516,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; R821 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Muse
   os_family: Android
   browser_family: Chrome
@@ -9467,19 +8534,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; R821T Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Muse
   os_family: Android
   browser_family: Unknown
@@ -9487,7 +8552,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; U707T Build/JOP40D) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.1.0.66_r1062275.542 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
@@ -9496,7 +8560,7 @@
     version: "6.1.0.66.r1062275.542"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find Way S
   os_family: Android
   browser_family: Unknown
@@ -9504,19 +8568,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PAFT00 Build/QKQ1.191008.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X
   os_family: Android
   browser_family: Unknown
@@ -9524,19 +8586,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1871) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X
   os_family: Android
   browser_family: Chrome
@@ -9544,19 +8604,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1875) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X
   os_family: Android
   browser_family: Chrome
@@ -9564,19 +8622,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PAFM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X
   os_family: Android
   browser_family: Chrome
@@ -9584,19 +8640,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PAHM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X Lamborghini
   os_family: Android
   browser_family: Chrome
@@ -9604,19 +8658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2023) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2
   os_family: Android
   browser_family: Chrome
@@ -9624,19 +8676,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDEM10 Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2
   os_family: Android
   browser_family: Chrome
@@ -9644,19 +8694,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2 Lite
   os_family: Android
   browser_family: Chrome
@@ -9664,19 +8712,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; OPG01 Build/QKQ1.191222.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2 Pro
   os_family: Android
   browser_family: Android Browser
@@ -9684,19 +8730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2025) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2 Pro
   os_family: Android
   browser_family: Chrome
@@ -9704,19 +8748,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDEM30 Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Find X2 Pro
   os_family: Android
   browser_family: Chrome
@@ -9724,19 +8766,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; R1011 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Joy Plus
   os_family: Android
   browser_family: Chrome
@@ -9744,19 +8784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBCM30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K1
   os_family: Android
   browser_family: Chrome
@@ -9764,19 +8802,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; PBCT10 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K1
   os_family: Android
   browser_family: Unknown
@@ -9784,19 +8820,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH1955) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K3
   os_family: Android
   browser_family: Chrome
@@ -9804,19 +8838,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCNM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K5
   os_family: Android
   browser_family: Chrome
@@ -9824,19 +8856,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PCLM50 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K7
   os_family: Android
   browser_family: Chrome
@@ -9844,19 +8874,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; N5207 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: N3
   os_family: Android
   browser_family: Unknown
@@ -9864,7 +8892,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; N5209 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -9873,7 +8900,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: N3
   os_family: Android
   browser_family: Unknown
@@ -9881,19 +8908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; R831 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo
   os_family: Android
   browser_family: Chrome
@@ -9901,19 +8926,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; R831T Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser-CMCC/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo
   os_family: Android
   browser_family: Unknown

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; R831K Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.1.549 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.1.549"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo 3
   os_family: Android
   browser_family: Unknown
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; ms-my; R831L Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo 5
   os_family: Android
   browser_family: Android Browser
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A33f Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo 7
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A33fw Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Neo 7s
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; id; R1001) U2/1.0.0 UCBrowser/9.5.1.494 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.1.494"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R1001
   os_family: Android
   browser_family: Unknown
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1707 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R11
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1719 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R11s
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; CPH1721 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R11s Plus
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PACT00 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1835 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PACM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; PACM00 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.1.4.994 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.1.4.994"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Unknown
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; PACT00 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.1.4.994 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.1.4.994"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Unknown
@@ -263,7 +237,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PAAM00 Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 MicroMessenger/6.6.5.1280(0x26060532) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -272,7 +245,7 @@
     version: "6.6.5.1280(0x26060532)"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15
   os_family: Android
   browser_family: Unknown
@@ -280,19 +253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1831 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15 Pro
   os_family: Android
   browser_family: Chrome
@@ -300,19 +271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1833) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15 Pro
   os_family: Android
   browser_family: Chrome
@@ -320,19 +289,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; PAAT00 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 OppoBrowser/10.6.2.1
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Oppo Browser
-    short_name: PP
     version: "10.6.2.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15 Pro
   os_family: Android
   browser_family: Unknown
@@ -340,19 +307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBCM10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15x
   os_family: Android
   browser_family: Chrome
@@ -360,19 +325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBEM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17
   os_family: Android
   browser_family: Chrome
@@ -380,19 +343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1879) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17
   os_family: Android
   browser_family: Chrome
@@ -400,19 +361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PBET00 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/039408 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17
   os_family: Android
   browser_family: Unknown
@@ -420,19 +379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1893) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17 Neo
   os_family: Android
   browser_family: Chrome
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1877) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17 Pro
   os_family: Android
   browser_family: Chrome
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PBDM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17 Pro
   os_family: Android
   browser_family: Chrome
@@ -480,19 +433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PBDT00 Build/PKQ1.190519.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17 Pro
   os_family: Android
   browser_family: Chrome
@@ -500,19 +451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2119) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R17 Pro
   os_family: Android
   browser_family: Chrome
@@ -520,7 +469,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; R8007 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025411 Mobile Safari/533.1 MicroMessenger/6.2.0.54_r1169949.561 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -529,7 +477,7 @@
     version: "6.2.0.54.r1169949.561"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R1S
   os_family: Android
   browser_family: Unknown
@@ -537,7 +485,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; R8000 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/3gnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -546,7 +493,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R1S
   os_family: Android
   browser_family: Unknown
@@ -554,19 +501,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; R2010 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025442 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R2010
   os_family: Android
   browser_family: Unknown
@@ -574,7 +519,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; R2017 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.76_r1119377.543 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -583,7 +527,7 @@
     version: "6.1.0.76.r1119377.543"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R2017
   os_family: Android
   browser_family: Unknown
@@ -591,19 +535,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; R8109 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025442 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R5
   os_family: Android
   browser_family: Unknown
@@ -611,7 +553,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; R8107 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.51_rdf8da56.600 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -620,7 +561,7 @@
     version: "6.2.4.51.rdf8da56.600"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R5
   os_family: Android
   browser_family: Unknown
@@ -628,7 +569,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; R6007) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 baidubrowser/5.3.4.0 (Baidu; P1 4.3.1) tieba/6.7.2 BMW
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -637,7 +577,7 @@
     version: "6.7.2"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R6007
   os_family: Android
   browser_family: Unknown
@@ -645,19 +585,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; R7kf Build/LMY47V)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R7 Lite
   os_family: Android
   browser_family: Android Browser
@@ -665,7 +603,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; R7Plusm Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043909 Mobile Safari/537.36 MicroMessenger/6.6.5.1280(0x26060536) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -674,7 +611,7 @@
     version: "6.6.5.1280(0x26060536)"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R7 Plus
   os_family: Android
   browser_family: Unknown
@@ -682,19 +619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; R7plusf) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R7 Plus F
   os_family: Android
   browser_family: Chrome
@@ -702,7 +637,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; R7005 Build/KVT49L) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.0.52_r1162382.561 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -711,7 +645,7 @@
     version: "6.2.0.52.r1162382.561"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R7005
   os_family: Android
   browser_family: Unknown
@@ -719,19 +653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; R7007 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R7007
   os_family: Android
   browser_family: Chrome
@@ -739,19 +671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-tw; OPPOR805 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R805
   os_family: Android
   browser_family: Android Browser
@@ -759,7 +689,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; R805 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
@@ -768,7 +697,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R805
   os_family: Android
   browser_family: Unknown
@@ -776,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; R819 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R819
   os_family: Android
   browser_family: Chrome
@@ -796,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; R819T Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R819T
   os_family: Android
   browser_family: Unknown
@@ -816,7 +741,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; R8200 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/3gnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -825,7 +749,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R8200
   os_family: Android
   browser_family: Unknown
@@ -833,7 +757,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; R8205 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -842,7 +765,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R8205
   os_family: Android
   browser_family: Unknown
@@ -850,7 +773,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; R8207 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -859,7 +781,7 @@
     version: "6.2.4.54.r266a9ba.601"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R8207
   os_family: Android
   browser_family: Unknown
@@ -867,19 +789,17 @@
   user_agent: 'OPPO_R823T/1.0 Linux/3.4.0 Android/4.2.1  Release/12.24.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1;'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R823T
   os_family: Android
   browser_family: Android Browser
@@ -887,19 +807,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; R823T Build/JOP40D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R823T
   os_family: Android
   browser_family: Unknown
@@ -907,7 +825,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; R829T Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.74_r1098891.543 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -916,7 +833,7 @@
     version: "6.1.0.74.r1098891.543"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R829T
   os_family: Android
   browser_family: Unknown
@@ -924,19 +841,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.1; en-US; R830) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R830
   os_family: Android
   browser_family: Unknown
@@ -944,7 +859,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; R830S Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025411 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/3gnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -953,7 +867,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R830S
   os_family: Android
   browser_family: Unknown
@@ -961,7 +875,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; R833T Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.5 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -970,7 +883,7 @@
     version: "6.5"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R833T
   os_family: Android
   browser_family: Unknown
@@ -978,19 +891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; X9079) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R9 Plus
   os_family: Android
   browser_family: Chrome
@@ -998,19 +909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CPH1607 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R9s
   os_family: Android
   browser_family: Chrome
@@ -1018,19 +927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CPH1611 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R9s Plus
   os_family: Android
   browser_family: Chrome
@@ -1038,19 +945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; OPPO R9s Plus Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.106 Mobile Safari/537.36 AWP/2.0 SogouMSE,SogouMobileBrowser/5.28.7
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.28.7"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R9s Plus
   os_family: Android
   browser_family: Safari
@@ -1058,19 +963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1917) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno
   os_family: Android
   browser_family: Chrome
@@ -1078,19 +981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCAT00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno
   os_family: Android
   browser_family: Chrome
@@ -1098,19 +999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCAM00 Build/PKQ1.190101.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno
   os_family: Android
   browser_family: Opera
@@ -1118,19 +1017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCCM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 10X
   os_family: Android
   browser_family: Chrome
@@ -1138,19 +1035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1919) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 10X Zoom
   os_family: Android
   browser_family: Chrome
@@ -1158,7 +1053,6 @@
   user_agent: AndroidDownloadManager/9 (Linux; U; Android 9; CPH1907 Build/PKQ1.190630.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
@@ -1167,7 +1061,7 @@
     version: "9"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2
   os_family: Android
   browser_family: Unknown
@@ -1175,19 +1069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCKM00 Build/PKQ1.190630.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2
   os_family: Android
   browser_family: Chrome
@@ -1195,19 +1087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH1989) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2F
   os_family: Android
   browser_family: Chrome
@@ -1215,19 +1105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1945) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2Z
   os_family: Android
   browser_family: Chrome
@@ -1235,19 +1123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCKM80) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2Z
   os_family: Android
   browser_family: Chrome
@@ -1255,19 +1141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; CPH1951) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaApp_Android/20.74 YaSearchBrowser/20.74 BroPP/1.0 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 2Z
   os_family: Android
   browser_family: Chrome
@@ -1275,19 +1159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2043 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.0.2672.49578
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.0.2672.49578"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3
   os_family: Android
   browser_family: Opera
@@ -1295,19 +1177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDCM00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3 5G
   os_family: Android
   browser_family: Chrome
@@ -1315,19 +1195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2035) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -1335,19 +1213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2037) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -1355,19 +1231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -1375,19 +1249,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; PCRM00 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.8.1078 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.8.1078"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3 Pro
   os_family: Android
   browser_family: Unknown
@@ -1395,19 +1267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 3A
   os_family: Android
   browser_family: Chrome
@@ -1415,19 +1285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2113) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 4G
   os_family: Android
   browser_family: Chrome
@@ -1435,19 +1303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDPT00 Build/QKQ1.200216.00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 5G
   os_family: Android
   browser_family: Chrome
@@ -1455,19 +1321,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; PDPM00 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.0.3.1083 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.3.1083"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 5G
   os_family: Android
   browser_family: Unknown
@@ -1475,19 +1339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2125) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.120 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.120"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 Lite
   os_family: Android
   browser_family: Chrome
@@ -1495,19 +1357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CPH2109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 Pro 4G
   os_family: Android
   browser_family: Chrome
@@ -1515,19 +1375,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDNT00 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -1535,19 +1393,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDNM00 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 Pro 5G
   os_family: Android
   browser_family: Unknown
@@ -1555,19 +1411,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PEAM00 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -1575,19 +1429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PEAT00 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -1595,19 +1447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1925) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 5G
   os_family: Android
   browser_family: Chrome
@@ -1615,19 +1465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1921) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 5G
   os_family: Android
   browser_family: Chrome
@@ -1635,19 +1483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1983) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno A
   os_family: Android
   browser_family: Chrome
@@ -1655,19 +1501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCLM10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno Ace
   os_family: Android
   browser_family: Chrome
@@ -1675,19 +1519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDHM00 Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno Ace 2
   os_family: Android
   browser_family: Chrome
@@ -1695,19 +1537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCGM00 Build/PKQ1.190101.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno K3
   os_family: Android
   browser_family: Opera
@@ -1715,19 +1555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1979) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno Z
   os_family: Android
   browser_family: Chrome
@@ -1735,19 +1573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCDM10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno Z
   os_family: Android
   browser_family: Chrome
@@ -1755,19 +1591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCDT10 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno Z
   os_family: Android
   browser_family: Chrome
@@ -1775,19 +1609,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; OPPOT29 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: T29
   os_family: Android
   browser_family: Android Browser
@@ -1795,19 +1627,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; OPPOX9017 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: X9017
   os_family: Android
   browser_family: Android Browser
@@ -1815,19 +1645,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; Orange Daytona Build/C224B197) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Daytona
   os_family: Android
   browser_family: Android Browser
@@ -1835,19 +1663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Orange Dive 30 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Dive 30
   os_family: Android
   browser_family: Chrome
@@ -1855,19 +1681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Orange Dive 71) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Dive 71
   os_family: Android
   browser_family: Chrome
@@ -1875,19 +1699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orange-Dive72) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Dive 72
   os_family: Android
   browser_family: Chrome
@@ -1895,19 +1717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Orange Dive 73) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Dive 73
   os_family: Android
   browser_family: Chrome
@@ -1915,19 +1735,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; Orange Dublin Build/GB_P752V_OCHV1.0.13B04) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Dublin
   os_family: Android
   browser_family: Android Browser
@@ -1935,19 +1753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Orange Fova) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Fova
   os_family: Android
   browser_family: Chrome
@@ -1955,19 +1771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; Orange Gova Build/OrangeGova) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Gova
   os_family: Android
   browser_family: Chrome
@@ -1975,19 +1789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orange Hi 4G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Hi 4G
   os_family: Android
   browser_family: Chrome
@@ -1995,19 +1807,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-; Orange Hiro Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30 bdbrowser_i18n/3.1.3.3
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "3.1.3.3"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Hiro
   os_family: Android
   browser_family: Baidu
@@ -2015,19 +1825,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Orange Kivo Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Kivo
   os_family: Android
   browser_family: Android Browser
@@ -2035,19 +1843,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; Orange Monte Carlo Build/OSP_B02) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Monte Carlo
   os_family: Android
   browser_family: Android Browser
@@ -2055,19 +1861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Orange Neva 80) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Neva 80
   os_family: Android
   browser_family: Chrome
@@ -2075,19 +1879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Orange Neva play) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Neva play
   os_family: Android
   browser_family: Chrome
@@ -2095,19 +1897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orange Nura Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Nura
   os_family: Android
   browser_family: Chrome
@@ -2115,19 +1915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Orange Reyo Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Reyo
   os_family: Android
   browser_family: Chrome
@@ -2135,19 +1933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orange Rise 30 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 30
   os_family: Android
   browser_family: Chrome
@@ -2155,19 +1951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orange-Rise31 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 31
   os_family: Android
   browser_family: Chrome
@@ -2175,19 +1969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orange-Rise32 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 32
   os_family: Android
   browser_family: Chrome
@@ -2195,19 +1987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Orange_Rise_33 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 33
   os_family: Android
   browser_family: Chrome
@@ -2215,19 +2005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orange Rise 34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 34
   os_family: Android
   browser_family: Chrome
@@ -2235,19 +2023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Orange Rise 40 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 40
   os_family: Android
   browser_family: Chrome
@@ -2255,19 +2041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orange-Rise51) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 51
   os_family: Android
   browser_family: Chrome
@@ -2275,19 +2059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Orange-Rise52) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 52
   os_family: Android
   browser_family: Chrome
@@ -2295,19 +2077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Orange Rise 53 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 53
   os_family: Android
   browser_family: Chrome
@@ -2315,19 +2095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Orange Rise 54 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 54
   os_family: Android
   browser_family: Chrome
@@ -2335,19 +2113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Orange Rise 55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rise 55
   os_family: Android
   browser_family: Chrome
@@ -2355,19 +2131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orange Rono) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Rono
   os_family: Android
   browser_family: Chrome
@@ -2375,19 +2149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Orange Roya Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Roya
   os_family: Android
   browser_family: Chrome
@@ -2395,19 +2167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Orange San Francisco Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: San Francisco
   os_family: Android
   browser_family: Android Browser
@@ -2415,19 +2185,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Orange Tactile internet 2 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Tactile internet 2
   os_family: Android
   browser_family: Android Browser
@@ -2435,19 +2203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orange Tado Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Tado
   os_family: Android
   browser_family: Chrome
@@ -2455,19 +2221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Orange Yomi Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Yomi
   os_family: Android
   browser_family: Chrome
@@ -2475,19 +2239,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Orange Yumo Build/OrangeYumo) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Yumo
   os_family: Android
   browser_family: Android Browser
@@ -2495,7 +2257,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Orange Zali Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -2504,7 +2265,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Zali
   os_family: Android
   browser_family: Unknown
@@ -2514,13 +2275,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q05A"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: OT
+    brand: O2
     model: COCOON
   os_family: Unknown
   browser_family: Unknown
@@ -2528,19 +2288,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) o2 Xda comet
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.6"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: OT
+    brand: O2
     model: Xda comet
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -2548,19 +2306,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; OV-Vertis-02 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OV
+    brand: Overmax
     model: Vertis 02
   os_family: Android
   browser_family: Android Browser
@@ -2568,19 +2324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; OV-Vertis 5011 Expi Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OV
+    brand: Overmax
     model: Vertis 5011 Expi
   os_family: Android
   browser_family: Chrome
@@ -2588,19 +2342,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Vertis 5021 Aim Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OV
+    brand: Overmax
     model: Vertis 5021 Aim
   os_family: Android
   browser_family: Chrome
@@ -2608,19 +2360,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; OV-V10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OV
+    brand: Overmax
     model: Vertis Yard
   os_family: Android
   browser_family: Chrome
@@ -2628,19 +2378,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; OWN FUN 5(4G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: Fun 5 4G
   os_family: Android
   browser_family: Chrome
@@ -2648,19 +2396,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; OWN FUN 6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: Fun 6
   os_family: Android
   browser_family: Chrome
@@ -2668,19 +2414,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; OWN FUN 7 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: Fun 7
   os_family: Android
   browser_family: Chrome
@@ -2688,19 +2432,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Own One Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: One
   os_family: Android
   browser_family: Chrome
@@ -2708,19 +2450,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; OWN One Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: One Plus
   os_family: Android
   browser_family: Chrome
@@ -2728,19 +2468,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; OWN S3000D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S3000D
   os_family: Android
   browser_family: Chrome
@@ -2748,19 +2486,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; OWN S3010 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S3010
   os_family: Android
   browser_family: Chrome
@@ -2768,19 +2504,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; OWN S3020D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S3020D
   os_family: Android
   browser_family: Chrome
@@ -2788,19 +2522,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-mx; OWN S4010 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S4010
   os_family: Android
   browser_family: Android Browser
@@ -2808,19 +2540,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; OWN_S4025 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S4025
   os_family: Android
   browser_family: Chrome
@@ -2828,19 +2558,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; S4035 3G Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S4035 3G
   os_family: Android
   browser_family: Android Browser
@@ -2848,19 +2576,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; S4035_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: S4035 4G
   os_family: Android
   browser_family: Chrome
@@ -2868,19 +2594,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; OWN SMART 9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OW
+    brand: öwn
     model: Smart 9
   os_family: Android
   browser_family: Chrome
@@ -2888,19 +2612,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AntarcticE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Antarctic E
   os_family: Android
   browser_family: Chrome
@@ -2908,19 +2630,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Atlantic4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Atlantic 4G
   os_family: Android
   browser_family: Chrome
@@ -2928,19 +2648,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IndianV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Indian V
   os_family: Android
   browser_family: Chrome
@@ -2948,19 +2666,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Oysters Pacific 800 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Pacific 800
   os_family: Android
   browser_family: Chrome
@@ -2968,19 +2684,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Pacific 800i) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Pacific 800i
   os_family: Android
   browser_family: Chrome
@@ -2988,19 +2702,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Pacific800i Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OY
+    brand: Oysters
     model: Pacific 800i
   os_family: Android
   browser_family: Opera
@@ -3008,19 +2720,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; POMP-W88A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: P2
+    brand: Pomp
     model: W88A
   os_family: Android
   browser_family: Android Browser
@@ -3028,19 +2738,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; POMP W89 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: P2
+    brand: Pomp
     model: W89
   os_family: Android
   browser_family: Android Browser
@@ -3048,19 +2756,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KING 7 Build/ABCDEF) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P3
+    brand: PPTV
     model: KING 7
   os_family: Android
   browser_family: Chrome
@@ -3068,19 +2774,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; KING 7S Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P3
+    brand: PPTV
     model: KING 7S
   os_family: Android
   browser_family: Chrome
@@ -3088,19 +2792,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PLUM Z405 Build/1503019633) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P4
+    brand: Plum
     model: Gator 3
   os_family: Android
   browser_family: Chrome
@@ -3108,19 +2810,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; W8480 Build/JOP40D)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Crystal 4 W8480
   os_family: Android
   browser_family: Android Browser
@@ -3128,19 +2828,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; POLYTRON_P520 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Prime 7S
   os_family: Android
   browser_family: Chrome
@@ -3148,19 +2846,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.6; id; PW1100S) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobil
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.460"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: PW1100S
   os_family: Android
   browser_family: Unknown
@@ -3168,19 +2864,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; POLYTRON.Q2352 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Q2352
   os_family: Android
   browser_family: Android Browser
@@ -3188,19 +2882,17 @@
   user_agent: ' Dalvik/1.6.0 (Linux; U; Android 4.2.2; W7430 Build/JDQ39)'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Quadra Mini W7430
   os_family: Android
   browser_family: Android Browser
@@ -3208,19 +2900,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; POLYTRON W6500 Build/A900_V0.1_2015.01.07)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Quadra Rocket
   os_family: Android
   browser_family: Android Browser
@@ -3228,19 +2918,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; POLYTRON W7452 Build/POLYTRONA728)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Quadra S2
   os_family: Android
   browser_family: Android Browser
@@ -3248,19 +2936,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; W7550 Build/JOP40D)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Quadra V5
   os_family: Android
   browser_family: Android Browser
@@ -3268,19 +2954,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; W8570 Build/JOP40D)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Quadra V7
   os_family: Android
   browser_family: Android Browser
@@ -3288,19 +2972,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; POLYTRON R2508 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket
   os_family: Android
   browser_family: Chrome
@@ -3308,19 +2990,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; id-id; R2401 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket 2X
   os_family: Android
   browser_family: Android Browser
@@ -3328,19 +3008,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; POLYTRON W1400 Build/POLYTRONW1400)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket Jetz
   os_family: Android
   browser_family: Android Browser
@@ -3348,19 +3026,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; id; POLYTRON_R3450 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket Jetz
   os_family: Android
   browser_family: Unknown
@@ -3368,19 +3044,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; id-id; POLYTRON_R3500 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket Jetz 5.0
   os_family: Android
   browser_family: Android Browser
@@ -3388,19 +3062,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 5.1; id; POLYTRON_L501) U2/1.0.0 UCBrowser/10.7.6.805 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.6.805"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket L501
   os_family: Android
   browser_family: Unknown
@@ -3408,19 +3080,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; id; POLYTRON_R1500) U2/1.0.0 UCBrowser/10.1.1.570 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.1.570"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket Q-Five
   os_family: Android
   browser_family: Unknown
@@ -3428,19 +3098,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; POLYTRON_R2403 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket R1
   os_family: Android
   browser_family: Android Browser
@@ -3448,19 +3116,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; POLYTRON_R2406 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket R2
   os_family: Android
   browser_family: Android Browser
@@ -3468,19 +3134,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; POLYTRON R2402 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket R2402
   os_family: Android
   browser_family: Android Browser
@@ -3488,19 +3152,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; POLYTRON R2407 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket R3
   os_family: Android
   browser_family: Chrome
@@ -3508,19 +3170,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1; POLYTRON-R2457 Build/LMY47D
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket S2
   os_family: Android
   browser_family: Android Browser
@@ -3528,19 +3188,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; POLYTRON R2501 Build/LRX21M)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket T1
   os_family: Android
   browser_family: Android Browser
@@ -3548,19 +3206,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; POLYTRON R2506 Build/Polytron_R2506_A900B_V03_2015.10.21)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket T4
   os_family: Android
   browser_family: Android Browser
@@ -3568,19 +3224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; POLYTRON R2509SE Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Rocket T6 SE
   os_family: Android
   browser_family: Chrome
@@ -3588,19 +3242,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; W7531 Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Wizard V
   os_family: Android
   browser_family: Android Browser
@@ -3608,19 +3260,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; POLYTRON 4G450 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 5
   os_family: Android
   browser_family: Chrome
@@ -3628,19 +3278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; POLYTRON 4G500 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Cleo
   os_family: Android
   browser_family: Chrome
@@ -3648,19 +3296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; POLYTRON_4G503 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Flaz
   os_family: Android
   browser_family: Chrome
@@ -3668,19 +3314,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; POLYTRON__4G550 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Note
   os_family: Android
   browser_family: Android Browser
@@ -3688,19 +3332,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; POLYTRON_4G501 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Posh
   os_family: Android
   browser_family: Android Browser
@@ -3708,19 +3350,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; POLYTRON_4G551 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Posh Note
   os_family: Android
   browser_family: Chrome
@@ -3728,19 +3368,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; POLYTRON_4G502 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: P5
+    brand: Polytron
     model: Zap 6 Power
   os_family: Android
   browser_family: Android Browser
@@ -3748,19 +3386,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PROTRULY D7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P7
+    brand: Protruly
     model: D7
   os_family: Android
   browser_family: Chrome
@@ -3768,19 +3404,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PROTRULY D8 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P7
+    brand: Protruly
     model: D8
   os_family: Android
   browser_family: Chrome
@@ -3788,19 +3422,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; PROTRULY V10S Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: P7
+    brand: Protruly
     model: V10S
   os_family: Android
   browser_family: Chrome
@@ -3808,19 +3440,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Eluga_A2 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Eluga A2
   os_family: Android
   browser_family: Chrome
@@ -3828,19 +3458,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ELUGA_I2 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Eluga I2
   os_family: Android
   browser_family: Chrome
@@ -3848,19 +3476,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ELUGA Note Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Eluga Note
   os_family: Android
   browser_family: Chrome
@@ -3868,19 +3494,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ELUGA Ray X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Eluga Ray X
   os_family: Android
   browser_family: Chrome
@@ -3888,19 +3512,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ELUGA Turbo Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Eluga Turbo
   os_family: Android
   browser_family: Chrome
@@ -3908,19 +3530,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P55 Novo 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: P55 Novo 4G
   os_family: Android
   browser_family: Chrome
@@ -3928,19 +3548,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Panasonic_T50 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: T50
   os_family: Android
   browser_family: Chrome
@@ -3948,19 +3566,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; FZ-N1 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Toughpad FZ-N1
   os_family: Android
   browser_family: Chrome
@@ -3968,19 +3584,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; FZ-X1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Toughpad FZ-X1
   os_family: Android
   browser_family: Chrome
@@ -3988,19 +3602,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Art-PCB-V116 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PB
+    brand: PCBOX
     model: Art
   os_family: Android
   browser_family: Chrome
@@ -4008,19 +3620,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Bee-PCB-V216 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PB
+    brand: PCBOX
     model: Bee
   os_family: Android
   browser_family: Chrome
@@ -4028,19 +3638,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Clap-PCB-I316 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PB
+    brand: PCBOX
     model: Clap
   os_family: Android
   browser_family: Chrome
@@ -4048,19 +3656,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PH4001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PC
+    brand: PCD
     model: PH4001
   os_family: Android
   browser_family: Chrome
@@ -4068,19 +3674,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PCD 506 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PD
+    brand: PCD Argentina
     model: "506"
   os_family: Android
   browser_family: Chrome
@@ -4088,19 +3692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PCD508 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PD
+    brand: PCD Argentina
     model: "508"
   os_family: Android
   browser_family: Chrome
@@ -4108,19 +3710,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PCD509 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PD
+    brand: PCD Argentina
     model: "509"
   os_family: Android
   browser_family: Chrome
@@ -4128,19 +3728,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Pentagram Ego Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PG
+    brand: Pentagram
     model: Ego
   os_family: Android
   browser_family: Android Browser
@@ -4148,19 +3746,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; Pentagram Monster Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PG
+    brand: Pentagram
     model: Monster
   os_family: Android
   browser_family: Android Browser
@@ -4168,19 +3764,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Monster X5 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PG
+    brand: Pentagram
     model: Monster X5
   os_family: Android
   browser_family: Android Browser
@@ -4188,19 +3782,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Philips_S396 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: S396
   os_family: Android
   browser_family: Chrome
@@ -4208,19 +3800,17 @@
   user_agent: Philips T3566_TD/V1 Linux/3.4.5 Android/4.2.2 Release/05.02.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: T3566
   os_family: Android
   browser_family: Android Browser
@@ -4228,19 +3818,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; Philips W632 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: W632
   os_family: Android
   browser_family: Android Browser
@@ -4248,19 +3836,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru; Philips W832 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: W832
   os_family: Android
   browser_family: Unknown
@@ -4268,19 +3854,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; vi-vn; Pioneer Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: ""
   os_family: Android
   browser_family: Android Browser
@@ -4288,19 +3872,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; E60w Build/PioneerE60w) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: E60w
   os_family: Android
   browser_family: Android Browser
@@ -4308,19 +3890,17 @@
   user_agent: 'Pioneer E71t/V100 Linux/3.4.5 Android/4.2.1  Release/12.24.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1;'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: E71t
   os_family: Android
   browser_family: Android Browser
@@ -4328,19 +3908,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; Pioneer E80w Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.2.585 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.2.585"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: E80w
   os_family: Android
   browser_family: Unknown
@@ -4348,19 +3926,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; en-us; Versus Pioneer_P1 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: P1
   os_family: Android
   browser_family: Android Browser
@@ -4368,19 +3944,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.1; zh-CN; Pioneer S90w) U2/1.0.0 UCBrowser/9.9.2.467 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PI
+    brand: Pioneer
     model: S90w
   os_family: Android
   browser_family: Unknown
@@ -4388,19 +3962,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PROV400 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Agate
   os_family: Android
   browser_family: Chrome
@@ -4408,19 +3980,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; Polaroid PSPC505 Build/PSPC505_MX_V1.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo 505
   os_family: Android
   browser_family: Android Browser
@@ -4428,19 +3998,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PSPC550 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo 550
   os_family: Android
   browser_family: Chrome
@@ -4448,19 +4016,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P5006A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo K
   os_family: Android
   browser_family: Chrome
@@ -4468,19 +4034,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P5526A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo K Plus
   os_family: Android
   browser_family: Chrome
@@ -4488,19 +4052,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PSPCK21NA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo K2 Plus
   os_family: Android
   browser_family: Chrome
@@ -4508,19 +4070,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P5026A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo L
   os_family: Android
   browser_family: Chrome
@@ -4528,19 +4088,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PSPCL20A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo L2
   os_family: Android
   browser_family: Chrome
@@ -4548,19 +4106,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PSPCM20A0 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo M2
   os_family: Android
   browser_family: Chrome
@@ -4568,19 +4124,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P5046A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo P5s
   os_family: Android
   browser_family: Chrome
@@ -4588,19 +4142,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P5525A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo Q5s
   os_family: Android
   browser_family: Chrome
@@ -4608,19 +4160,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P5047A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo Z
   os_family: Android
   browser_family: Chrome
@@ -4628,19 +4178,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PSPCZ20A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Cosmo Z2
   os_family: Android
   browser_family: Chrome
@@ -4648,19 +4196,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P5025A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: L5s
   os_family: Android
   browser_family: Chrome
@@ -4668,19 +4214,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PRO4006 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro4006
   os_family: Android
   browser_family: Android Browser
@@ -4688,19 +4232,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PRO4006 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro4006
   os_family: Android
   browser_family: Chrome
@@ -4708,19 +4250,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PRO400B Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro400B
   os_family: Android
   browser_family: Android Browser
@@ -4728,19 +4268,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PRO450B Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro450B
   os_family: Android
   browser_family: Android Browser
@@ -4748,19 +4286,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PRO4611PR201 Build/PRO4611PR201-V1.0-2013.07.25) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro4611
   os_family: Android
   browser_family: Android Browser
@@ -4768,19 +4304,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; PRO5701 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro5701
   os_family: Android
   browser_family: Chrome
@@ -4788,19 +4322,17 @@
   user_agent: PRO7111 Linux/3.0.13 Android/4.0.4 Release/05.14.2013 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Pro7111
   os_family: Android
   browser_family: Android Browser
@@ -4808,19 +4340,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PROV350 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: ProV350
   os_family: Android
   browser_family: Android Browser
@@ -4828,19 +4358,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SIGMA 5 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Sigma 5
   os_family: Android
   browser_family: Chrome
@@ -4848,19 +4376,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P4005A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Turbo C4
   os_family: Android
   browser_family: Chrome
@@ -4868,19 +4394,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; Polaroid P5005A Build/P5005A_MX_V1.0) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Turbo C5
   os_family: Android
   browser_family: Chrome
@@ -4888,19 +4412,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P4006A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Turbo D4
   os_family: Android
   browser_family: Chrome
@@ -4908,19 +4430,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P4526A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PL
+    brand: Polaroid
     model: Turbo E
   os_family: Android
   browser_family: Chrome
@@ -4928,19 +4448,17 @@
   user_agent: 'Palmscape/3.0J [ja] (v. 3.5.2H1.5; 153x130; c8)'
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palmscape
-    short_name: PA
     version: "3.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: ""
   os_family: Other Mobile
   browser_family: Unknown
@@ -4948,19 +4466,17 @@
   user_agent: 'Xiino/1.0.9E [en] (v. 4.1; 153x130; g4)'
   os:
     name: palmOS
-    short_name: POS
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Xiino
-    short_name: XI
     version: "1.0.9"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: ""
   os_family: Other Mobile
   browser_family: Unknown
@@ -4968,13 +4484,12 @@
   user_agent: CorePlayer/1.0 (Palm OS 5.4.9; ARM Intel PXA27x; en) CorePlayer/1.3.2_6909
   os:
     name: palmOS
-    short_name: POS
     version: "5.4.9"
     platform: ARM
   client: null
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: ""
   os_family: Other Mobile
   browser_family: Unknown
@@ -4982,19 +4497,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource/Palm-D050; Blazer/4.3) 16;320x320
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palm Blazer
-    short_name: PL
     version: "4.3"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: D050
   os_family: Other Mobile
   browser_family: Unknown
@@ -5002,19 +4515,17 @@
   user_agent: Mozilla/5.0 (webOS/1.4.5; U; ru-RU) AppleWebKit/532.2 (KHTML, like Gecko) Version/1.0 Safari/532.2 Pixi/1.0
   os:
     name: webOS
-    short_name: WOS
     version: "1.4.5"
     platform: ""
   client:
     type: browser
     name: wOSBrowser
-    short_name: WO
     version: "1.4.5"
     engine: WebKit
     engine_version: "532.2"
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Pixi 1.0
   os_family: Other Mobile
   browser_family: Unknown
@@ -5022,19 +4533,17 @@
   user_agent: Mozilla/5.0 (webOS/1.0; U; en-US) AppleWebKit/525.27.1 (KHTML, like Gecko) Version/1.0 Safari/525.27.1 Pre/1.0
   os:
     name: webOS
-    short_name: WOS
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Palm Pre
-    short_name: PR
     version: "1.0"
     engine: WebKit
     engine_version: "525.27.1"
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Pre 1.0
   os_family: Other Mobile
   browser_family: Unknown
@@ -5042,19 +4551,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) 320X320 Palm Treo850e
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Treo850e
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -5062,19 +4569,17 @@
   user_agent: Mozilla/4.76 (compatible; MSIE 6.0; U; Windows 95; PalmSource; PalmOS; WebPro; Tungsten Proxyless 1.1 320x320x16)
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palm WebPro
-    short_name: PW
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Tungsten
   os_family: Other Mobile
   browser_family: Unknown
@@ -5082,19 +4587,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource/Palm-TunX; Blazer/4.3) 16;320x448
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palm Blazer
-    short_name: PL
     version: "4.3"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: TunX
   os_family: Other Mobile
   browser_family: Unknown
@@ -5102,19 +4605,17 @@
   user_agent: 'Mozilla/5.0 [en] (PalmOS; U; WebPro/3.5; Palm-Zi72)'
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palm WebPro
-    short_name: PW
     version: "3.5"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Zi72
   os_family: Other Mobile
   browser_family: Unknown
@@ -5122,19 +4623,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows 98; PalmSource/Palm-Zir4; Blazer/4.0) 16;320x320
   os:
     name: palmOS
-    short_name: POS
     version: ""
     platform: ""
   client:
     type: browser
     name: Palm Blazer
-    short_name: PL
     version: "4.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PM
+    brand: Palm
     model: Zir4
   os_family: Other Mobile
   browser_family: Unknown
@@ -5142,19 +4641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Muze C3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: Muze C3
   os_family: Android
   browser_family: Chrome
@@ -5162,19 +4659,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PAP3350DUO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP3350DUO
   os_family: Android
   browser_family: Android Browser
@@ -5182,19 +4677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; PAP3400DUO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP3400DUO
   os_family: Android
   browser_family: Android Browser
@@ -5202,19 +4695,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; PAP3540DUO Build/PrestigioPAP3540DUO) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP3540DUO
   os_family: Android
   browser_family: Android Browser
@@ -5222,19 +4713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; PAP4040_DUO Build/PrestigioPAP4040DUO) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP4040 DUO
   os_family: Android
   browser_family: Android Browser
@@ -5242,19 +4731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; PAP4300 DUO Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP4300 DUO
   os_family: Android
   browser_family: Android Browser
@@ -5262,19 +4749,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-; PAP4322DUO Build/PrestigioPAP4322DUO) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP4322DUO
   os_family: Android
   browser_family: Android Browser
@@ -5282,19 +4767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; PAP4500TDUO Build/PrestigioPAP4500TDUO) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP4500TDUO
   os_family: Android
   browser_family: Chrome
@@ -5302,7 +4785,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PAP4505DUO Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.2.17.1009776.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -5311,7 +4793,7 @@
     version: "3.2.17.1009776"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP4505DUO
   os_family: Android
   browser_family: Unknown
@@ -5319,19 +4801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; PAP5044DUO Build/PrestigioPAP5044DUO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP5044DUO
   os_family: Android
   browser_family: Chrome
@@ -5339,19 +4819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PAP5500DUO Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP5500DUO
   os_family: Android
   browser_family: Chrome
@@ -5359,19 +4837,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PAP5501 Build/PrestigioPAP5501) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PAP5501
   os_family: Android
   browser_family: Android Browser
@@ -5379,19 +4855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PSP3502DUO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PSP3502DUO
   os_family: Android
   browser_family: Chrome
@@ -5399,19 +4873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PSP5453DUO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PSP5453DUO
   os_family: Android
   browser_family: Chrome
@@ -5419,19 +4891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PSP5504DUO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PSP5504DUO
   os_family: Android
   browser_family: Chrome
@@ -5439,19 +4909,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; PSP8500DUO) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: PR
+    brand: Prestigio
     model: PSP8500DUO
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -5459,19 +4927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; YPY_S450 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PS
+    brand: Positivo
     model: YPY S450
   os_family: Android
   browser_family: Chrome
@@ -5479,19 +4945,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; IM-A840S Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: IM-A840S
   os_family: Android
   browser_family: Android Browser
@@ -5499,19 +4963,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; IM-A850K Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: IM-A850K
   os_family: Android
   browser_family: Android Browser
@@ -5519,19 +4981,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; IM-A850L Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: IM-A850L
   os_family: Android
   browser_family: Android Browser
@@ -5539,19 +4999,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ko-kr; IM-T100K Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 NAVER(inapp; search; 200; 3.7.0)
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: IM-T100K
   os_family: Android
   browser_family: Android Browser
@@ -5561,13 +5019,12 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "4.2.15645"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P7000
   os_family: Unknown
   browser_family: Opera
@@ -5575,19 +5032,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; PantechP8000 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P8000
   os_family: Android
   browser_family: Unknown
@@ -5595,19 +5050,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; PantechP8010 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P8010
   os_family: Android
   browser_family: Android Browser
@@ -5617,13 +5070,12 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "4.2.18216"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P9020
   os_family: Unknown
   browser_family: Opera
@@ -5631,19 +5083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; PantechP9060 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P9060
   os_family: Android
   browser_family: Android Browser
@@ -5651,19 +5101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; PantechP9070 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: P9070
   os_family: Android
   browser_family: Chrome
@@ -5671,19 +5119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; ADR910L Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: Star Q
   os_family: Android
   browser_family: Android Browser
@@ -5691,19 +5137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; ADR910L 4G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: Star Q
   os_family: Android
   browser_family: Android Browser
@@ -5711,19 +5155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-us; IM-A870K/2.10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PT
+    brand: Pantech
     model: Vega Iron
   os_family: Android
   browser_family: Chrome
@@ -5731,19 +5173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; PULID F11 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100501012
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: F11
   os_family: Android
   browser_family: Chrome
@@ -5751,19 +5191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; vi; F13 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: F13
   os_family: Android
   browser_family: Unknown
@@ -5771,19 +5209,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; vi; F15 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: F15
   os_family: Android
   browser_family: Unknown
@@ -5791,19 +5227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; PULID_F6 Build/IMM76D) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/9.7.0.520 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: F6
   os_family: Android
   browser_family: Unknown
@@ -5811,19 +5245,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Android 2.3.6; en-US; PULID F7) U2/1.0.0 UCBrowser/10.4.1.565 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.1.565"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: F7
   os_family: Android
   browser_family: Unknown
@@ -5831,19 +5263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; PULID T3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PU
+    brand: PULID
     model: T3
   os_family: Android
   browser_family: Android Browser
@@ -5851,19 +5281,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; MOB-5045 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: PV
+    brand: Point of View
     model: Mobii Phone 5045
   os_family: Android
   browser_family: Android Browser
@@ -5871,19 +5299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; pixus hit 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PX
+    brand: Pixus
     model: Hit 2
   os_family: Android
   browser_family: Chrome
@@ -5891,19 +5317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Pixus_Jet) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PX
+    brand: Pixus
     model: Jet
   os_family: Android
   browser_family: Chrome
@@ -5911,19 +5335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Pixus Raze Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PX
+    brand: Pixus
     model: Raze
   os_family: Android
   browser_family: Chrome
@@ -5931,19 +5353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Quantum Fit) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: Fit
   os_family: Android
   browser_family: Chrome
@@ -5951,19 +5371,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Quantum Go Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: Go
   os_family: Android
   browser_family: Android Browser
@@ -5971,19 +5389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Quantum Mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: Mini
   os_family: Android
   browser_family: Chrome
@@ -5991,19 +5407,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Quantum MUV PRO Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: MUV Pro
   os_family: Android
   browser_family: Android Browser
@@ -6011,19 +5425,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; Quantum MUV UP Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: MUV Up
   os_family: Android
   browser_family: Android Browser
@@ -6031,19 +5443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Quantum V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: V
   os_family: Android
   browser_family: Chrome
@@ -6051,19 +5461,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Quantum You 2 Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: You 2
   os_family: Android
   browser_family: Android Browser
@@ -6071,19 +5479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Quantum You E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QA
+    brand: Quantum
     model: You E
   os_family: Android
   browser_family: Chrome
@@ -6091,19 +5497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; QPHONE_10.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QB
+    brand: Q.Bell
     model: QPHONE 10.1
   os_family: Android
   browser_family: Chrome
@@ -6111,19 +5515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; QPHONE 5.4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QB
+    brand: Q.Bell
     model: QPHONE 5.4
   os_family: Android
   browser_family: Chrome
@@ -6131,19 +5533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; QPHONE 9.1 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QB
+    brand: Q.Bell
     model: QPHONE 9.1
   os_family: Android
   browser_family: Chrome
@@ -6151,19 +5551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q09 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QH
+    brand: Q-Touch
     model: Q09
   os_family: Android
   browser_family: Chrome
@@ -6171,19 +5569,17 @@
   user_agent: Qilive 40/V2 Linux/3.0.13 Android/4.0 Release/02.15.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: "40"
   os_family: Android
   browser_family: Android Browser
@@ -6191,19 +5587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Qilive 40 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: "40"
   os_family: Android
   browser_family: Chrome
@@ -6211,19 +5605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Qilive 45 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: "45"
   os_family: Android
   browser_family: Chrome
@@ -6231,19 +5623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Qilive 50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: "50"
   os_family: Android
   browser_family: Android Browser
@@ -6251,19 +5641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Qilive 53 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: "53"
   os_family: Android
   browser_family: Chrome
@@ -6271,19 +5659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Q10S5IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q10 5.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6291,19 +5677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Q10S5IN4GR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q10 5.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6311,19 +5695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Q10S53IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q10 5.3" 4G
   os_family: Android
   browser_family: Chrome
@@ -6331,19 +5713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Q10S57IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q10 5.7" 4G
   os_family: Android
   browser_family: Chrome
@@ -6351,19 +5731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Q10S6IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q10 6.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6371,19 +5749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q7S5IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q7 5.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6391,19 +5767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q7S55IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q7 5.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6411,19 +5785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Q8S5IN4GP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q8 5.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -6431,19 +5803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Q8S55IN4G2 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q8 5.5" 4G
   os_family: Android
   browser_family: Chrome
@@ -6451,19 +5821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Q8S6IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q8 6.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6471,19 +5839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Q9S5IN4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QI
+    brand: Qilive
     model: Q9 5.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -6491,19 +5857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; QMobile A11Note Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: A11Note
   os_family: Android
   browser_family: Android Browser
@@ -6511,19 +5875,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.5; en-US; QMobile_A2_Lite) U2/1.0.0 UCBrowser/9.1.1.420 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.1.420"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: A2 Lite
   os_family: Android
   browser_family: Unknown
@@ -6531,19 +5893,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; en-US; QMobile A30) U2/1.0.0 UCBrowser/9.3.1.344 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.1.344"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: A30
   os_family: Android
   browser_family: Unknown
@@ -6551,19 +5911,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; QMobile A65 Build/QMobileA65) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: A65
   os_family: Android
   browser_family: Unknown
@@ -6571,19 +5929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LUNA PRO Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: Luna Pro
   os_family: Android
   browser_family: Chrome
@@ -6591,19 +5947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NICE S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: Nice S
   os_family: Android
   browser_family: Chrome
@@ -6611,19 +5965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Noir X1S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: Noir X1S
   os_family: Android
   browser_family: Chrome
@@ -6631,19 +5983,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.5; vi; Q-Smart_S12) U2/1.0.0 UCBrowser/9.7.0.520 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: S12
   os_family: Android
   browser_family: Unknown
@@ -6651,19 +6001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QMobile X25 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36 OPR/27.0.1698.88647
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "27.0.1698.88647"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: X25
   os_family: Android
   browser_family: Opera
@@ -6671,19 +6019,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; QMobile Z10 Build/LMY47D) U2/1.0.0 UCMini/10.9.0.946 (SpeedMode; Android 5.1; QMobile Z10 Build/LMY47D) Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser Mini
-    short_name: UM
     version: "10.9.0.946"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: QM
+    brand: QMobile
     model: Z10
   os_family: Android
   browser_family: Unknown
@@ -6691,19 +6037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; QUMO_Quest353 Build/97055LL) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 353
   os_family: Android
   browser_family: Android Browser
@@ -6711,19 +6055,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; QUMO_Quest_354 Build/97055KT) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 354
   os_family: Android
   browser_family: Android Browser
@@ -6731,19 +6073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUMO Quest 402) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 402
   os_family: Android
   browser_family: Chrome
@@ -6751,19 +6091,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; QUMO Quest 406 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 406
   os_family: Android
   browser_family: Chrome
@@ -6771,19 +6109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QUMO_Quest452 Build/97055LT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 452
   os_family: Android
   browser_family: Chrome
@@ -6791,19 +6127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUMO Quest 458 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 458
   os_family: Android
   browser_family: Chrome
@@ -6811,19 +6145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUMO Quest 476 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 476
   os_family: Android
   browser_family: Chrome
@@ -6831,19 +6163,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; QUMO Quest 507 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 507
   os_family: Android
   browser_family: Chrome
@@ -6851,19 +6181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Qumo Quest 570 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 570
   os_family: Android
   browser_family: Android Browser
@@ -6871,19 +6199,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; QUMO QUEST 600 Build/JRO03C)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: QO
+    brand: Qumo
     model: Quest 600
   os_family: Android
   browser_family: Android Browser
@@ -6891,19 +6217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Quechua Phone 5 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: QU
+    brand: Quechua
     model: Quechua Phone 5
   os_family: Android
   browser_family: Chrome
@@ -6911,19 +6235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; IO Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R1
+    brand: Rokit
     model: IO Pro
   os_family: Android
   browser_family: Chrome
@@ -6931,19 +6253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIA_A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA A1
   os_family: Android
   browser_family: Chrome
@@ -6951,19 +6271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIA_A1_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA A1 Plus
   os_family: Android
   browser_family: Chrome
@@ -6971,19 +6289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; CASPER_VIA_A2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA A2
   os_family: Android
   browser_family: Chrome
@@ -6991,19 +6307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; VIA_A3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA A3
   os_family: Android
   browser_family: Chrome
@@ -7011,19 +6325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VIA A4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA A4
   os_family: Android
   browser_family: Chrome
@@ -7031,19 +6343,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; CASPER_VIA_E1 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA E1
   os_family: Android
   browser_family: Chrome
@@ -7051,19 +6361,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; CASPER_VIA_E1c AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA E1C
   os_family: Android
   browser_family: Chrome
@@ -7071,19 +6379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CASPER_VIA_E2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA E2
   os_family: Android
   browser_family: Chrome
@@ -7091,19 +6397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VIA_E3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA E3
   os_family: Android
   browser_family: Chrome
@@ -7111,19 +6415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIA_F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA F1
   os_family: Android
   browser_family: Chrome
@@ -7131,19 +6433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIA_F2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA F2
   os_family: Android
   browser_family: Chrome
@@ -7151,19 +6451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VIA_F3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA F3
   os_family: Android
   browser_family: Chrome
@@ -7171,19 +6469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; CASPER_VIA_G1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA G1
   os_family: Android
   browser_family: Chrome
@@ -7191,19 +6487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; CASPER_VIA_G1_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA G1 Plus
   os_family: Android
   browser_family: Chrome
@@ -7211,19 +6505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CASPER VIA_G3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 AlohaBrowser/2.8.0.3
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "2.8.0.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA G3
   os_family: Android
   browser_family: Unknown
@@ -7231,19 +6523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VIA_G4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA G4
   os_family: Android
   browser_family: Chrome
@@ -7251,19 +6541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CASPER_VIA_M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA M1
   os_family: Android
   browser_family: Chrome
@@ -7271,19 +6559,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; CASPER_VIA_M2 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA M2
   os_family: Android
   browser_family: Chrome
@@ -7291,19 +6577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CASPER_VIA_M3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA M3
   os_family: Android
   browser_family: Chrome
@@ -7311,19 +6595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VIA_M4 Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA M4
   os_family: Android
   browser_family: Chrome
@@ -7331,19 +6613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIA_P2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA P2
   os_family: Android
   browser_family: Chrome
@@ -7351,19 +6631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VIA_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA S
   os_family: Android
   browser_family: Chrome
@@ -7371,19 +6649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Casper_VIA_V10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V10
   os_family: Android
   browser_family: Chrome
@@ -7391,19 +6667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Casper_VIA_V3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V3
   os_family: Android
   browser_family: Chrome
@@ -7411,19 +6685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Casper_VIA_V5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V5
   os_family: Android
   browser_family: Chrome
@@ -7431,19 +6703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Casper_VIA_V6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V6
   os_family: Android
   browser_family: Chrome
@@ -7451,19 +6721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Casper_VIA_V8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V8
   os_family: Android
   browser_family: Chrome
@@ -7471,19 +6739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA_V8C Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V8C
   os_family: Android
   browser_family: Chrome
@@ -7491,19 +6757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Casper_VIA_V9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R4
+    brand: Casper
     model: VIA V9
   os_family: Android
   browser_family: Chrome
@@ -7511,19 +6775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RoverPhone) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R6
+    brand: RoverPad
     model: ""
   os_family: Android
   browser_family: Chrome
@@ -7531,19 +6793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RITZVIVA_S500C Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R7
+    brand: Ritzviva
     model: S500C
   os_family: Android
   browser_family: Chrome
@@ -7551,19 +6811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; H1A1000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R8
+    brand: RED
     model: Hydrogen One
   os_family: Android
   browser_family: Chrome
@@ -7571,19 +6829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RAVOZ R4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: R4
   os_family: Android
   browser_family: Chrome
@@ -7591,19 +6847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RAVOZ R7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: R7
   os_family: Android
   browser_family: Chrome
@@ -7611,19 +6865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RAVOZ R8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: R8
   os_family: Android
   browser_family: Chrome
@@ -7631,19 +6883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RAVOZ Z3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4114.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4114.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: Z3
   os_family: Android
   browser_family: Chrome
@@ -7651,19 +6901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RAVOZ_Z4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: Z4
   os_family: Android
   browser_family: Chrome
@@ -7671,19 +6919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RAVOZ Z7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: R9
+    brand: Ravoz
     model: Z7
   os_family: Android
   browser_family: Chrome
@@ -7691,19 +6937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RCA RLTP4028 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RC
+    brand: RCA Tablets
     model: RLTP4028
   os_family: Android
   browser_family: Chrome
@@ -7711,19 +6955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1861 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "1"
   os_family: Android
   browser_family: Chrome
@@ -7731,19 +6973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1809) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -7751,19 +6991,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; RMX1805 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.5.5.1111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.5.5.1111"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "2"
   os_family: Android
   browser_family: Unknown
@@ -7771,19 +7009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1801) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7791,19 +7027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1807) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7811,19 +7045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1833) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -7831,19 +7063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1821) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -7851,19 +7081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1825) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -7871,19 +7099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1851) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -7891,19 +7117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1827) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 3i
   os_family: Android
   browser_family: Chrome
@@ -7911,19 +7135,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; RMX1919 Build/PKQ1.190616.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "5"
   os_family: Android
   browser_family: Android Browser
@@ -7931,59 +7153,53 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1911) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/B31D67
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
-    model: 5
+    brand: Realme
+    model: "5"
   os_family: Android
   browser_family: Chrome
 - 
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1927) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
-    model: 5
+    brand: Realme
+    model: "5"
   os_family: Android
   browser_family: Chrome
 - 
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1971) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -7991,19 +7207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX2030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 5i
   os_family: Android
   browser_family: Chrome
@@ -8011,19 +7225,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; RMX2032 Build/QKQ1.200209.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 5i
   os_family: Android
   browser_family: Android Browser
@@ -8031,19 +7243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1925) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 5S
   os_family: Android
   browser_family: Chrome
@@ -8051,19 +7261,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 10; RMX2001)  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: "6"
   os_family: Android
   browser_family: Chrome
@@ -8071,19 +7279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2063) AppleWebKit/537.36 (KHTML, like GECKO) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 6 Pro
   os_family: Android
   browser_family: Chrome
@@ -8091,19 +7297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2061 Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 6 Pro
   os_family: Android
   browser_family: Chrome
@@ -8111,19 +7315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2040 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 6I
   os_family: Android
   browser_family: Chrome
@@ -8131,19 +7333,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; RMX2002 Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 6S
   os_family: Android
   browser_family: Android Browser
@@ -8151,19 +7351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1811) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C1
   os_family: Android
   browser_family: Chrome
@@ -8171,19 +7369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2185 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C11
   os_family: Android
   browser_family: Chrome
@@ -8191,19 +7387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2189 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C12
   os_family: Android
   browser_family: Chrome
@@ -8211,19 +7405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2180 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C15
   os_family: Android
   browser_family: Chrome
@@ -8231,19 +7423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1943) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -8251,19 +7441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1945) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -8271,19 +7459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1941) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -8291,19 +7477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1942) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -8311,19 +7495,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; RMX2021 Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C3
   os_family: Android
   browser_family: Android Browser
@@ -8331,19 +7513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2020 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C3
   os_family: Android
   browser_family: Chrome
@@ -8351,19 +7531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2027 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: C3
   os_family: Android
   browser_family: Chrome
@@ -8371,19 +7549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RMX1831) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: U1
   os_family: Android
   browser_family: Chrome
@@ -8391,7 +7567,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; RMX2200 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 HeyTapBrowser/40.7.2.9
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -8400,7 +7575,7 @@
     version: "40.7.2.9"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: V3 5G
   os_family: Android
   browser_family: Unknown
@@ -8408,19 +7583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; RMX2111 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.3.1093 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.3.1093"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: V5 5G
   os_family: Android
   browser_family: Unknown
@@ -8428,19 +7601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1901) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X
   os_family: Android
   browser_family: Chrome
@@ -8448,19 +7619,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; RMX1903 Build/PKQ1.190101.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X
   os_family: Android
   browser_family: Unknown
@@ -8468,19 +7637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1992) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -8488,19 +7655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1991) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -8508,19 +7673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1993) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X2 Dual
   os_family: Android
   browser_family: Chrome
@@ -8528,19 +7691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1931) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X2 Pro
   os_family: Android
   browser_family: Chrome
@@ -8548,19 +7709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2142 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X3
   os_family: Android
   browser_family: Chrome
@@ -8568,19 +7727,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; RMX2086 Build/QKQ1.191021.002)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X3 Super Zoom
   os_family: Android
   browser_family: Android Browser
@@ -8588,19 +7745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2025 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 5G
   os_family: Android
   browser_family: Chrome
@@ -8608,19 +7763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; RMX2051 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.8.1078 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.8.1078"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 5G
   os_family: Android
   browser_family: Unknown
@@ -8628,19 +7781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2071 Build/QKQ1.191222.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 Pro
   os_family: Android
   browser_family: Chrome
@@ -8648,19 +7799,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; RMX2072 Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 Pro Player
   os_family: Android
   browser_family: Unknown
@@ -8668,19 +7817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2176 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X7 5G
   os_family: Android
   browser_family: Chrome
@@ -8688,19 +7835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2121 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X7 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -8708,19 +7853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RMX1921) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.3.2672.50220
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.3.2672.50220"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: XT
   os_family: Android
   browser_family: Opera
@@ -8728,19 +7871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-RU; RG310 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.1.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.1.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG310
   os_family: Android
   browser_family: Unknown
@@ -8748,19 +7889,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-RU; RG500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.9.3.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.9.3.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG500
   os_family: Android
   browser_family: Unknown
@@ -8768,19 +7907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RG650) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG650
   os_family: Android
   browser_family: Chrome
@@ -8788,19 +7925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; RG655) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG655
   os_family: Android
   browser_family: Chrome
@@ -8808,19 +7943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RG702 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG702
   os_family: Android
   browser_family: Chrome
@@ -8828,19 +7961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RG710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG710
   os_family: Android
   browser_family: Chrome
@@ -8848,19 +7979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; RugGear RG730) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG730
   os_family: Android
   browser_family: Chrome
@@ -8868,19 +7997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; RG850) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RG
+    brand: RugGear
     model: RG850
   os_family: Android
   browser_family: Chrome
@@ -8888,19 +8015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BBC100-1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Aurora
   os_family: Android
   browser_family: Chrome
@@ -8908,7 +8033,6 @@
   user_agent: FlyCast/1.34 (BlackBerry; 8330/4.5.0.131 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/-1)
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: ""
     platform: ""
   client:
@@ -8917,7 +8041,7 @@
     version: "1.34"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry
   os_family: BlackBerry
   browser_family: Unknown
@@ -8925,19 +8049,17 @@
   user_agent: UCWEB/2.0(BlackBerry; U; 6.6.0.236; en-us; 9300/6.6.0.236) U2/1.0.0 UCBrowser/8.1.0.216 U2/1.0.0 Mobile
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.1.0.216"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry
   os_family: BlackBerry
   browser_family: Unknown
@@ -8945,19 +8067,17 @@
   user_agent: Opera/9.80 (BlackBerry; Opera Mini/4.5.33868/34.861; U; es) Presto/2.8.119 Version/11.10
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "11.10"
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "4.5.33868"
     engine: Presto
     engine_version: "2.8.119"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry
   os_family: BlackBerry
   browser_family: Opera
@@ -8965,19 +8085,17 @@
   user_agent: OneBrowser/for Blackberry3.0.0 (BlackBerry9930/7.1.0.580)
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "7.1.0.580"
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 3
   os_family: BlackBerry
   browser_family: Unknown
@@ -8985,19 +8103,17 @@
   user_agent: BlackBerry7520/4.0.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 UP.Browser/5.0.3.3 UP.Link/5.1.2.12 (Google WAP Proxy/1.0)
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "4.0.0"
     platform: ""
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "5.0.3.3"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 7520
   os_family: BlackBerry
   browser_family: Unknown
@@ -9005,19 +8121,17 @@
   user_agent: BlackBerry8520/5.0.0.681 Profile/MIDP-2.1 Configuration/CLDC-1.1 VendorID/134
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "5.0.0.681"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 8520
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9025,19 +8139,17 @@
   user_agent: Mozilla/5.0 (BlackBerry; U; BlackBerry 9220; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.714 Mobile Safari/534.11+
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "7.1.0.714"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "534.11"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 9220
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9045,19 +8157,17 @@
   user_agent: Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; zh-TW) AppleWebKit/534.8+ (KHTML, like Gecko) Version/6.0.0.448 Mobile Safari/534.8+
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "6.0.0.448"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "534.8"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 9800
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9065,19 +8175,17 @@
   user_agent: Mozilla/5.0 (BlackBerry; U; BlackBerry 9930; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.755 Mobile Safari/534.11+
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "7.1.0.755"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "534.11"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry 9930
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9085,19 +8193,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; STH100-2 Build/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry DTEK50
   os_family: Android
   browser_family: Android Browser
@@ -9105,19 +8211,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; STH100-1 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry DTEK50
   os_family: Android
   browser_family: Chrome
@@ -9125,19 +8229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; BBA100-2 Build/6.0.1_0.248.0.069) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry DTEK60
   os_family: Android
   browser_family: Chrome
@@ -9145,19 +8247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; BBA100-1 Build/6.0.1_0.223.0.064) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry DTEK60
   os_family: Android
   browser_family: Chrome
@@ -9165,19 +8265,17 @@
   user_agent: Mozilla/5.0 (BB10; Kbd) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.1.0.4651 Mobile Safari/537.10+
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "10.1.0.4651"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "537.10"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Kbd
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9185,19 +8283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; STV100-1 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Priv
   os_family: Android
   browser_family: Chrome
@@ -9205,19 +8301,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; STV100-3 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Priv
   os_family: Android
   browser_family: Chrome
@@ -9225,19 +8319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; STV100-4 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Priv
   os_family: Android
   browser_family: Chrome
@@ -9245,19 +8337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; STV100-4 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Priv
   os_family: Android
   browser_family: Chrome
@@ -9265,19 +8355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; STV100-2 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Priv
   os_family: Android
   browser_family: Chrome
@@ -9285,19 +8373,17 @@
   user_agent: Mozilla/5.0 (BB10; Touch) AppleWebKit/537.10+ (KHTML, like Gecko) Version/10.1.0.4633 Mobile Safari/537.10+
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: "10.1.0.4633"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "537.10"
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: BlackBerry Touch
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -9305,19 +8391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBG100-1 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Evolve
   os_family: Android
   browser_family: Chrome
@@ -9325,19 +8409,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBH100-1 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Evolve X
   os_family: Android
   browser_family: Chrome
@@ -9345,19 +8427,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-6 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9365,19 +8445,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-7 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9385,19 +8463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-1 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9405,19 +8481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-2 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9425,19 +8499,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-3 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9445,19 +8517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-4 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9465,19 +8535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-5 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2
   os_family: Android
   browser_family: Chrome
@@ -9485,19 +8553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-9 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 Black
   os_family: Android
   browser_family: Chrome
@@ -9505,19 +8571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-1 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9525,19 +8589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-2 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9545,19 +8607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-3 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9565,19 +8625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-4 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9585,19 +8643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-5 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9605,19 +8661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-6 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9625,19 +8679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-7 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9645,19 +8697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-8 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9665,19 +8715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBE100-9 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 LE
   os_family: Android
   browser_family: Chrome
@@ -9685,19 +8733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BBF100-8 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEY2 Silver
   os_family: Android
   browser_family: Chrome
@@ -9705,19 +8751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-3 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9725,19 +8769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-5 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9745,19 +8787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-6 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9765,19 +8805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-7 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9785,19 +8823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BBB100-2 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9805,19 +8841,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-us; BBB100-4 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: KEYone
   os_family: Android
   browser_family: Chrome
@@ -9825,19 +8859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; BBD100-2 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Motion
   os_family: Android
   browser_family: Chrome
@@ -9845,19 +8877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; BBD100-6 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Motion
   os_family: Android
   browser_family: Chrome
@@ -9865,19 +8895,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; BBD100-1 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RM
+    brand: RIM
     model: Motion
   os_family: Android
   browser_family: Chrome
@@ -9885,19 +8913,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; es-us; RINNO R505 Build/KOT49H) Browser/AppleWebKit534.30 Mobile Safari/534.30 System/Android 5.1;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RN
+    brand: Rinno
     model: R505
   os_family: Android
   browser_family: Android Browser
@@ -9905,19 +8931,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Shock 5 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RT
+    brand: RT Project
     model: Shock 5
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-12.yml
+++ b/Tests/fixtures/smartphone-12.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; RunboF1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: F1
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Runbo F1 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: F1 Plus
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RunboF1-EN Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: F1-EN
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RunboF1-TT Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: F1-TT
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; RunboQ5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: Q5
   os_family: Android
   browser_family: Android Browser
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; RunboQ5-S Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: Q5-S
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Runbo-TT Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: TT
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; RunboX5-King Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: X5-King
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; RunboX5-W Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: X5-W
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; RunboX6 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RU
+    brand: Runbo
     model: X6
   os_family: Android
   browser_family: Android Browser
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RIVIERA F23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RV
+    brand: Riviera
     model: F23
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; RMP-450 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RX
+    brand: Ritmix
     model: RMP-450
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Ritmix RMP-505 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RX
+    brand: Ritmix
     model: RMP-505
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; RITMIX RMP-506 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RX
+    brand: Ritmix
     model: RMP-506
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMP-530 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RX
+    brand: Ritmix
     model: RMP-530
   os_family: Android
   browser_family: Android Browser
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMP-600 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: RX
+    brand: Ritmix
     model: RMP-600
   os_family: Android
   browser_family: Android Browser
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RYTE U55 LTE Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 AlohaBrowser/2.7.0.3
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "2.7.0.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RY
+    brand: Ryte
     model: U55 LTE
   os_family: Android
   browser_family: Unknown
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Phone 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RZ
+    brand: Razer
     model: Phone 2
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 8312D Build/8312D) AppleWebKit/534.30 (KHTML, like Gecko) Version/2.0 Chrome/30.0.0.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: G101
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; cs-cz; G602 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: G602
   os_family: Android
   browser_family: Android Browser
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; Ar-eg; G703 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: G703
   os_family: Android
   browser_family: Android Browser
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; G708G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: G708G
   os_family: Android
   browser_family: Android Browser
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; N83-2cpu Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: N83
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; N91 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baidubrowser/4.2.9.2 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.2.9.2"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S0
+    brand: Sanei
     model: N91
   os_family: Android
   browser_family: Baidu
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; ELEMENT P501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S1
+    brand: Sencor
     model: Element P501
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; STX EVO Build/STXSTX_EVO) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S2
+    brand: Stonex
     model: EVO
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; STX Mini Build/STXSTX_MINI) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S2
+    brand: Stonex
     model: Mini
   os_family: Android
   browser_family: Android Browser
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; STX MINI 2 Build/STXSTX_MINI_2) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S2
+    brand: Stonex
     model: MINI 2
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; STX ULTRA Build/STXSTX_ULTRA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S2
+    brand: Stonex
     model: ULTRA
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; STX ULTRA 2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S2
+    brand: Stonex
     model: ULTRA 2
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; SUNVAN S8888A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S3
+    brand: SunVan
     model: S8888A
   os_family: Android
   browser_family: Unknown
@@ -623,7 +561,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; SUNVAN_S899 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 BaiduBoxApp/3.6_7300050a
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -632,7 +569,7 @@
     version: "3.6"
   device:
     type: smartphone
-    brand: S3
+    brand: SunVan
     model: S899
   os_family: Android
   browser_family: Unknown
@@ -640,7 +577,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; zh-cn; SUNVAN S899B Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.4)
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
@@ -649,7 +585,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: S3
+    brand: SunVan
     model: S899B
   os_family: Android
   browser_family: Unknown
@@ -657,19 +593,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; zh-cn; SUNVAN S899C Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S3
+    brand: SunVan
     model: S899C
   os_family: Android
   browser_family: Unknown
@@ -677,19 +611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; N8800 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N8800
   os_family: Android
   browser_family: Chrome
@@ -697,19 +629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; N9500 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N9500
   os_family: Android
   browser_family: Chrome
@@ -717,19 +647,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; N9600 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N9600
   os_family: Android
   browser_family: Android Browser
@@ -737,19 +665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; N9700 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N9700
   os_family: Android
   browser_family: Chrome
@@ -757,19 +683,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; N9800 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N9800
   os_family: Android
   browser_family: Android Browser
@@ -777,19 +701,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; N9977 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: N9977
   os_family: Android
   browser_family: Android Browser
@@ -797,19 +719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; N9000 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S4
+    brand: Star
     model: Note 3
   os_family: Android
   browser_family: Chrome
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SENSEIT A109 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S6
+    brand: Senseit
     model: A109
   os_family: Android
   browser_family: Chrome
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SENSEIT E500 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S6
+    brand: Senseit
     model: E500
   os_family: Android
   browser_family: Chrome
@@ -857,19 +773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SENSEIT L301 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S6
+    brand: Senseit
     model: L301
   os_family: Android
   browser_family: Chrome
@@ -877,19 +791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SENSEIT R390 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S6
+    brand: Senseit
     model: R390
   os_family: Android
   browser_family: Chrome
@@ -897,19 +809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SENSEIT T300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S6
+    brand: Senseit
     model: T300
   os_family: Android
   browser_family: Chrome
@@ -917,19 +827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; OS103 Build/NGI77B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: JianGuo Pro 2
   os_family: Android
   browser_family: Chrome
@@ -937,7 +845,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM919 Build/MXB48T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -946,7 +853,7 @@
     version: "6.5.4.1000"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: M1L
   os_family: Android
   browser_family: Unknown
@@ -954,19 +861,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-cn; OC106 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Nut 3
   os_family: Android
   browser_family: Unknown
@@ -974,19 +879,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-CN; OC105 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Nut 3
   os_family: Android
   browser_family: Unknown
@@ -994,19 +897,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; OE106 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Nut Pro 2s
   os_family: Android
   browser_family: Unknown
@@ -1014,19 +915,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; DT1901A Build/PKQ1.190727.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/12.8.9.1069 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.9.1069"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Nut Pro 3
   os_family: Android
   browser_family: Unknown
@@ -1034,19 +933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; OD105 Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043409 Safari/537.36 V1_AND_SQ_7.1.0_692_YYB_D QQ/7.1.0.3175 NetType/WIFI WebP/0.3.0 Pixel/1080
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Pro
   os_family: Android
   browser_family: Unknown
@@ -1054,19 +951,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; OS105 Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.8.1078 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.8.1078"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: Pro 2
   os_family: Android
   browser_family: Unknown
@@ -1074,19 +969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DE106 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: R1
   os_family: Android
   browser_family: Chrome
@@ -1094,7 +987,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; SM701 Build/SANFRANCISCO) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025469 Mobile Safari/533.1 MicroMessenger/6.2.5.49_r7ead8bf.620 NetType/WIFI Language/zh_CN QQ/6.6.0.2935
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1103,7 +995,7 @@
     version: "6.2.5.49.r7ead8bf.620"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: T1
   os_family: Android
   browser_family: Unknown
@@ -1111,7 +1003,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM801 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043024 Safari/537.36 MicroMessenger/6.5.4.1000 NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -1120,7 +1011,7 @@
     version: "6.5.4.1000"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: T2
   os_family: Android
   browser_family: Unknown
@@ -1128,19 +1019,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-CN; YQ601 Build/LMY47V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.9.3.727 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.3.727"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: S7
+    brand: Smartisan
     model: U1
   os_family: Android
   browser_family: Unknown
@@ -1148,19 +1037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; STK Avenger 500 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S8
+    brand: STK
     model: Avenger 500
   os_family: Android
   browser_family: Chrome
@@ -1168,19 +1055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; STK_Sync_5e Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S8
+    brand: STK
     model: Sync 5e
   os_family: Android
   browser_family: Chrome
@@ -1188,19 +1073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; STK Sync 5z Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: S8
+    brand: STK
     model: Sync 5z
   os_family: Android
   browser_family: Chrome
@@ -1208,19 +1091,17 @@
   user_agent: MWP/1.0/Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; SAMSUNG; SM-W750V) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Ativ SE
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1228,19 +1109,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; GT-I5800 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY 3
   os_family: Android
   browser_family: Android Browser
@@ -1248,19 +1127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A015A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A01
   os_family: Android
   browser_family: Chrome
@@ -1268,19 +1145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A015M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.0 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A01
   os_family: Android
   browser_family: Chrome
@@ -1288,19 +1163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A105N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10
   os_family: Android
   browser_family: Chrome
@@ -1308,19 +1181,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A105F Build/PPR1.180610.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 YandexSearch/8.60 YandexSearchBrowser/8.60
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10
   os_family: Android
   browser_family: Chrome
@@ -1328,19 +1199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A102U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10e
   os_family: Android
   browser_family: Chrome
@@ -1348,19 +1217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A102N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10e
   os_family: Android
   browser_family: Chrome
@@ -1368,19 +1235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A102W Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10e
   os_family: Android
   browser_family: Chrome
@@ -1388,19 +1253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-S102DL Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10e
   os_family: Android
   browser_family: Chrome
@@ -1408,19 +1271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A107M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10s
   os_family: Android
   browser_family: Chrome
@@ -1428,19 +1289,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 9; SM-A107F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 YaBrowser/19.9.1.126.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.9.1.126.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A10s
   os_family: Android
   browser_family: Unknown
@@ -1448,19 +1307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A115F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A11
   os_family: Android
   browser_family: Chrome
@@ -1468,19 +1325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-A260G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A2 Core
   os_family: Android
   browser_family: Chrome
@@ -1488,19 +1343,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; SC-02M Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Android Browser
@@ -1508,19 +1361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A205U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1528,19 +1379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SCV46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1548,19 +1397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A205U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1568,19 +1415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A205W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1588,19 +1433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A205YN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1608,19 +1451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A205S) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20
   os_family: Android
   browser_family: Chrome
@@ -1628,19 +1469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A202F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20e
   os_family: Android
   browser_family: Chrome
@@ -1648,19 +1487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A2070) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20s
   os_family: Android
   browser_family: Chrome
@@ -1668,19 +1505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A207M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A20s
   os_family: Android
   browser_family: Chrome
@@ -1688,19 +1523,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; SM-A215U Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A21
   os_family: Android
   browser_family: Android Browser
@@ -1708,19 +1541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A217F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A21s
   os_family: Android
   browser_family: Chrome
@@ -1728,19 +1559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A3009 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1748,19 +1577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A300YZ Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1768,19 +1595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A3000 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1788,19 +1613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A300XU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1808,19 +1631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-A300H Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1828,19 +1649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-A300Y Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -1848,19 +1667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A310X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1868,19 +1685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-A310M Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1888,19 +1703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A310F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.101 Mobile Safari/537.36 (Ecosia android@62.0.3202.101)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Ecosia
-    short_name: EC
     version: "62.0.3202.101"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1908,19 +1721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A310N0 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1928,19 +1739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A310Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1948,19 +1757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A320Y Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.2 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -1968,19 +1775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A320X Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -1988,19 +1793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A320FL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2008,19 +1811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV43) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A30
   os_family: Android
   browser_family: Chrome
@@ -2028,19 +1829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A305N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A30
   os_family: Android
   browser_family: Chrome
@@ -2048,19 +1847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A307G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A30s
   os_family: Android
   browser_family: Chrome
@@ -2068,19 +1865,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; SM-A315G Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A31
   os_family: Android
   browser_family: Android Browser
@@ -2088,19 +1883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A315F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A31
   os_family: Android
   browser_family: Chrome
@@ -2108,19 +1901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A315N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A31
   os_family: Android
   browser_family: Chrome
@@ -2128,19 +1919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A405FM Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36 YandexSearch/9.00 YandexSearchWebView/9.00
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A40
   os_family: Android
   browser_family: Chrome
@@ -2148,19 +1937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A405S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A40
   os_family: Android
   browser_family: Chrome
@@ -2168,19 +1955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A3051) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A40s
   os_family: Android
   browser_family: Chrome
@@ -2188,19 +1973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A3050) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A40s
   os_family: Android
   browser_family: Chrome
@@ -2208,19 +1991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A415F Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A41
   os_family: Android
   browser_family: Chrome
@@ -2228,19 +2009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A500Y Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.534 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.534"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2248,19 +2027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A500L Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2268,19 +2045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A5009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2288,19 +2063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SM-A500 Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2308,19 +2081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-A500W Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2328,19 +2099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A500S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -2348,19 +2117,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; ru-RU; SM-A500X Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.7.5.658 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.5.658"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2015)
   os_family: Android
   browser_family: Unknown
@@ -2368,19 +2135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A510M Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2388,19 +2153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A5100 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2408,19 +2171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A510X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2428,19 +2189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-A510S Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2448,19 +2207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A510Y Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2468,19 +2225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A510L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2488,19 +2243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A510K/KKU1CQK1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -2508,19 +2261,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; SM-A5108 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.9.1215 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.9.1215"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -2528,19 +2279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A520X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2548,19 +2297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A520K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2568,19 +2315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A520L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2588,19 +2333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A520F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2608,19 +2351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A520S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2628,19 +2369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A520W Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -2648,19 +2387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ko-kr; SAMSUNG SM-A500K/KTU1AOA1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "34.0.1847.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 Duos
   os_family: Android
   browser_family: Chrome
@@ -2668,19 +2405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A500G Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 Duos
   os_family: Android
   browser_family: Chrome
@@ -2688,19 +2423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-505FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2708,19 +2441,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A505U AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2728,19 +2459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A505X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2748,19 +2477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A505N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2768,19 +2495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A505U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2788,19 +2513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A505U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2808,19 +2531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A505W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2828,19 +2549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A505YN) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2848,19 +2567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-S506DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -2868,19 +2585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A5070) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50s
   os_family: Android
   browser_family: Chrome
@@ -2888,19 +2603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A507FN Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50s
   os_family: Android
   browser_family: Chrome
@@ -2908,19 +2621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-A515F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A51
   os_family: Android
   browser_family: Chrome
@@ -2928,19 +2639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600P Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -2948,19 +2657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600A Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -2968,19 +2675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -2988,19 +2693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3008,19 +2711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3028,19 +2729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3048,19 +2747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3068,19 +2765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3088,19 +2783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600AZ Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3108,19 +2801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A600GN Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3128,19 +2819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A600F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3148,19 +2837,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A600U AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -3168,19 +2855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605GN Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3188,19 +2873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605X) Build/R16NW AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3208,19 +2891,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A6050 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3228,19 +2909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A6058 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3248,19 +2927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605G Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3268,19 +2945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3288,19 +2963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605FN/A605FNXXU1ARD7 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -3308,19 +2981,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A6060 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A60
   os_family: Android
   browser_family: Chrome
@@ -3328,19 +2999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A606Y Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A60
   os_family: Android
   browser_family: Chrome
@@ -3348,19 +3017,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; SM-G6200 Build/OPM1.181019.026_global) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6s (2018)
   os_family: Android
   browser_family: Unknown
@@ -3368,19 +3035,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.4; SM-A7009 Build/KTU84P
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Android Browser
@@ -3388,19 +3053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A700YD Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Chrome
@@ -3408,19 +3071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A700X Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Chrome
@@ -3428,19 +3089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-A7000 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Chrome
@@ -3448,19 +3107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A700H Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Chrome
@@ -3468,19 +3125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A7108 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3488,19 +3143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A710X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3508,19 +3161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A710L Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3528,19 +3179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A710F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3548,19 +3197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A710S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3568,19 +3215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A710K/KKU1CQL1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -3588,19 +3233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A720X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -3608,19 +3251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A720F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -3628,19 +3269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A720S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -3648,19 +3287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A750G Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3668,19 +3305,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; SM-A750X AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3688,19 +3323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A750GN Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3708,19 +3341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A750F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3728,19 +3359,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-A750N AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3748,19 +3377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A750C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -3768,19 +3395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A705FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70
   os_family: Android
   browser_family: Chrome
@@ -3788,19 +3413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-A705X Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70
   os_family: Android
   browser_family: Chrome
@@ -3808,19 +3431,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-A705F Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.0.1187 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.0.1187"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70
   os_family: Android
   browser_family: Unknown
@@ -3828,19 +3449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A705MN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70
   os_family: Android
   browser_family: Chrome
@@ -3848,19 +3467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A7070) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70s
   os_family: Android
   browser_family: Chrome
@@ -3868,19 +3485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A707F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A70s
   os_family: Android
   browser_family: Chrome
@@ -3888,19 +3503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A715W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A71
   os_family: Android
   browser_family: Chrome
@@ -3908,19 +3521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A715F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A71
   os_family: Android
   browser_family: Chrome
@@ -3928,19 +3539,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-A71 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A71
   os_family: Android
   browser_family: Android Browser
@@ -3948,19 +3557,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; SM-A716U Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A71 5G
   os_family: Android
   browser_family: Android Browser
@@ -3968,19 +3575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A800I Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Chrome
@@ -3988,19 +3593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A8000 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Chrome
@@ -4008,19 +3611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-A800S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Chrome
@@ -4028,19 +3629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A800F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Chrome
@@ -4048,19 +3647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SCV32 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Chrome
@@ -4068,7 +3665,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.1.1; SM-A530F Build/NMF26X; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/173.0.0.62.99;]'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
@@ -4077,7 +3673,7 @@
     version: "173.0.0.62.99"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8
   os_family: Android
   browser_family: Unknown
@@ -4085,19 +3681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A810F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2016)
   os_family: Android
   browser_family: Chrome
@@ -4105,19 +3699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A810S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2016)
   os_family: Android
   browser_family: Chrome
@@ -4125,19 +3717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-A810YZ Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2016)
   os_family: Android
   browser_family: Chrome
@@ -4145,19 +3735,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; SM-A530X AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4165,19 +3753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-A530W Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4185,19 +3771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A530N Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4205,19 +3789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.2.2; SM-A530M Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.103 Mobile Safari/537.36 YandexSearch/8.30 YandexSearchBrowser/8.30
   os:
     name: Android
-    short_name: AND
     version: "8.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.103"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4225,19 +3807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G885F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 Star
   os_family: Android
   browser_family: Chrome
@@ -4245,19 +3825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G885Y Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 Star
   os_family: Android
   browser_family: Chrome
@@ -4265,19 +3843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G885S Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 Star
   os_family: Android
   browser_family: Chrome
@@ -4285,19 +3861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-A730F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8+ (2018)
   os_family: Android
   browser_family: Chrome
@@ -4305,19 +3879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A8050) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A80
   os_family: Android
   browser_family: Chrome
@@ -4325,19 +3897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A805N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A80
   os_family: Android
   browser_family: Chrome
@@ -4345,19 +3915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A805X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A80
   os_family: Android
   browser_family: Chrome
@@ -4365,19 +3933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A805F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A80
   os_family: Android
   browser_family: Chrome
@@ -4385,19 +3951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G8870) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8s
   os_family: Android
   browser_family: Chrome
@@ -4405,19 +3969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G887F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8s
   os_family: Android
   browser_family: Chrome
@@ -4425,19 +3987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-A9000 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9
   os_family: Android
   browser_family: Chrome
@@ -4445,19 +4005,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.0.0; SM-A920X Build/R16NW)
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 (2018)
   os_family: Android
   browser_family: Android Browser
@@ -4465,19 +4023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A920F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4485,19 +4041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A9200) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4505,19 +4059,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-A920N Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.6.1200 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.6.1200"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 (2018)
   os_family: Android
   browser_family: Unknown
@@ -4525,19 +4077,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; SM-A9[7] Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 7
   os_family: Android
   browser_family: Chrome
@@ -4545,19 +4095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-A9100 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Pro
   os_family: Android
   browser_family: Chrome
@@ -4565,19 +4113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-A910F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Pro
   os_family: Android
   browser_family: Chrome
@@ -4585,19 +4131,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; ru-ru; SM-G887N Build/M1AJQ AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/Mint Browser/2.2.2
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Mint Browser
-    short_name: MT
     version: "2.2.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Pro
   os_family: Android
   browser_family: Chrome
@@ -4605,19 +4149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G8858) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Star
   os_family: Android
   browser_family: Chrome
@@ -4625,19 +4167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G8850) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Star
   os_family: Android
   browser_family: Chrome
@@ -4645,19 +4185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A908N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A90
   os_family: Android
   browser_family: Chrome
@@ -4665,19 +4203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A908B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A90
   os_family: Android
   browser_family: Chrome
@@ -4685,19 +4221,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; GT-S5830L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4705,19 +4239,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ro-ro; GT-S5830i Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4725,19 +4257,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; sr-rs; GT-S5830i Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4745,19 +4275,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; vi-vn; GT-S5830 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4765,19 +4293,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; GT-S5830 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4785,19 +4311,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; GT-S5830i Build/830iv1.4cn20120908) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4805,19 +4329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; GT-S5830i Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4825,19 +4347,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; in-id; GT-S5830 Build/GRWK74; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4845,19 +4365,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; ru-ru; GT-S5830 Build/GRWK74; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4865,19 +4383,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; sl-si; GT-S5830 Build/GRWK74; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace
   os_family: Android
   browser_family: Android Browser
@@ -4885,19 +4401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; GT-I8160P-ORANGE/I8160PBVLK3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 2
   os_family: Android
   browser_family: Android Browser
@@ -4905,19 +4419,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ro-ro; GT-I8160 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 2
   os_family: Android
   browser_family: Android Browser
@@ -4925,19 +4437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GT-I8160P Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 2
   os_family: Android
   browser_family: Chrome
@@ -4945,19 +4455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; fr-ch; SAMSUNG GT-S7275R/S7275RXXUAMK2 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY ACE 3
   os_family: Android
   browser_family: Chrome
@@ -4965,19 +4473,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; SM-G313HY Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Android Browser
@@ -4985,19 +4491,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; SM-G313MU Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Android Browser
@@ -5005,19 +4509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313ML Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.517 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.517"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Chrome
@@ -5025,19 +4527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313MY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.517 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.517"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Chrome
@@ -5045,19 +4545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Chrome
@@ -5065,19 +4563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4
   os_family: Android
   browser_family: Chrome
@@ -5085,19 +4581,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.4; SM-G316M Build/KTU84P
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Duos
   os_family: Android
   browser_family: Android Browser
@@ -5105,19 +4599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313U Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Lite
   os_family: Android
   browser_family: Chrome
@@ -5125,19 +4617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313HZ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Lite
   os_family: Android
   browser_family: Chrome
@@ -5145,19 +4635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G313HN Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Lite
   os_family: Android
   browser_family: Chrome
@@ -5165,19 +4653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; SM-G313H Build/KOT49H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 OPR/36.2.2254.130496
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "36.2.2254.130496"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Lite
   os_family: Android
   browser_family: Opera
@@ -5185,19 +4671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G318ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Neo
   os_family: Android
   browser_family: Chrome
@@ -5205,19 +4689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG SM-G318H Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Neo
   os_family: Android
   browser_family: Chrome
@@ -5225,19 +4707,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6_mobile-star; iw-il; GT-S7500 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY ACE Plus
   os_family: Android
   browser_family: Android Browser
@@ -5245,19 +4725,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; SM-G310HN Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace Style
   os_family: Android
   browser_family: Android Browser
@@ -5265,19 +4743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G357M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace Style
   os_family: Android
   browser_family: Chrome
@@ -5285,19 +4761,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; SM-G357FZ Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace Style
   os_family: Android
   browser_family: Android Browser
@@ -5305,19 +4779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SC-01H) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Active Neo
   os_family: Android
   browser_family: Chrome
@@ -5325,19 +4797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG-SM-G850A Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5345,19 +4815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G850M Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5365,19 +4833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G850Y Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5385,19 +4851,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.0.2; SM-G850K Build/LRX22G
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Android Browser
@@ -5405,19 +4869,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.0.2; SM-G850L Build/LRX22G
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Android Browser
@@ -5425,19 +4887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-G850S Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5445,19 +4905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-G850W Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5465,19 +4923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G850X Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Alpha
   os_family: Android
   browser_family: Chrome
@@ -5485,19 +4941,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-J327AZ Build/NRD91D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.88 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.88"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Amp Prime 2
   os_family: Android
   browser_family: Chrome
@@ -5505,19 +4959,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; SM-J337AZ AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Amp Prime 3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -5525,19 +4977,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; GT-I5801 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Apollo
   os_family: Android
   browser_family: Android Browser
@@ -5545,19 +4995,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ko-kr; SAMSUNG SM-G386T Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Avant
   os_family: Android
   browser_family: Chrome
@@ -5565,19 +5013,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; SM-G386T1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.5.0.1015 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.5.0.1015"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Avant
   os_family: Android
   browser_family: Unknown
@@ -5585,19 +5031,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-US; GT-I8520 Build/ECLAIR) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.1.0.297 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.0.297"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Beam
   os_family: Android
   browser_family: Unknown
@@ -5605,19 +5049,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-I8530 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Beam
   os_family: Android
   browser_family: Android Browser
@@ -5625,19 +5067,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-G3858) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Beam 2
   os_family: Android
   browser_family: Unknown
@@ -5645,19 +5085,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C5000 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C5
   os_family: Android
   browser_family: Chrome
@@ -5665,19 +5103,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C5018 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C5 Pro
   os_family: Android
   browser_family: Chrome
@@ -5685,19 +5121,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C5010 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C5 Pro
   os_family: Android
   browser_family: Chrome
@@ -5705,19 +5139,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C7000 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C7
   os_family: Android
   browser_family: Chrome
@@ -5725,19 +5157,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-C7018 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C7 Pro
   os_family: Android
   browser_family: Chrome
@@ -5745,19 +5175,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C701F Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.2 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C7 Pro
   os_family: Android
   browser_family: Chrome
@@ -5765,19 +5193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-C7010 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C7 Pro
   os_family: Android
   browser_family: Chrome
@@ -5785,19 +5211,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-C7100 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C8
   os_family: Android
   browser_family: Chrome
@@ -5805,19 +5229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-C7108 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C8
   os_family: Android
   browser_family: Chrome
@@ -5825,19 +5247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-C9008 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C9 Pro
   os_family: Android
   browser_family: Chrome
@@ -5845,19 +5265,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; SM-C900F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.0.1088 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.0.1088"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY C9 Pro
   os_family: Android
   browser_family: Unknown
@@ -5865,19 +5283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SCH-S738C Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Centura
   os_family: Android
   browser_family: Chrome
@@ -5885,19 +5301,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; es-es; GT-B5330 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Chat
   os_family: Android
   browser_family: Android Browser
@@ -5905,19 +5319,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; es-us; GT-B5330L Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Chat
   os_family: Android
   browser_family: Android Browser
@@ -5925,19 +5337,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2; pt-br; GT-I8262B Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30  '
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core
   os_family: Android
   browser_family: Android Browser
@@ -5945,19 +5355,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GT-I8262D Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core
   os_family: Android
   browser_family: Android Browser
@@ -5965,19 +5373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-I8260 Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core
   os_family: Android
   browser_family: Chrome
@@ -5985,19 +5391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-I8260L Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core
   os_family: Android
   browser_family: Chrome
@@ -6005,19 +5409,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-I8262 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core
   os_family: Android
   browser_family: Android Browser
@@ -6025,19 +5427,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; SM-G3556D Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core 2
   os_family: Android
   browser_family: Android Browser
@@ -6045,19 +5445,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; SM-G355M Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core 2
   os_family: Android
   browser_family: Android Browser
@@ -6065,19 +5463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G355H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 UCBrowser/11.4.1.1138 (UCMini) Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser Mini
-    short_name: UM
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core 2
   os_family: Android
   browser_family: Unknown
@@ -6085,19 +5481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; pl-pl; SAMSUNG GT-I8580 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Advance
   os_family: Android
   browser_family: Chrome
@@ -6105,19 +5499,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; SM-G386F Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core LTE
   os_family: Android
   browser_family: Android Browser
@@ -6125,19 +5517,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.3; SM-G3586V Build/JLS36C
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core LTE
   os_family: Android
   browser_family: Android Browser
@@ -6145,19 +5535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G386W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core LTE
   os_family: Android
   browser_family: Chrome
@@ -6165,19 +5553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G5108Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Max
   os_family: Android
   browser_family: Chrome
@@ -6185,19 +5571,17 @@
   user_agent: MQQBrowser/5.2/Mozilla/5.0 (Linux; Android 4.4.2; SM-G3568V Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Mini 4G
   os_family: Android
   browser_family: Unknown
@@ -6205,19 +5589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-G350 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Plus
   os_family: Android
   browser_family: Chrome
@@ -6225,19 +5607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-S820L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Prime
   os_family: Android
   browser_family: Chrome
@@ -6245,19 +5625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G361H Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Prime Value Edition
   os_family: Android
   browser_family: Chrome
@@ -6265,19 +5643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SGH-S730M Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Discover
   os_family: Android
   browser_family: Chrome
@@ -6285,19 +5661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SCH-R740C Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Discover
   os_family: Android
   browser_family: Chrome
@@ -6305,19 +5679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-E500YZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -6325,19 +5697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SM-E5000 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -6345,19 +5715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-S978L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -6365,19 +5733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-E500H Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -6385,19 +5751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-E700H Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E7
   os_family: Android
   browser_family: Chrome
@@ -6405,19 +5769,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; GT-I8730 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Express
   os_family: Android
   browser_family: Android Browser
@@ -6425,19 +5787,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; SAMSUNG SM-G3815/G3815XXUBMK5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY EXPRESS II
   os_family: Android
   browser_family: Android Browser
@@ -6445,19 +5805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S6810 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY FAME
   os_family: Android
   browser_family: Chrome
@@ -6465,19 +5823,17 @@
   user_agent: MQQBrowser/5.0/Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GT-S6812C Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY FAME Duos
   os_family: Android
   browser_family: Unknown
@@ -6485,19 +5841,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-S6812 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY FAME Duos
   os_family: Android
   browser_family: Unknown
@@ -6505,19 +5859,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; GT-S6812) U2/1.0.0 UCBrowser/9.0.0.366 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY FAME Duos
   os_family: GNU/Linux
   browser_family: Opera
@@ -6525,19 +5877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S6790 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY FAME Lite with NFC
   os_family: Android
   browser_family: Chrome
@@ -6545,19 +5895,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SC-04J) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Feel
   os_family: Android
   browser_family: Chrome
@@ -6565,19 +5913,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-G155S Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Folder
   os_family: Android
   browser_family: Android Browser
@@ -6585,19 +5931,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 6.0.1; SM-G160N Build/MMB29M
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Folder 2
   os_family: Android
   browser_family: Android Browser
@@ -6605,19 +5949,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; SM-G1600 Build/MMB29M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/42.0.2254.139276
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "42.0.2254.139276"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Folder 2
   os_family: Android
   browser_family: Opera
@@ -6625,19 +5967,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-cn; SM-G1650 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.8 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.8"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Folder 2
   os_family: Android
   browser_family: Unknown
@@ -6645,19 +5985,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.4; SM-G7200 Build/KTU84P
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Max
   os_family: Android
   browser_family: Android Browser
@@ -6665,19 +6003,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G720N0 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Max
   os_family: Android
   browser_family: Chrome
@@ -6685,19 +6021,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G720AX Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Max
   os_family: Android
   browser_family: Chrome
@@ -6705,19 +6039,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G7202 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Max
   os_family: Android
   browser_family: Chrome
@@ -6725,19 +6057,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.0; SAMSUNG-SM-J727AZ Build/NRD90M
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Halo
   os_family: Android
   browser_family: Android Browser
@@ -6745,19 +6075,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-J100H Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1
   os_family: Android
   browser_family: Chrome
@@ -6765,19 +6093,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG SM-J100Y Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1
   os_family: Android
   browser_family: Chrome
@@ -6785,19 +6111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J100VPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1
   os_family: Android
   browser_family: Chrome
@@ -6805,19 +6129,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J120G Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Android Browser
@@ -6825,19 +6147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J120H Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -6845,19 +6165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J120ZN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -6865,19 +6183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J120W Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -6885,19 +6201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J05H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -6905,19 +6219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG SM-J110G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Ace
   os_family: Android
   browser_family: Chrome
@@ -6925,19 +6237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SAMSUNG SM-J110H Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Ace
   os_family: Android
   browser_family: Chrome
@@ -6945,19 +6255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J111F Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Ace
   os_family: Android
   browser_family: Chrome
@@ -6965,19 +6273,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J105F Build/LMY47V
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Mini
   os_family: Android
   browser_family: Android Browser
@@ -6985,19 +6291,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J105Y Build/LMY47V
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Mini
   os_family: Android
   browser_family: Android Browser
@@ -7005,19 +6309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J105B Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Mini
   os_family: Android
   browser_family: Chrome
@@ -7025,19 +6327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J105M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Mini
   os_family: Android
   browser_family: Chrome
@@ -7045,19 +6345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J106F Build/MMB29Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.103 Mobile Safari/537.36 YandexSearch/8.45 YandexSearchBrowser/8.45
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.103"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 mini Prime
   os_family: Android
   browser_family: Chrome
@@ -7065,19 +6363,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; SM-J106H Build/MMB29Q; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/20.1.2254.110627
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "20.1.2254.110627"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 mini Prime
   os_family: Android
   browser_family: Opera
@@ -7085,19 +6381,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; SM-J106B Build/MMB29Q; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 mini Prime
   os_family: Android
   browser_family: Opera
@@ -7105,19 +6399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J200G Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2
   os_family: Android
   browser_family: Chrome
@@ -7125,19 +6417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J200F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2
   os_family: Android
   browser_family: Chrome
@@ -7145,19 +6435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J200M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2
   os_family: Android
   browser_family: Chrome
@@ -7165,19 +6453,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; SM-J260F Build/M1AJB)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Android Browser
@@ -7185,19 +6471,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; SM-J260G Build/M1AJB
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Android Browser
@@ -7205,19 +6489,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; SM-J260M Build/M1AJB
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Android Browser
@@ -7225,19 +6507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J260A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Chrome
@@ -7245,19 +6525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J260Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Chrome
@@ -7265,19 +6543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J260T1) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Chrome
@@ -7285,19 +6561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-S260DL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Core
   os_family: Android
   browser_family: Chrome
@@ -7305,19 +6579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J200BT Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Duos
   os_family: Android
   browser_family: Chrome
@@ -7325,19 +6597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J210F Build/MMB29Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7345,19 +6615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-J250F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7365,19 +6633,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; SM-J250G AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7385,19 +6651,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; SM-J250Y AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7405,19 +6669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-J250N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pro
   os_family: Android
   browser_family: Chrome
@@ -7425,19 +6687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J260AZ Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J2 Pure
   os_family: Android
   browser_family: Chrome
@@ -7445,19 +6705,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.0; SM-J3109 Build/LRX21M
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2015)
   os_family: Android
   browser_family: Android Browser
@@ -7465,19 +6723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J320FN Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7485,19 +6741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J320H Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7505,19 +6759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J320Y Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7525,19 +6777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J320YZ Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7545,19 +6795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J320ZN Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7565,19 +6813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-J320F Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7585,19 +6831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J320W8 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7605,19 +6849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J320N0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7625,19 +6867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J320R4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2016)
   os_family: Android
   browser_family: Chrome
@@ -7645,19 +6885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-J330G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7665,19 +6903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327R7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7685,19 +6921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7705,19 +6939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-J3308) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7725,19 +6957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-J3300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.44 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.44"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7745,19 +6975,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ru; SM-J330L Build/R16NW AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.4.6.900
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.4.6.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Unknown
@@ -7765,19 +6993,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; SM-J330FN Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Android Browser
@@ -7785,19 +7011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J330N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -7805,19 +7029,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; SM-J337P AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7825,19 +7047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J337U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7845,19 +7065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J337V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7865,19 +7083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J337VPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7885,19 +7101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-J337W Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7905,19 +7119,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SAMSUNG SM-J337A Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -7925,19 +7137,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; SM-J337R4 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Aura
   os_family: Android
   browser_family: Chrome
@@ -7945,19 +7155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J327V Build/M1AJQ; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Eclipse
   os_family: Android
   browser_family: Chrome
@@ -7965,19 +7173,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; SM-J327P Build/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Emerge
   os_family: Android
   browser_family: Android Browser
@@ -7985,19 +7191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327R4 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Emerge
   os_family: Android
   browser_family: Chrome
@@ -8005,19 +7209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Emerge
   os_family: Android
   browser_family: Chrome
@@ -8025,19 +7227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-S327VL Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Luna Pro
   os_family: Android
   browser_family: Chrome
@@ -8045,19 +7245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-S337TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Luna Pro
   os_family: Android
   browser_family: Chrome
@@ -8065,19 +7263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-S357BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Orbit
   os_family: Android
   browser_family: Chrome
@@ -8085,19 +7281,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; SM-S367VL Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Orbit
   os_family: Android
   browser_family: Android Browser
@@ -8105,19 +7299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-J327T1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Prime
   os_family: Android
   browser_family: Chrome
@@ -8125,19 +7317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327W Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.2 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Prime
   os_family: Android
   browser_family: Chrome
@@ -8145,19 +7335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327A) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Prime
   os_family: Android
   browser_family: Chrome
@@ -8165,19 +7353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J327T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Prime
   os_family: Android
   browser_family: Chrome
@@ -8185,19 +7371,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J3110 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Pro
   os_family: Android
   browser_family: Android Browser
@@ -8205,19 +7389,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J3119S Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Pro
   os_family: Android
   browser_family: Android Browser
@@ -8225,19 +7407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG-SM-J3119 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.3 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Pro
   os_family: Android
   browser_family: Chrome
@@ -8245,19 +7425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S320VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Sky
   os_family: Android
   browser_family: Chrome
@@ -8265,19 +7443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J337T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Star
   os_family: Android
   browser_family: Chrome
@@ -8285,19 +7461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J400F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4
   os_family: Android
   browser_family: Chrome
@@ -8305,19 +7479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J410F Build/M1AJB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4 Core
   os_family: Android
   browser_family: Chrome
@@ -8325,19 +7497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J410G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4 Core
   os_family: Android
   browser_family: Chrome
@@ -8345,19 +7515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J415F Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4+
   os_family: Android
   browser_family: Chrome
@@ -8365,19 +7533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-J415FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4+
   os_family: Android
   browser_family: Chrome
@@ -8385,19 +7551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J415G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4+
   os_family: Android
   browser_family: Chrome
@@ -8405,19 +7569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J415GN) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4+
   os_family: Android
   browser_family: Chrome
@@ -8425,19 +7587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J415N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J4+
   os_family: Android
   browser_family: Chrome
@@ -8445,19 +7605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SM-J5008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Chrome
@@ -8465,19 +7623,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J500N0 Build/LMY48B
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Android Browser
@@ -8485,19 +7641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J5007 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.70 YaSearchBrowser/10.70
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Chrome
@@ -8505,19 +7659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J500H Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Chrome
@@ -8525,19 +7677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-J500F Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Chrome
@@ -8545,19 +7695,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.4.4; ru-ru; SM-G510H Build/KTU84P AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Android Browser
@@ -8565,19 +7713,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1; SM-5108 Build/LMY47I
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Android Browser
@@ -8585,19 +7731,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-J5108 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Android Browser
@@ -8605,19 +7749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SM-J510G Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -8625,19 +7767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J510MN Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.97 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.97"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -8645,19 +7785,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; SM-J510UN Build/MMB29M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Opera
@@ -8665,19 +7803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-J510Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -8685,19 +7821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-J510FN Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -8705,19 +7839,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.1.1; en-US; SM-J510H Build/NMF26X AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/11.0.5.850 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.5.850"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -8725,19 +7857,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.1.1; en-US; SM-J510K Build/NMF26X AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.8.976"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -8745,19 +7875,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.1.1; en-US; SM-J510L Build/NMF26X AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1196 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1196"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -8765,19 +7893,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.1.1; en-US; SM-J510GN Build/NMF26X AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -8785,19 +7911,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.1.1; ru-RU; SM-J510S Build/NMF26X AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.4.6.900
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.4.6.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Unknown
@@ -8805,19 +7929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J530F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -8825,19 +7947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J530G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -8845,19 +7965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G570M Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 Prime
   os_family: Android
   browser_family: Chrome
@@ -8865,19 +7983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G570Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 Prime
   os_family: Android
   browser_family: Chrome
@@ -8885,19 +8001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G570F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 Prime
   os_family: Android
   browser_family: Chrome
@@ -8905,19 +8019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G5700) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 Prime
   os_family: Android
   browser_family: Chrome
@@ -8925,19 +8037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J600G Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6
   os_family: Android
   browser_family: Chrome
@@ -8945,19 +8055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J600GF Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6
   os_family: Android
   browser_family: Chrome
@@ -8965,19 +8073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J600F Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6
   os_family: Android
   browser_family: Chrome
@@ -8985,19 +8091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-J600N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6
   os_family: Android
   browser_family: Chrome
@@ -9005,19 +8109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-J600L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6
   os_family: Android
   browser_family: Chrome
@@ -9025,19 +8127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J610F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J6+
   os_family: Android
   browser_family: Chrome
@@ -9045,19 +8145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SAMSUNG SM-J7008 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7
   os_family: Android
   browser_family: Chrome
@@ -9065,19 +8163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J700K Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7
   os_family: Android
   browser_family: Chrome
@@ -9085,19 +8181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J700F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7
   os_family: Android
   browser_family: Chrome
@@ -9105,19 +8199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J710MN Build/MMB29K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7
   os_family: Android
   browser_family: Chrome
@@ -9125,19 +8217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-J710F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7
   os_family: Android
   browser_family: Chrome
@@ -9145,19 +8235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J700P Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2015)
   os_family: Android
   browser_family: Chrome
@@ -9165,19 +8253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J700T Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -9185,19 +8271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J7109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.2.2672.49907
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.2.2672.49907"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2016)
   os_family: Android
   browser_family: Opera
@@ -9205,19 +8289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-J700T1 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -9225,19 +8307,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; SM-J710GN Build/M1AJQ AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.5.1185 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.5.1185"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2016)
   os_family: Android
   browser_family: Unknown
@@ -9245,19 +8325,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; SM-J727F Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Opera
@@ -9265,19 +8343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-J727A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.0.2517.139457
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.0.2517.139457"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Opera
@@ -9285,19 +8361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J727U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9305,19 +8379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J727S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9325,19 +8397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-J727R4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9345,19 +8415,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; SM-J730K Build/M1AJQ AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.2.1184 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.2.1184"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Unknown
@@ -9365,19 +8433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737S Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9385,19 +8451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9405,19 +8469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9425,19 +8487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9445,19 +8505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9465,19 +8523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737VPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9485,19 +8541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J737T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9505,19 +8559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-J737U Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9525,19 +8577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-J737R4) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9545,19 +8595,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.1; SM-J7[7] Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 7
   os_family: Android
   browser_family: Chrome
@@ -9565,19 +8613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J701F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Core
   os_family: Android
   browser_family: Chrome
@@ -9585,19 +8631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-S757BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Crown
   os_family: Android
   browser_family: Chrome
@@ -9605,19 +8649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-S767VL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Crown
   os_family: Android
   browser_family: Chrome
@@ -9625,19 +8667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J720M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Duo
   os_family: Android
   browser_family: Chrome
@@ -9645,19 +8685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J720F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Duo
   os_family: Android
   browser_family: Chrome
@@ -9665,19 +8703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G615F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Max
   os_family: Android
   browser_family: Chrome
@@ -9685,19 +8721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G610F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Prime
   os_family: Android
   browser_family: Chrome
@@ -9705,19 +8739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G610M Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Prime
   os_family: Android
   browser_family: Chrome
@@ -9725,19 +8757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-G611MT Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Prime 2
   os_family: Android
   browser_family: Chrome
@@ -9745,19 +8775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G611FF) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Prime 2
   os_family: Android
   browser_family: Chrome
@@ -9765,19 +8793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G611M Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Prime 2
   os_family: Android
   browser_family: Chrome
@@ -9785,19 +8811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-J730GM Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Pro
   os_family: Android
   browser_family: Chrome
@@ -9805,19 +8829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-J730G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Pro
   os_family: Android
   browser_family: Chrome
@@ -9825,19 +8847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S727VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Sky Pro
   os_family: Android
   browser_family: Chrome
@@ -9845,19 +8865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-S737TL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Sky Pro
   os_family: Android
   browser_family: Chrome
@@ -9865,19 +8883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-J727T1 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 V
   os_family: Android
   browser_family: Chrome
@@ -9885,19 +8901,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; SM-C710F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.5.0.1109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.5.0.1109"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7+ (C7)
   os_family: Android
   browser_family: Unknown
@@ -9905,19 +8919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-J810M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J8
   os_family: Android
   browser_family: Chrome
@@ -9925,19 +8937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SM-J8 Pro Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J8 Pro
   os_family: Android
   browser_family: Chrome
@@ -9945,19 +8955,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; SM-J9[7] Prime Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J9 7 Prime
   os_family: Android
   browser_family: Chrome
@@ -9965,19 +8973,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.1.1; SM-J9[8] Pro Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J9 8 Pro
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-13.yml
+++ b/Tests/fixtures/smartphone-13.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605K/KKU1ARJ1 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.4 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Jean
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-A202K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Jean 2
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; SM-C115 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.514 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.514"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY K zoom
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-C111M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY K zoom
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SAMSUNG SM-C111 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY K zoom
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-S120VL Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Luna
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-M015G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M01
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-M015F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M01
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-M105F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M10
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; SM-M105G Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M10
   os_family: Android
   browser_family: Android Browser
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-M105M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M10
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-M107F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M10s
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-M115F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M11
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-M205N Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M20
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-M205M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M20
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-M205F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M20
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-M205G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M20
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SAMSUNG SM-M215F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M21
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-M305F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M30
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-M307F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M30s
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-M307FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M30s
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-M3070) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M30s
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; SM-M315F Build/QP1A.190711.020)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M31
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-M405F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M40
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-G5500 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Android Browser
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T1 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T2 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G550FY Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G5510 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G5520 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S550TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G550T Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Opera
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G5528) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G6000 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G600FY Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G600F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G6100 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G610K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G610L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G610S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 (2016)
   os_family: Android
   browser_family: Chrome
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-G611F Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 Prime
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SAMSUNG SM-G611S Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 Prime
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-G611K Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.8.1172 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.8.1172"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 Prime
   os_family: Android
   browser_family: Unknown
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-G611L Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On7 Prime
   os_family: Android
   browser_family: Unknown
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G110H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET 2
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G110M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET 2
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G110B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET 2
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-S5310 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; Maxthon (4.0.4.1000);
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET Neo
   os_family: Android
   browser_family: Unknown
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; GT-S5301 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET Plus
   os_family: Android
   browser_family: Android Browser
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; GT-S5301L Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET Plus
   os_family: Android
   browser_family: Android Browser
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-br; GT-S5301B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY POCKET Plus
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; GT-I9103 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY R
   os_family: Android
   browser_family: Android Browser
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G910S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Round
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; GT-I9088 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Android Browser
@@ -1083,19 +975,17 @@
   user_agent: SAMSUNG-GT-I9008L_TD/1.0 Android/2.2.1 Release/12.15.2010 Browser/AppleWebKit533.1 Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Android Browser
@@ -1103,19 +993,17 @@
   user_agent: MQQBrowser/3.0/Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; GT-I9018 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "3.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Unknown
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ca; GT-I9000M Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Android Browser
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; GT-I9000 Build/admin.AiLL) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Android Browser
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; nl-nl; GT-I9000 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S
   os_family: Android
   browser_family: Android Browser
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-ch; GT-I9070 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S Advance
   os_family: Android
   browser_family: Android Browser
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-ch; SAMSUNG GT-I9070/I9070BULK1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S Advance
   os_family: Android
   browser_family: Android Browser
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; GT-I9070P-ORANGE/I9070PBVLD3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S Advance
   os_family: Android
   browser_family: Android Browser
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SCH-i919 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS
   os_family: Android
   browser_family: Android Browser
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-; GT-S7562 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS
   os_family: Android
   browser_family: Android Browser
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; GT-S7562L Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS
   os_family: Android
   browser_family: Android Browser
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; GT-S7582 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS 2
   os_family: Android
   browser_family: Android Browser
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; GT-S7582 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.7.0.636 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.0.636"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS 2
   os_family: Android
   browser_family: Unknown
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G316HU Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S DUOS 3
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; GT-I9010 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S Giorgio Armani
   os_family: Android
   browser_family: Android Browser
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-ca; GT-I9100M Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; SAMSUNG GT-I9100/I9100BUKJ3 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1423,19 +1281,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; SC-02C) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Unknown
@@ -1443,19 +1299,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; zh-CN; GT-I9100) U2/1.0.0 UCBrowser/9.6.1.401 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.1.401"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Unknown
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; GT-I9100T Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-es; GT-I9100G Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-CN; GT-I9108 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.3.413 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.3.413"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Unknown
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; Galaxy S II Build/GRJ22) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; it-it; GT-I9100P Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G9100 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; GT-I9100 Build/JOP40G; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II
   os_family: Android
   browser_family: Android Browser
@@ -1603,19 +1443,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; ru; SHV-E120S Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II HD LTE
   os_family: Android
   browser_family: Android Browser
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ar-ae; GT-I9105 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II Plus
   os_family: Android
   browser_family: Android Browser
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9105P Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II Plus
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ISW11SC Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S II WiMAX
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: samsung-GT-I9300/1.0 Linux/2.6.35.7 Android/4.0.4 Release/04.18.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Android Browser
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SCH-I535 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Android Browser
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; GT-I9300-ORANGE/I9300XXEMF1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Android Browser
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SCH-I535 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "19.0.1340.69721"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Opera
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; SCH-I939I Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.1.3.546 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.3.546"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Unknown
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; SCH-L710 Build/JSS15J) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Unknown
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SCH-I535 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SCH-R530U Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 USCC-R530U
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III LTE
   os_family: Android
   browser_family: Android Browser
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; de-de; SAMSUNG GT-I9305/I9305XXUEMKC Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III LTE
   os_family: Android
   browser_family: Android Browser
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SAMSUNG GT-I8190/I8190XXALJL Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III mini
   os_family: Android
   browser_family: Android Browser
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; GT-I8190L Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III mini
   os_family: Android
   browser_family: Chrome
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SAMSUNG GT-I8190N/I8190NXXAML1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III mini
   os_family: Android
   browser_family: Android Browser
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I8200N Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S III mini Value Edition
   os_family: Android
   browser_family: Chrome
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; sv-se; GT-I9001 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S Plus
   os_family: Android
   browser_family: Android Browser
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-G977T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G973F Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G977N/KSU2ASJ8) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G977P) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G977U) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-03L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G977B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G977N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV41) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10
   os_family: Android
   browser_family: Chrome
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G770F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4181.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4181.5"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10 Lite
   os_family: Android
   browser_family: Chrome
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G975N/KSU3ASJG) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10+
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G975X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10+
   os_family: Android
   browser_family: Chrome
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; en-US; SM-G975N Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10+
   os_family: Android
   browser_family: Unknown
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-04L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10+
   os_family: Android
   browser_family: Chrome
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV42) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10+
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G9700 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10e
   os_family: Android
   browser_family: Chrome
@@ -2283,19 +2055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G970N Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10e
   os_family: Android
   browser_family: Chrome
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G9708 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10e
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G970W) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10e
   os_family: Android
   browser_family: Chrome
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G970X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S10e
   os_family: Android
   browser_family: Chrome
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G980F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20
   os_family: Android
   browser_family: Chrome
@@ -2383,19 +2145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G981B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20 5G
   os_family: Android
   browser_family: Chrome
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCG01) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20 5G
   os_family: Android
   browser_family: Chrome
@@ -2423,19 +2181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G988B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20 Ultra 5G
   os_family: Android
   browser_family: Chrome
@@ -2443,19 +2199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G985F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20+
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCG02) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20+
   os_family: Android
   browser_family: Chrome
@@ -2483,19 +2235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G986B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20+ 5G
   os_family: Android
   browser_family: Chrome
@@ -2503,19 +2253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-52A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S20+ 5G
   os_family: Android
   browser_family: Chrome
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SAMSUNG-SM-G730A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S3 mini
   os_family: Android
   browser_family: Chrome
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G730V Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S3 mini
   os_family: Android
   browser_family: Chrome
@@ -2563,19 +2307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G730W8 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S3 mini
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2325,17 @@
   user_agent: samsung-GT-I9505+/1.0 Linux/2.6.35.7 Android/4.1.2 Release/08.14.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Android Browser
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; GT-I9500. Build/CNANZHI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Android Browser
@@ -2623,19 +2361,17 @@
   user_agent: sprd-Galaxy-S4/1.0 Linux/2.6.35.7 Android/4.2.2 Release/10.14.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Android Browser
@@ -2643,19 +2379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; SCH-I959 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/4.2.13.3 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.2.13.3"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Baidu
@@ -2663,19 +2397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SC-04E Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2683,19 +2415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-gb; SAMSUNG GT-I9505X Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2703,19 +2433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG GT-I9500 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2723,19 +2451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SGH-M919N Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2743,19 +2469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; GT-I9500 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2763,19 +2487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SCH-I545 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2783,19 +2505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-S975L Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2803,19 +2523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG SCH-R970C Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2823,19 +2541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; zh-cn; SAMSUNG-SCH-I959 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2843,19 +2559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-us; SAMSUNG SGH-M919 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2863,19 +2577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GT-I9502 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 MApi 1.0 (com.dianping.v1 7.0.0 om_sd_360sz GT-I9502; Android 4.4.2) MApi 1.0 (com.dianping.v1 7.0.0 om_sd_360sz GT-I9502; Android 4.4.2) efte/1.0 (efte-for-android)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2595,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-us; GT-I9500 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Android Browser
@@ -2903,19 +2613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; SAMSUNG GT-I9500 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9295 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 ACTIVE
   os_family: Android
   browser_family: Chrome
@@ -2943,19 +2649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9190 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SCH-I435 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -2983,19 +2685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9192 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -3003,19 +2703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-I9195 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -3023,19 +2721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; de-de; SAMSUNG GT-I9195 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -3043,7 +2739,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; GT-I9195I Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.130 Crosswalk/14.43.343.17 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -3052,7 +2747,7 @@
     version: "14.43.343.17"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Unknown
@@ -3060,19 +2755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; Samsung GT-I9192) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 mini
   os_family: Android
   browser_family: Chrome
@@ -3080,19 +2773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; fr-fr; SAMSUNG GT-I9506/I9506XXUBNA2 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 with LTE+
   os_family: Android
   browser_family: Chrome
@@ -3100,19 +2791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SAMSUNG-SM-C105A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 zoom
   os_family: Android
   browser_family: Chrome
@@ -3120,19 +2809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-C105 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 zoom
   os_family: Android
   browser_family: Chrome
@@ -3140,19 +2827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; fr-be; SAMSUNG SM-C101 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 zoom
   os_family: Android
   browser_family: Chrome
@@ -3160,19 +2845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SAMSUNG SM-C105L Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4 zoom
   os_family: Android
   browser_family: Chrome
@@ -3180,19 +2863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-ca; SM-G900W8 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3200,19 +2881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-G900F-ORANGE Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3220,19 +2899,17 @@
   user_agent: sprd-Galaxy-S5/1.0 Linux/2.6.35.7 Android/4.4.4 Release/11.29.2014 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Android Browser
@@ -3240,19 +2917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SM-S902L Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3260,19 +2935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G906L Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3280,19 +2953,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G906K Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3300,19 +2971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S903VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3320,19 +2989,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G906S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5
   os_family: Android
   browser_family: Chrome
@@ -3340,19 +3007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SAMSUNG SM-G870F Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.1 Chrome/34.0.1847.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Active
   os_family: Android
   browser_family: Chrome
@@ -3360,19 +3025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SAMSUNG SM-G870W Build/LRX21T) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Active
   os_family: Android
   browser_family: Chrome
@@ -3380,19 +3043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG-SM-G890A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Active
   os_family: Android
   browser_family: Chrome
@@ -3400,19 +3061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SC-02G Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Active
   os_family: Android
   browser_family: Chrome
@@ -3420,19 +3079,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G870A Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Active
   os_family: Android
   browser_family: Chrome
@@ -3440,19 +3097,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; zh-cn; SAMSUNG-SM-G9009D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.6 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Dual-SIM
   os_family: Android
   browser_family: Chrome
@@ -3460,19 +3115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G860P Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 K Sport
   os_family: Android
   browser_family: Chrome
@@ -3480,19 +3133,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; tr-tr; SM-G800 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 mini
   os_family: Android
   browser_family: Android Browser
@@ -3500,19 +3151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G800F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 MobileIron/1.6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Iron Mobile
-    short_name: I3
     version: "1.6.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 mini
   os_family: Android
   browser_family: Chrome
@@ -3520,19 +3169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G903W Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Neo
   os_family: Android
   browser_family: Chrome
@@ -3540,19 +3187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G903F Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Neo
   os_family: Android
   browser_family: Chrome
@@ -3560,19 +3205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G903M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S5 Neo
   os_family: Android
   browser_family: Chrome
@@ -3580,19 +3223,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.0.2; SM-G920 Build/LRX22G
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Android Browser
@@ -3600,19 +3241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-G920W8 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3620,19 +3259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G920V Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3640,19 +3277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G920X Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3660,19 +3295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G920F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3680,19 +3313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G920I Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3700,19 +3331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G920P Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3720,19 +3349,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-cn; SM-G9200 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Unknown
@@ -3740,19 +3367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G920L Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3760,19 +3385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-S907VL) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3780,19 +3403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G920K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3800,19 +3421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G920T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3820,19 +3439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G920R4 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3840,19 +3457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SC-05G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6
   os_family: Android
   browser_family: Chrome
@@ -3860,19 +3475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG-SM-G925A Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3880,19 +3493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G9250 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3900,19 +3511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G925X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3920,19 +3529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G925I Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3940,19 +3547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G925S Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3960,19 +3565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G925P Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -3980,19 +3583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G925D Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4000,19 +3601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G925T Build/LDY.08) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4020,19 +3619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G925K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4040,19 +3637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SCV31 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4060,19 +3655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 404SC Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4080,19 +3673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G925L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -4100,19 +3691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928G Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4120,19 +3709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928P Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4140,19 +3727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928W8 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4160,19 +3745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4180,19 +3763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4200,19 +3781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SAMSUNG-SM-G928A Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4220,19 +3799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G9287C Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4240,19 +3817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G928I Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4260,19 +3835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G928V Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4280,19 +3853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G9280 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4300,19 +3871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G928S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4320,19 +3889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G9287 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4340,19 +3907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G928K/KKU3DQL1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4360,19 +3925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G928R4 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4380,19 +3943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G928T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -4400,19 +3961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G930S Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4420,19 +3979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G9300 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4440,19 +3997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G930X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4460,19 +4015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G930V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4480,19 +4033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G930K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4500,19 +4051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G930L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4520,19 +4069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G9308) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4540,19 +4087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-G930) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -4560,19 +4105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G891A Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.2 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Active
   os_family: Android
   browser_family: Chrome
@@ -4580,19 +4123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SC-02H Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4600,19 +4141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G935F Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4620,19 +4159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G935X Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4640,19 +4177,17 @@
   user_agent: Mozilla/5.0 (Android 6.0.1; samsung SAMSUNG-SM-G935A) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 SurfBrowser/3.0
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4660,19 +4195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G9350 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/4.0 Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4680,19 +4213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G935W8 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4700,19 +4231,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; ko-kr; SM-G935S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4720,19 +4249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G935T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4740,19 +4267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G935V Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4760,19 +4285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SCV33 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4780,19 +4303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G935U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.0 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4800,19 +4321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G935P Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4820,19 +4339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G935K/KKU1DQL1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4840,19 +4357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G935R4 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4860,19 +4375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G935L Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7 Edge
   os_family: Android
   browser_family: Chrome
@@ -4880,19 +4393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G950 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -4900,19 +4411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G950F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -4920,19 +4429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SCV36 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -4940,19 +4447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G9508 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -4960,19 +4465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G9500 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -4980,19 +4483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G950W Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -5000,19 +4501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G950U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -5020,19 +4519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G950N Build/R16NW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36;KAKAOTALK 1908210
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -5040,19 +4537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SC-02J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8
   os_family: Android
   browser_family: Chrome
@@ -5060,19 +4555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G892U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8 Active
   os_family: Android
   browser_family: Chrome
@@ -5080,19 +4573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G892A Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8 Active
   os_family: Android
   browser_family: Chrome
@@ -5100,19 +4591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-G8750) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8 Lite
   os_family: Android
   browser_family: Chrome
@@ -5120,19 +4609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G955F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5140,19 +4627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-G955N Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5160,19 +4645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G955U Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/5.4 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "5.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5180,19 +4663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G955X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.1 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5200,19 +4681,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-G955 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.5.1171 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.5.1171"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Unknown
@@ -5220,19 +4699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G9550 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5240,19 +4717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SCV35 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5260,19 +4735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SC-03J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S8+
   os_family: Android
   browser_family: Chrome
@@ -5280,19 +4753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G960) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5300,19 +4771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-02K Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5320,19 +4789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G960X Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5340,19 +4807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G960N Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5360,19 +4825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SCV38 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5380,19 +4843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G960F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9
   os_family: Android
   browser_family: Chrome
@@ -5400,19 +4861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SC-03K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9+
   os_family: Android
   browser_family: Chrome
@@ -5420,19 +4879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SCV39 Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9+
   os_family: Android
   browser_family: Chrome
@@ -5440,19 +4897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G965F Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9+
   os_family: Android
   browser_family: Chrome
@@ -5460,19 +4915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G965N Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9+
   os_family: Android
   browser_family: Chrome
@@ -5480,19 +4933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-G965X Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/7.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "7.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S9+
   os_family: Android
   browser_family: Chrome
@@ -5500,19 +4951,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; GT-I9003 Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY SL
   os_family: Android
   browser_family: Android Browser
@@ -5520,19 +4969,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 6.0.1; SAMSUNG-SM-J321AZ Build/MMB29K
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Sol
   os_family: Android
   browser_family: Android Browser
@@ -5540,19 +4987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-J326AZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Sol 2
   os_family: Android
   browser_family: Chrome
@@ -5560,19 +5005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J336AZ) Build/R16NW AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Sol 3
   os_family: Android
   browser_family: Chrome
@@ -5580,19 +5023,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.5; fr-fr; GT-I5700 Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Spica
   os_family: Android
   browser_family: Android Browser
@@ -5600,19 +5041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ar-ae; GT-S5280 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY STAR
   os_family: Android
   browser_family: Android Browser
@@ -5620,19 +5059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SCH-I200 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Stellar
   os_family: Android
   browser_family: Android Browser
@@ -5640,19 +5077,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; SCH-I200 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Stellar
   os_family: Android
   browser_family: Android Browser
@@ -5660,19 +5095,17 @@
   user_agent: Mozilla 5.0 (Linux; U; Android 4.1.2; zh-cn; SCH-I829 Build JZO54K) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Style Duos
   os_family: Android
   browser_family: Unknown
@@ -5680,19 +5113,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.2; zh-CN; SCH-I829) U2/1.0.0 UCBrowser/9.5.0.360 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Style Duos
   os_family: Android
   browser_family: Unknown
@@ -5700,19 +5131,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SCH-I699 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend
   os_family: Android
   browser_family: Android Browser
@@ -5720,19 +5149,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; GT-S7560M-parrot Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend
   os_family: Android
   browser_family: Android Browser
@@ -5740,19 +5167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-pt; SAMSUNG GT-S7560/S7560XXBNC2 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend
   os_family: Android
   browser_family: Android Browser
@@ -5760,19 +5185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SCH-I739) AppleWebKit/535.19 (KHTML, like Gecko) Version/4.0 LieBaoFast/2.10.0 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: LieBaoFast
-    short_name: LF
     version: "2.10.0"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend 2
   os_family: Android
   browser_family: Chrome
@@ -5780,19 +5203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S7390 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend Lite
   os_family: Android
   browser_family: Chrome
@@ -5800,19 +5221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-S7580 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Mobile Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Trend Plus
   os_family: Android
   browser_family: Opera
@@ -5820,19 +5239,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.4; SM-G318MZ Build/KTU84P
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY V Plus
   os_family: Android
   browser_family: Android Browser
@@ -5840,19 +5257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G318HZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY V Plus
   os_family: Android
   browser_family: Chrome
@@ -5860,19 +5275,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; nl-nl; GT-I8150 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W
   os_family: Android
   browser_family: Android Browser
@@ -5880,19 +5293,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.6; en-US; GT-I8150) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W
   os_family: Android
   browser_family: Unknown
@@ -5900,19 +5311,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.3; SM-T255S Build/JLS36C
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W
   os_family: Android
   browser_family: Android Browser
@@ -5920,19 +5329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SAMSUNG-SM-W2016 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2016
   os_family: Android
   browser_family: Chrome
@@ -5940,19 +5347,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 9; SM-W2018) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.215.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.0.215.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2018
   os_family: Android
   browser_family: Unknown
@@ -5960,19 +5365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-W2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2019
   os_family: Android
   browser_family: Chrome
@@ -5980,19 +5383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-G600S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Wide
   os_family: Android
   browser_family: Chrome
@@ -6000,19 +5401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-I8552 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win
   os_family: Android
   browser_family: Chrome
@@ -6020,19 +5419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-I8552B Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win
   os_family: Android
   browser_family: Chrome
@@ -6040,19 +5437,17 @@
   user_agent: samsung-GT-I8550/1.0 Linux/2.6.35.7 Android/4.2.2 Release/08.08.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win
   os_family: Android
   browser_family: Android Browser
@@ -6060,19 +5455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; zh-cn; SAMSUNG-GT-I8558_TD/1.0 Android/4.2.2 Release/04.15.2013 Browser/AppleWebKit535.19 Build/JDQ39) ApplelWebkit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win
   os_family: Android
   browser_family: Chrome
@@ -6080,19 +5473,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; SM-G3818 Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win Pro
   os_family: Android
   browser_family: Android Browser
@@ -6100,19 +5491,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; SM-G3812 Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30 OPR/43.1.2254.140112
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.1.2254.140112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Win Pro
   os_family: Android
   browser_family: Opera
@@ -6120,19 +5509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S7710 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 2
   os_family: Android
   browser_family: Chrome
@@ -6140,19 +5527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-G389F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 3
   os_family: Android
   browser_family: Chrome
@@ -6160,19 +5545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G390F Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 4
   os_family: Android
   browser_family: Chrome
@@ -6180,19 +5563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-G390W) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/11.2 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "11.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 4
   os_family: Android
   browser_family: Chrome
@@ -6200,19 +5581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-G390Y Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 4
   os_family: Android
   browser_family: Chrome
@@ -6220,19 +5599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G398FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover 4s
   os_family: Android
   browser_family: Chrome
@@ -6240,19 +5617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-G715FN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Xcover Pro
   os_family: Android
   browser_family: Chrome
@@ -6260,19 +5635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; GT-S5360L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Hello Kitty
   os_family: Android
   browser_family: Android Browser
@@ -6280,19 +5653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; GT-S5360B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Hello Kitty
   os_family: Android
   browser_family: Android Browser
@@ -6300,19 +5671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; SAMSUNG GT-S5360T Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Hello Kitty
   os_family: Android
   browser_family: Android Browser
@@ -6320,19 +5689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.3; en-gb; GT-S5360 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Hello Kitty
   os_family: Android
   browser_family: Android Browser
@@ -6340,19 +5707,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-ch; GT-B5510-ORANGE/B5510BVLH1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Pro
   os_family: Android
   browser_family: Android Browser
@@ -6360,19 +5725,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.6; en-US; GT-B5510) U2/1.0.0 UCBrowser/9.1.0.386 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.0.386"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Pro
   os_family: Android
   browser_family: Unknown
@@ -6380,19 +5743,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; tr-tr; GT-B5512 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Y Pro Duos
   os_family: Android
   browser_family: Android Browser
@@ -6400,19 +5761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S6310 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young
   os_family: Android
   browser_family: Chrome
@@ -6420,19 +5779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G130H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.517 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.517"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Chrome
@@ -6440,19 +5797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G130HN Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.517 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.517"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Chrome
@@ -6460,19 +5815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G130M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Chrome
@@ -6480,19 +5833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-G130U Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Chrome
@@ -6500,19 +5851,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; SM-G130E Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.0.950 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.0.950"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Unknown
@@ -6520,19 +5869,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; SM-G130BT Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2
   os_family: Android
   browser_family: Android Browser
@@ -6540,19 +5887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G130BU Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -6560,19 +5905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S6312 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Mobile Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Young DUOS
   os_family: Android
   browser_family: Opera
@@ -6580,19 +5923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-F700U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z Flip
   os_family: Android
   browser_family: Chrome
@@ -6600,19 +5941,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 2.4; SAMSUNG SM-Z130H) AppleWebKit/537.3 (KHTML, like Gecko) SamsungBrowser/1.1 Mobile Safari/537.3
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.1"
     engine: WebKit
     engine_version: "537.3"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z1
   os_family: Other Mobile
   browser_family: Chrome
@@ -6620,19 +5959,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 2.4; SAMSUNG SM-Z200F) AppleWebKit/537.3 (KHTML, like Gecko) SamsungBrowser/1.1 Mobile Safari/537.3
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.1"
     engine: WebKit
     engine_version: "537.3"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z2
   os_family: Other Mobile
   browser_family: Chrome
@@ -6640,19 +5977,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 2.4; SAMSUNG SM-Z200M) AppleWebKit/537.3 (KHTML, like Gecko) SamsungBrowser/1.1 Mobile Safari/537.3
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.1"
     engine: WebKit
     engine_version: "537.3"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z2
   os_family: Other Mobile
   browser_family: Chrome
@@ -6660,19 +5995,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 2.4; SAMSUNG SM-Z200Y) AppleWebKit/537.3 (KHTML, like Gecko) SamsungBrowser/1.1 Mobile Safari/537.3
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.1"
     engine: WebKit
     engine_version: "537.3"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z2
   os_family: Other Mobile
   browser_family: Chrome
@@ -6680,19 +6013,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 2.4; SAMSUNG SM-Z300H) AppleWebKit/537.3 (KHTML, like Gecko) SamsungBrowser/1.1 Mobile Safari/537.3
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.4"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.1"
     engine: WebKit
     engine_version: "537.3"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z3
   os_family: Other Mobile
   browser_family: Chrome
@@ -6700,19 +6031,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 3.0; SAMSUNG SM-Z400Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.69 Mobile Safari/537.36
   os:
     name: Tizen
-    short_name: TIZ
     version: "3.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.69"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z4
   os_family: Other Mobile
   browser_family: Chrome
@@ -6720,19 +6049,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 3.0; SAMSUNG SM-Z400F) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/47.0.2526.69 Mobile Safari/537.36
   os:
     name: Tizen
-    short_name: TIZ
     version: "3.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z4
   os_family: Other Mobile
   browser_family: Chrome
@@ -6740,19 +6067,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-G310R5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GreatCall Touch 3
   os_family: Android
   browser_family: Chrome
@@ -6762,13 +6087,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.3"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-C3011
   os_family: Unknown
   browser_family: Unknown
@@ -6778,13 +6102,12 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.0.30281"
     engine: Presto
     engine_version: "2.8.119"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-C3262
   os_family: Unknown
   browser_family: Opera
@@ -6794,13 +6117,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-C3303K
   os_family: Unknown
   browser_family: NetFront
@@ -6810,13 +6132,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.1"
     engine: NetFront
     engine_version: "4.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-C3520
   os_family: Unknown
   browser_family: NetFront
@@ -6824,19 +6145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; pt-br; GT-I5500 Build/GINGERBREAD; CyanogenMod-7.1.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I5500
   os_family: Android
   browser_family: Android Browser
@@ -6844,19 +6163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; GT-I5500L Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I5500L
   os_family: Android
   browser_family: Android Browser
@@ -6864,19 +6181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-ca; GT-I5500M Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I5500M
   os_family: Android
   browser_family: Android Browser
@@ -6884,19 +6199,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; NOKIA; GT-I8750)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I8750
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6904,19 +6217,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; SAMSUNG; GT-I8750)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I8750
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6924,19 +6235,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.1; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; SAMSUNG; GT-I8750) like Gecko
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I8750
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6944,19 +6253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; zh-cn; SAMSUNG-GT-I9508_TD/1.0 Android/4.2.2 Release/03.15.2013 Browser/AppleWebKit535.19 Build/JDQ39) ApplelWebkit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-I9508
   os_family: Android
   browser_family: Chrome
@@ -6966,13 +6273,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "0.8"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5230
   os_family: Unknown
   browser_family: Unknown
@@ -6982,13 +6288,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "0.8"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5230
   os_family: Unknown
   browser_family: Unknown
@@ -6998,13 +6303,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "1.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5230
   os_family: Unknown
   browser_family: Unknown
@@ -7014,13 +6318,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "0.8"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5230N
   os_family: Unknown
   browser_family: Unknown
@@ -7030,13 +6333,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "1.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5230W
   os_family: Unknown
   browser_family: Unknown
@@ -7044,19 +6346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-S5282 Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5282
   os_family: Android
   browser_family: Chrome
@@ -7064,19 +6364,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.2; en-US; GT-S5282) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5282
   os_family: Android
   browser_family: Unknown
@@ -7084,19 +6382,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-nz; GT-S5300 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5300
   os_family: Android
   browser_family: Android Browser
@@ -7104,19 +6400,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fi-fi; GT-S5660 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5660
   os_family: Android
   browser_family: Android Browser
@@ -7124,19 +6418,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; nb-no; GT-S5660 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5660
   os_family: Android
   browser_family: Android Browser
@@ -7144,19 +6436,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ro-ro; GT-S5660 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5660
   os_family: Android
   browser_family: Android Browser
@@ -7164,19 +6454,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; el-gr; GT-S5839i Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S5839i
   os_family: Android
   browser_family: Android Browser
@@ -7184,19 +6472,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; GT-S6010 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6010
   os_family: Android
   browser_family: Android Browser
@@ -7204,19 +6490,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; GT-S6010L Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6010L
   os_family: Android
   browser_family: Android Browser
@@ -7224,19 +6508,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; tr-tr; GT-S6102 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6102
   os_family: Android
   browser_family: Android Browser
@@ -7244,19 +6526,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; el-gr; GT-S6500 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6500
   os_family: Android
   browser_family: Android Browser
@@ -7264,19 +6544,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; lv-lv; GT-S6500 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6500
   os_family: Android
   browser_family: Android Browser
@@ -7284,19 +6562,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-ph; GT-S6500D Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6500D
   os_family: Android
   browser_family: Android Browser
@@ -7304,19 +6580,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-nz; GT-S6802 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6802
   os_family: Android
   browser_family: Android Browser
@@ -7324,19 +6598,17 @@
   user_agent: SAMSUNG-GT-S6818_TD/1.0 Android/4.1.2 Release/02.03.2013 Browser/ApplelWebkit/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S6818
   os_family: Android
   browser_family: Android Browser
@@ -7344,19 +6616,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-S7262) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.0.347 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.347"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S7262
   os_family: Android
   browser_family: Unknown
@@ -7364,19 +6634,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SAMSUNG-GT-S7568_TD/1.0 Android/4.0.4 Release/07.15.2012 Browser/AppleWebKit534.30 Build/IMM76D) ApplelWebkit/534.30 (KHTML,like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S7568
   os_family: Android
   browser_family: Android Browser
@@ -7384,19 +6652,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GT-S7568 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GT-S7568
   os_family: Android
   browser_family: Unknown
@@ -7404,19 +6670,17 @@
   user_agent: SAMSUNG-GT-I8320-Vodafone/I8320BUJC1 Linux/X2/R1 Opera/9.6 SMS-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.6"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: H1
   os_family: GNU/Linux
   browser_family: Opera
@@ -7424,19 +6688,17 @@
   user_agent: Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 Samsung/I8910;; Profile/MIDP-2.1 Configuration/CLDC-1.1 ) AppleWebKit/535.1 (KHTML, like Gecko) NokiaBrowser/ Mobile Safari/535.1
   os:
     name: Symbian OS Series 60
-    short_name: S60
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: ""
     engine: WebKit
     engine_version: "535.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: I8910
   os_family: Symbian
   browser_family: Nokia Browser
@@ -7444,19 +6706,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) SAMSUNG-GT-i8000V/BUIJ1
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Omnia II
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7464,19 +6724,17 @@
   user_agent: SAMSUNG-GT-i8000/1.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Omnia II
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7484,19 +6742,17 @@
   user_agent: SAMSUNG-GT-i8000/1.0 (Windows CE; Opera Mobi; U; en) Opera 9.5
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.5"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Omnia II
   os_family: Windows Mobile
   browser_family: Opera
@@ -7504,19 +6760,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; SAMSUNG; Omnia W; Orange)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Omnia W
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7526,13 +6780,12 @@
   client:
     type: browser
     name: Jasmine
-    short_name: JS
     version: "1.0"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: S8000
   os_family: Unknown
   browser_family: Unknown
@@ -7540,19 +6793,17 @@
   user_agent: Mozilla/4.0 (compatible; Polaris 6.2; Brew 3.1.5; en)/240X320 Samsung sam-r631
   os:
     name: Brew
-    short_name: BMP
     version: "3.1.5"
     platform: ""
   client:
     type: browser
     name: Polaris
-    short_name: PO
     version: "6.2"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: sam-r631
   os_family: Brew
   browser_family: Unknown
@@ -7560,19 +6811,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SCH-I519 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SCH-I519
   os_family: Android
   browser_family: Android Browser
@@ -7582,13 +6831,12 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.8"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SCH-r560
   os_family: Unknown
   browser_family: Unknown
@@ -7596,19 +6844,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SCH-W2013 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360browser(securitypay,securityinstalled); 360(android,uppayplugin); 360 Aphone Browser (5.3.1)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "5.3.1"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SCH-W2013
   os_family: Android
   browser_family: Unknown
@@ -7618,13 +6864,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.4"
     engine: NetFront
     engine_version: "3.4"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-A737
   os_family: Unknown
   browser_family: NetFront
@@ -7634,13 +6879,12 @@
   client:
     type: browser
     name: QQ Browser Mini
-    short_name: Q1
     version: "2.6"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-A777
   os_family: Unknown
   browser_family: Unknown
@@ -7648,19 +6892,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-ca; SAMSUNG-SGH-I317 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I317
   os_family: Android
   browser_family: Android Browser
@@ -7668,19 +6910,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SAMSUNG-SGH-I317 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I317
   os_family: Android
   browser_family: Chrome
@@ -7688,19 +6928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SGH-I317M Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I317M
   os_family: Android
   browser_family: Chrome
@@ -7708,19 +6946,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SAMSUNG-SGH-I337 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I337
   os_family: Android
   browser_family: Chrome
@@ -7728,7 +6964,6 @@
   user_agent: NS/3.0.1 (Linux; U; Android 4.3; en-us; phone/SAMSUNG-SGH-I337 Build/JSS15J; Density/480; gzip) com.google.android.apps.magazines/133431644
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -7737,7 +6972,7 @@
     version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I337
   os_family: Android
   browser_family: Unknown
@@ -7745,19 +6980,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-ca; SGH-I337M Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I337M
   os_family: Android
   browser_family: Chrome
@@ -7765,19 +6998,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; SAMSUNG-SGH-I437 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I437
   os_family: Android
   browser_family: Android Browser
@@ -7785,19 +7016,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SAMSUNG-SGH-I437P Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I437P
   os_family: Android
   browser_family: Android Browser
@@ -7805,19 +7034,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-us; SAMSUNG-SGH-I547 Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I547
   os_family: Android
   browser_family: Android Browser
@@ -7825,19 +7052,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-es; SAMSUNG-SGH-I577 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I577
   os_family: Android
   browser_family: Android Browser
@@ -7845,19 +7070,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SAMSUNG-SGH-I717 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I717
   os_family: Android
   browser_family: Android Browser
@@ -7865,19 +7088,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SAMSUNG-SGH-I747 Build/JRO03L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I747
   os_family: Android
   browser_family: Chrome
@@ -7885,19 +7106,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; SGH-I747 Build/JOP40D; LiquidSmooth-Liquid-JB-v2.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I747
   os_family: Android
   browser_family: Android Browser
@@ -7905,19 +7124,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; SAMSUNG-SGH-I747 Build/JOP40D; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I747
   os_family: Android
   browser_family: Android Browser
@@ -7925,19 +7142,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-ca; SGH-I747M Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I747M
   os_family: Android
   browser_family: Android Browser
@@ -7945,19 +7160,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SGH-I897 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I897
   os_family: Android
   browser_family: Android Browser
@@ -7965,19 +7178,17 @@
   user_agent: 'Mozilla/4.0 (compatible: MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; WpsLondonTest; SAMSUNG; SGH-i917)'
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-i917
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7985,19 +7196,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 7.10; en-US; SAMSUNG; SGH-i917) U2/1.0.0 UCBrowser/3.2.0.340 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.2.0.340"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-i917
   os_family: Windows Mobile
   browser_family: Unknown
@@ -8005,19 +7214,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; SGH-I927 Build/JOP40D; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I927
   os_family: Android
   browser_family: Android Browser
@@ -8025,19 +7232,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SGH-I997 Build/IMM76L; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-I997
   os_family: Android
   browser_family: Android Browser
@@ -8045,19 +7250,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SGH-M819N Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-M819N
   os_family: Android
   browser_family: Chrome
@@ -8067,13 +7270,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.1"
     engine: NetFront
     engine_version: "4.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T259
   os_family: Unknown
   browser_family: NetFront
@@ -8083,13 +7285,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T359
   os_family: Unknown
   browser_family: NetFront
@@ -8097,19 +7298,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-ca; SGH-T589W Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T589W
   os_family: Android
   browser_family: Android Browser
@@ -8117,19 +7316,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SGH-T599N Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T599N
   os_family: Android
   browser_family: Android Browser
@@ -8139,13 +7336,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "3.5"
     engine: NetFront
     engine_version: "3.5"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T749
   os_family: Unknown
   browser_family: NetFront
@@ -8153,19 +7349,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-ca; SGH-T889V Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T889V
   os_family: Android
   browser_family: Android Browser
@@ -8173,19 +7367,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SGH-T959 Build/JRO03L; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T959
   os_family: Android
   browser_family: Android Browser
@@ -8193,19 +7385,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SGH-T959V Build/IMM76L; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T959V
   os_family: Android
   browser_family: Android Browser
@@ -8213,19 +7403,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; SGH-T989 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T989
   os_family: Android
   browser_family: Android Browser
@@ -8233,19 +7421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; SGH-T989D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T989D
   os_family: Android
   browser_family: Android Browser
@@ -8253,19 +7439,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SGH-T999 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999
   os_family: Android
   browser_family: Android Browser
@@ -8273,19 +7457,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; SGH-T999 Build/JRO03L; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999
   os_family: Android
   browser_family: Android Browser
@@ -8293,19 +7475,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; es-us; SGH-T999L Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999L
   os_family: Android
   browser_family: Android Browser
@@ -8313,19 +7493,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; SGH-T999L Build/JSS15J) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999L
   os_family: Android
   browser_family: Unknown
@@ -8333,19 +7511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SGH-T999N Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999N
   os_family: Android
   browser_family: Chrome
@@ -8353,19 +7529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-ca; SGH-T999V Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SGH-T999V
   os_family: Android
   browser_family: Android Browser
@@ -8373,19 +7547,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; SHV-E110S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E110S
   os_family: Android
   browser_family: Android Browser
@@ -8393,19 +7565,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; SHV-E140L Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E140L
   os_family: Android
   browser_family: Android Browser
@@ -8413,19 +7583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SHV-E160L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E160L
   os_family: Android
   browser_family: Android Browser
@@ -8433,19 +7601,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; tr-tr; SHV-E210K Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E210K
   os_family: Android
   browser_family: Android Browser
@@ -8453,19 +7619,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; SHV-E210K Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E210K
   os_family: Android
   browser_family: Android Browser
@@ -8473,19 +7637,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SHV-E210S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E210S
   os_family: Android
   browser_family: Android Browser
@@ -8493,19 +7655,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SHV-E210S Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E210S
   os_family: Android
   browser_family: Android Browser
@@ -8513,19 +7673,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; SHV-E250K Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E250K
   os_family: Android
   browser_family: Android Browser
@@ -8533,19 +7691,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SHV-E250K Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E250K
   os_family: Android
   browser_family: Android Browser
@@ -8553,19 +7709,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; ko-kr; SHV-E250K/KKUEMK8 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E250K
   os_family: Android
   browser_family: Android Browser
@@ -8573,19 +7727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; ko-kr; SAMSUNG SHV-E330L Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHV-E330L
   os_family: Android
   browser_family: Chrome
@@ -8593,19 +7745,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; vi-vn; SHW-M110S Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHW-M110S
   os_family: Android
   browser_family: Android Browser
@@ -8613,19 +7763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ko-kr; SHW-M130L Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHW-M130L
   os_family: Android
   browser_family: Android Browser
@@ -8633,19 +7781,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; ko-kr; SHW-M380S Build/HTK75D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHW-M380S
   os_family: Android
   browser_family: Android Browser
@@ -8653,19 +7799,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; SHW-M440S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SHW-M440S
   os_family: Android
   browser_family: Android Browser
@@ -8673,19 +7817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SPH-D700 Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-D700
   os_family: Android
   browser_family: Android Browser
@@ -8693,19 +7835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SPH-D710 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-D710
   os_family: Android
   browser_family: Chrome
@@ -8713,19 +7853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SPH-D710BST Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-D710BST
   os_family: Android
   browser_family: Chrome
@@ -8733,19 +7871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; SPH-L300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L300
   os_family: Android
   browser_family: Android Browser
@@ -8753,19 +7889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; en-us; SAMSUNG SPH-L520 Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Version/1.0 Chrome/18.0.1025.308 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "18.0.1025.308"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L520
   os_family: Android
   browser_family: Chrome
@@ -8773,19 +7907,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; SPH-L710 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L710
   os_family: Android
   browser_family: Android Browser
@@ -8793,19 +7925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SPH-L710 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L710
   os_family: Android
   browser_family: Chrome
@@ -8813,19 +7943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; en-us; SAMSUNG SPH-L720 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L720
   os_family: Android
   browser_family: Chrome
@@ -8833,19 +7961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SPH-L720 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L720
   os_family: Android
   browser_family: Chrome
@@ -8853,19 +7979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-us; SAMSUNG SPH-L720T Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-L720T
   os_family: Android
   browser_family: Chrome
@@ -8873,19 +7997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SPH-M830 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-M830
   os_family: Android
   browser_family: Android Browser
@@ -8893,19 +8015,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; SPH-M930BST Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-M930BST
   os_family: Android
   browser_family: Android Browser
@@ -8913,19 +8033,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SPH-P500 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: SPH-P500
   os_family: Android
   browser_family: Android Browser
@@ -8933,19 +8051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; vollo Vi86 Build/volloVi86) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Vollo Vi86
   os_family: Android
   browser_family: Android Browser
@@ -8953,19 +8069,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500XXJF4; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave
   os_family: Other Mobile
   browser_family: Unknown
@@ -8973,19 +8087,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500M/S8500MUGJF5; U; Bada/1.0; fr-ca) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave
   os_family: Other Mobile
   browser_family: Unknown
@@ -8993,7 +8105,6 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500-VODAFONE/S8500BUJF1; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
@@ -9002,7 +8113,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave
   os_family: Other Mobile
   browser_family: Unknown
@@ -9010,19 +8121,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500JPLC2; U; Bada/2.0; en-us) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave
   os_family: Other Mobile
   browser_family: Unknown
@@ -9030,19 +8139,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8500/S8500XXLA1; U; Bada/2.0; de-de) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave
   os_family: Other Mobile
   browser_family: Unknown
@@ -9050,19 +8157,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S8600/1.0; U; Bada/2.0; en-us) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 3
   os_family: Other Mobile
   browser_family: Unknown
@@ -9070,19 +8175,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5250/1.0; U; bada/1.0; pt-br) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 525
   os_family: Other Mobile
   browser_family: Unknown
@@ -9090,19 +8193,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5330/S5330XXJJ1; U; Bada/1.0; it-it) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 533
   os_family: Other Mobile
   browser_family: Unknown
@@ -9110,7 +8211,6 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5780/S5780NAKH3; U; Bada/1.1; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.1"
     platform: ""
   client:
@@ -9119,7 +8219,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 578
   os_family: Other Mobile
   browser_family: Unknown
@@ -9127,19 +8227,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230E/S723EXXJJ3; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 723
   os_family: Other Mobile
   browser_family: Unknown
@@ -9147,7 +8245,6 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230E-ORANGE/S723EBVJJ1; U; Bada/1.0; fr-fr) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
@@ -9156,7 +8253,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 723
   os_family: Other Mobile
   browser_family: Unknown
@@ -9164,7 +8261,6 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230E-VODAFONE/S723EBUJJ3; U; Bada/1.0; en-us) AppleWebKit/533.1 (KHTML, like Gecko) Dolfin/2.0 Mobile WQVGA SMM-MMS/1.2.0 NexPlayer/3.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
@@ -9173,7 +8269,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 723
   os_family: Other Mobile
   browser_family: Unknown
@@ -9181,7 +8277,6 @@
   user_agent: SAMSUNG-GT-S7230E/S723EBGJJ3 Bada/1.0 AppleWebKit/533.1 Dolfin/2.0 Mobile NexPlayer/3.0 SMM-MMS/1.2.0 profile/MIDP-2.1 configuration/CLDC-1.1 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
@@ -9190,7 +8285,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 723
   os_family: Other Mobile
   browser_family: Unknown
@@ -9198,19 +8293,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7230-VODAFONE/1.0; U; Bada/1.0; en-us) OperaMini/5.0.21073 Mobile WVGA SMM-MMS/1.2.0 NexPla
   os:
     name: Bada
-    short_name: SBA
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "5.0.21073"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave 723
   os_family: Other Mobile
   browser_family: Opera
@@ -9218,19 +8311,17 @@
   user_agent: Mozilla/13.0 (SAMSUNG; SAMSUNG-GT-S8530/S8530XXLA1; U; Bada/2.0; xx) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile WVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave II
   os_family: Other Mobile
   browser_family: Unknown
@@ -9238,19 +8329,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S7250/S7250XXKHD; U; Bada/2.0; tr-tr) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave M
   os_family: Other Mobile
   browser_family: Unknown
@@ -9258,19 +8347,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5380-BOUYGUES/S5380AGLH1; U; Bada/2.0; fr-fr) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave Y
   os_family: Other Mobile
   browser_family: Unknown
@@ -9278,19 +8365,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5380/S5380AELB3; U; Bada/2.0; fr-fr) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave Y
   os_family: Other Mobile
   browser_family: Unknown
@@ -9298,19 +8383,17 @@
   user_agent: Mozilla/5.0 (SAMSUNG; SAMSUNG-GT-S5380D/S5380DNVKL1; U; Bada/2.0; fr-fr) AppleWebKit/534.20 (KHTML, like Gecko) Dolfin/3.0 Mobile HVGA SMM-MMS/1.2.0 OPN-B
   os:
     name: Bada
-    short_name: SBA
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Dolphin
-    short_name: DF
     version: "3.0"
     engine: WebKit
     engine_version: "534.20"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Wave Y
   os_family: Other Mobile
   browser_family: Unknown
@@ -9318,19 +8401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AERIAL PLUS Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SB
+    brand: STF Mobile
     model: Aerial Plus
   os_family: Android
   browser_family: Chrome
@@ -9338,19 +8419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Fractal) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SB
+    brand: STF Mobile
     model: Fractal
   os_family: Android
   browser_family: Chrome
@@ -9358,19 +8437,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; Andromax-c Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax c
   os_family: Android
   browser_family: Android Browser
@@ -9378,19 +8455,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; id-; Smartfren Andromax AD688G Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) FlyFlow/3.1 Version/4.0 Mobile Safari/534.24 T5/2.0
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "3.1"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax C2
   os_family: Android
   browser_family: Baidu
@@ -9398,19 +8473,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; id-id; Smartfren Andromax AD9A1H Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax G2
   os_family: Android
   browser_family: Android Browser
@@ -9418,19 +8491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Smartfren Andromax AD6B1H Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax G2 Hot
   os_family: Android
   browser_family: Chrome
@@ -9438,19 +8509,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; id-id; Smartfren Andromax AD689G Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax i3
   os_family: Android
   browser_family: Android Browser
@@ -9458,19 +8527,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; id-id; Smartfren Andromax AD682H Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax i3s
   os_family: Android
   browser_family: Android Browser
@@ -9478,19 +8545,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; en-US; Andromax_U) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax U
   os_family: Android
   browser_family: Unknown
@@ -9498,19 +8563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; id-; PD6D1J Build/KVT49L) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 bdbrowser_i18n/4.4.0.2
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.4.0.2"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: Andromax V3s
   os_family: Android
   browser_family: Baidu
@@ -9518,19 +8581,17 @@
   user_agent: 'Mozilla/5.0_(Smartfren-E781A/E2_SQID_V0.1.6; U; REX/4.3;BREW/3.1.5.189; Profile/MIDP-2.0_Configuration/CLDC-1.1; 240*320; CTC/2.0)_Obigo Browser/Q7'
   os:
     name: Brew
-    short_name: BMP
     version: "3.1.5.189"
     platform: ""
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q7"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: E781A
   os_family: Brew
   browser_family: Unknown
@@ -9538,19 +8599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; id-id; New Andromax-i Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SC
+    brand: Smartfren
     model: New Andromax I
   os_family: Android
   browser_family: Android Browser
@@ -9558,19 +8617,17 @@
   user_agent: Mozilla/4.0 (Compatible; MSIE 6.0; Windows NT 5.1) SonyEricssonM1i/R1AA Profile/MIDP-2.1 Configuration/CLDC-1.1; Windows Phone 6.5
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Aspen
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9578,19 +8635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-in; SonyEricssonWT19i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Android Browser
@@ -9598,19 +8653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; SonyEricssonWT19iv Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Android Browser
@@ -9618,19 +8671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-be; SonyEricssonWT19i-o Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Android Browser
@@ -9638,19 +8689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; WT19i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Android Browser
@@ -9658,7 +8707,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; ru-ru; WT19i Build/4.0.2.A.0.58) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Flipboard/2.1.2/854,2.1.2.854,2013-12-05 11:59, +0300
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
@@ -9667,7 +8715,7 @@
     version: "2.1.2"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Unknown
@@ -9675,19 +8723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; LiveWithWalkman Build/IMM76L; CyanogenMod-9.1.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Live with Walkman
   os_family: Android
   browser_family: Android Browser
@@ -9695,19 +8741,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonMT25i Build/4.1.B.0.631) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: MT25i
   os_family: Android
   browser_family: Android Browser
@@ -9715,19 +8759,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-co; MT25i Build/4.1.B.0.631) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: MT25i
   os_family: Android
   browser_family: Android Browser
@@ -9735,19 +8777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; W960 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.8.9.457 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.9.457"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: W960
   os_family: Android
   browser_family: Unknown
@@ -9755,19 +8795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-02L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia Ace
   os_family: Android
   browser_family: Chrome
@@ -9775,19 +8813,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-ph; SonyEricssonST17a Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia active
   os_family: Android
   browser_family: Android Browser
@@ -9795,19 +8831,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-ch; SonyEricssonST17i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia active
   os_family: Android
   browser_family: Android Browser
@@ -9815,19 +8849,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.2; fr-fr; SonyEricssonLT15 Build/3.0.A.2.181_R3D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -9835,19 +8867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.2; fr-fr; SonyEricssonLT15i Build/3.0.A.2.181) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -9855,19 +8885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.2; fr-fr; SonyEricssonLT15i-o Build/3.0.A.2.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -9875,19 +8903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-ca; SonyEricssonLT15a Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -9895,19 +8921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; LT15i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser

--- a/Tests/fixtures/smartphone-14.yml
+++ b/Tests/fixtures/smartphone-14.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonSO-01C Build/4.0.1.C.1.21) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -23,19 +21,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.4; en-US; LT15i) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Unknown
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT15iv Build/4.1.B.0.431) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc
   os_family: Android
   browser_family: Android Browser
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-ca; SonyEricssonLT18a Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonLT18i-o Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonLT18iv Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.4; en-US; LT18i) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Unknown
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-at; LT18i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyEricssonLT18i Build/Xperia Ultimate HDâ„¢ 3.0.2) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; LT18i Build/4.1.B.0.431) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia arc S
   os_family: Android
   browser_family: Android Browser
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonST15i Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini
   os_family: Android
   browser_family: Android Browser
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-pa; ST15a Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini
   os_family: Android
   browser_family: Android Browser
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; ST15i Build/4.1.B.0.431) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini
   os_family: Android
   browser_family: Android Browser
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-be; SonyEricssonSK17i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-ca; SonyEricssonSK17a Build/4.0.2.A.0.58) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonSK17i-o Build/4.0.2.A.0.58) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonSK17iv Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-jm; SK17a Build/4.1.B.0.431) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-py; SK17i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-; SK17i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia mini pro
   os_family: Android
   browser_family: Android Browser
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-gb; SonyEricssonMT15i-o Build/3.0.1.A.0.145) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo
   os_family: Android
   browser_family: Android Browser
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; SonyEricssonMT15i Build/3.0.1.A.0.145) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo
   os_family: Android
   browser_family: Android Browser
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonMT15a Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; cs_cz; MT11i Build/GINGERBREAD) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 NetFrontLifeBrowser/2.3 Mobile (Dragonfruit)
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: NetFront Life
-    short_name: NL
     version: "2.3"
     engine: NetFront
     engine_version: ""
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo V
   os_family: Android
   browser_family: Unknown
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; el-gr; SonyEricssonMT11i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo V
   os_family: Android
   browser_family: Android Browser
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; SonyEricssonMT11i-o Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo V
   os_family: Android
   browser_family: Android Browser
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; SonyEricssonMT11iv Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo V
   os_family: Android
   browser_family: Android Browser
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonMT11a Build/4.0.2.A.0.42) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia neo V
   os_family: Android
   browser_family: Android Browser
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.2; en-us; SonyEricssonR800x Build/3.0.E.2.89) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia PLAY
   os_family: Android
   browser_family: Android Browser
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; SonyEricssonR800at Build/3.0.1.B.0.285) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia PLAY
   os_family: Android
   browser_family: Android Browser
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-; R800x Build/4.0.2.E.0.57) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia PLAY
   os_family: Android
   browser_family: Android Browser
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-gb; SonyEricssonMK16i Build/4.0.2.A.0.69) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia pro
   os_family: Android
   browser_family: Android Browser
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-ca; SonyEricssonMK16a Build/4.0.2.A.0.58) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia pro
   os_family: Android
   browser_family: Android Browser
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fa-ir; MK16i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia pro
   os_family: Android
   browser_family: Android Browser
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-be; SonyEricssonST18i Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia ray
   os_family: Android
   browser_family: Android Browser
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-ca; SonyEricssonST18a Build/4.0.1.A.0.283) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia ray
   os_family: Android
   browser_family: Android Browser
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; SonyEricssonST18iv Build/4.0.2.A.0.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia ray
   os_family: Android
   browser_family: Android Browser
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; ST18i Build/4.1.B.0.587) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia ray
   os_family: Android
   browser_family: Android Browser
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; el-gr; MT27i Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia Sola
   os_family: Android
   browser_family: Android Browser
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyEricssonMT27i Build/6.1.1.B.1.54) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia Sola
   os_family: Android
   browser_family: Android Browser
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; SonyEricssonX10iv Build/R1FA014) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10
   os_family: Android
   browser_family: Android Browser
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; SonyEricssonX10a Build/2.1.A.0.492) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10
   os_family: Android
   browser_family: Android Browser
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; SonyEricssonX10i Build/3.0.1.G.0.75) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10
   os_family: Android
   browser_family: Android Browser
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; X10i Build/3.0.1.G.0.75) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10
   os_family: Android
   browser_family: Android Browser
@@ -883,13 +795,12 @@
   user_agent: CWEB/2.0 (Linux; U; Adr 2.1-update1; en-US; E10i) U2/1.0.0 UC \x11@0C75@/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10 mini
   os_family: Android
   browser_family: Unknown
@@ -897,19 +808,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; SonyEricssonE10iv Build/2.1.1.A.0.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10 mini
   os_family: Android
   browser_family: Android Browser
@@ -917,19 +826,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; iw-il; SonyEricssonE10a Build/2.1.1.A.0.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10 mini
   os_family: Android
   browser_family: Android Browser
@@ -937,19 +844,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; cs-cz; E10i Build/3.0.1.A.0.145; MiniCM7-2.1.6) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10 mini
   os_family: Android
   browser_family: Android Browser
@@ -957,19 +862,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; en-us; SonyEricssonU20a Build/R1X) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X10 mini pro
   os_family: Android
   browser_family: Android Browser
@@ -977,19 +880,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; SonyEricssonE15i-o Build/1.3.A.0.50) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X8
   os_family: Android
   browser_family: Android Browser
@@ -997,19 +898,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-au; SonyEricssonE15i Build/2.1.1.A.0.6) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X8
   os_family: Android
   browser_family: Android Browser
@@ -1017,19 +916,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; es-es; SonyEricssonE15iv Build/2.0.1.A.0.47) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X8
   os_family: Android
   browser_family: Android Browser
@@ -1037,19 +934,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; E15i Build/2.1.1.A.0.16) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X8
   os_family: Android
   browser_family: Android Browser
@@ -1057,19 +952,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; pt-br; SonyEricssonE15a Build/2.0.1.A.0.47) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: SE
+    brand: Sony Ericsson
     model: Xperia X8
   os_family: Android
   browser_family: Android Browser
@@ -1077,19 +970,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; SHARP-ADS1 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: ADS1
   os_family: Android
   browser_family: Android Browser
@@ -1097,19 +988,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; NP601SH Build/S0018) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos 2
   os_family: Android
   browser_family: Chrome
@@ -1117,19 +1006,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 509SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos 3
   os_family: Android
   browser_family: Chrome
@@ -1137,19 +1024,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SH-02H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Compact
   os_family: Android
   browser_family: Chrome
@@ -1157,19 +1042,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 305SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Crystal
   os_family: Android
   browser_family: Chrome
@@ -1177,19 +1060,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 402SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Crystal X
   os_family: Android
   browser_family: Chrome
@@ -1197,19 +1078,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SH-04G Build/S6260; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Ever
   os_family: Android
   browser_family: Chrome
@@ -1217,19 +1096,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SH-02J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Ever
   os_family: Android
   browser_family: Chrome
@@ -1237,19 +1114,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SH-L02 Build/SB070) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos L2
   os_family: Android
   browser_family: Chrome
@@ -1257,7 +1132,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; SHL22 Build/S8202) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YJApp-ANDROID jp.co.yahoo.android.yjtop/3.15.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -1266,7 +1140,7 @@
     version: "3.15.1"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Phone SHL22
   os_family: Android
   browser_family: Unknown
@@ -1274,19 +1148,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ja-jp; SH-02E Build/SC050) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Phone Zeta
   os_family: Android
   browser_family: Android Browser
@@ -1294,19 +1166,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SH-01G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Phone Zeta
   os_family: Android
   browser_family: Chrome
@@ -1314,19 +1184,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SH-01H Build/S8250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Phone Zeta
   os_family: Android
   browser_family: Chrome
@@ -1334,19 +1202,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SH-04H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Phone Zeta
   os_family: Android
   browser_family: Chrome
@@ -1354,19 +1220,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 605SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R
   os_family: Android
   browser_family: Chrome
@@ -1374,19 +1238,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-03J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R
   os_family: Android
   browser_family: Chrome
@@ -1394,19 +1256,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R
   os_family: Android
   browser_family: Chrome
@@ -1414,19 +1274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHV41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R Compact
   os_family: Android
   browser_family: Chrome
@@ -1434,19 +1292,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 701SH Build/S0018; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R Compact
   os_family: Android
   browser_family: Chrome
@@ -1454,19 +1310,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-M09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R2
   os_family: Android
   browser_family: Chrome
@@ -1474,19 +1328,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R2
   os_family: Android
   browser_family: Chrome
@@ -1494,19 +1346,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; SH-03K Build/S128P)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R2
   os_family: Android
   browser_family: Android Browser
@@ -1514,19 +1364,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 706SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R2
   os_family: Android
   browser_family: Chrome
@@ -1534,19 +1382,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 803SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R2 Compact
   os_family: Android
   browser_family: Chrome
@@ -1554,19 +1400,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SH-03G Build/S3160; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R3
   os_family: Android
   browser_family: Chrome
@@ -1574,19 +1418,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SHV44) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R3
   os_family: Android
   browser_family: Chrome
@@ -1594,19 +1436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 808SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R3
   os_family: Android
   browser_family: Chrome
@@ -1614,19 +1454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-04L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R3
   os_family: Android
   browser_family: Chrome
@@ -1634,19 +1472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-51A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R5G
   os_family: Android
   browser_family: Chrome
@@ -1654,19 +1490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S
   os_family: Android
   browser_family: Chrome
@@ -1674,19 +1508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV40_u Build/S3050; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S
   os_family: Android
   browser_family: Chrome
@@ -1694,19 +1526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 702SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S Basic
   os_family: Android
   browser_family: Chrome
@@ -1714,19 +1544,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SHV33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S Mini
   os_family: Android
   browser_family: Chrome
@@ -1734,19 +1562,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHV38) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S Mini
   os_family: Android
   browser_family: Chrome
@@ -1754,19 +1580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; FS8010 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -1774,19 +1598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-M08) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -1794,19 +1616,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -1814,19 +1634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -1834,19 +1652,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV43) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -1854,19 +1670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SH-Z01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2 (C10)
   os_family: Android
   browser_family: Chrome
@@ -1874,19 +1688,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FS8032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3
   os_family: Android
   browser_family: Chrome
@@ -1894,19 +1706,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-02M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3
   os_family: Android
   browser_family: Chrome
@@ -1914,19 +1724,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SHV45) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3
   os_family: Android
   browser_family: Chrome
@@ -1934,19 +1742,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.1.1; FS8018 Build/NMF26X
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Mini
   os_family: Android
   browser_family: Android Browser
@@ -1954,19 +1760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 901SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Plus
   os_family: Android
   browser_family: Chrome
@@ -1974,19 +1778,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SHV46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Plus
   os_family: Android
   browser_family: Chrome
@@ -1994,19 +1796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SH-M05 Build/S5221) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Sense Lite
   os_family: Android
   browser_family: Chrome
@@ -2014,19 +1814,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SHV35 Build/S6020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos U
   os_family: Android
   browser_family: Chrome
@@ -2034,19 +1832,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-C02 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos V
   os_family: Android
   browser_family: Chrome
@@ -2054,19 +1850,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 502SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Xx2
   os_family: Android
   browser_family: Chrome
@@ -2074,19 +1868,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 503SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Xx2
   os_family: Android
   browser_family: Chrome
@@ -2094,19 +1886,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 506SH Build/S1006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Xx3
   os_family: Android
   browser_family: Chrome
@@ -2114,19 +1904,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 603SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Xx3 Mini
   os_family: Android
   browser_family: Chrome
@@ -2134,19 +1922,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-Z10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos zero
   os_family: Android
   browser_family: Chrome
@@ -2154,19 +1940,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 801SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos zero
   os_family: Android
   browser_family: Chrome
@@ -2174,19 +1958,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SHV36 Build/S3281; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Basio 2
   os_family: Android
   browser_family: Chrome
@@ -2194,19 +1976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TG-L900S Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Luna S
   os_family: Android
   browser_family: Chrome
@@ -2214,19 +1994,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 507SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Android One
   os_family: Android
   browser_family: Chrome
@@ -2234,19 +2012,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; S3-SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Android One S3
   os_family: Android
   browser_family: Chrome
@@ -2254,19 +2030,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; S5-SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Android One S5
   os_family: Android
   browser_family: Chrome
@@ -2274,19 +2048,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.0; FS8028 Build/NRD90M
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: R1S
   os_family: Android
   browser_family: Android Browser
@@ -2294,19 +2066,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; SH-06D Build/S7231) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: SH-06D
   os_family: Android
   browser_family: Android Browser
@@ -2314,19 +2084,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; SH-07D Build/S7190) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: SH-07D
   os_family: Android
   browser_family: Android Browser
@@ -2334,19 +2102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; SH-10D Build/S4040) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: SH-10D
   os_family: Android
   browser_family: Chrome
@@ -2354,19 +2120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SH837W Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: SH837W
   os_family: Android
   browser_family: Chrome
@@ -2376,13 +2140,12 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "4.2.19039"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: STX2
   os_family: Unknown
   browser_family: Opera
@@ -2390,19 +2153,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS8002 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Z2
   os_family: Android
   browser_family: Chrome
@@ -2410,19 +2171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SHV47) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Z2
   os_family: Android
   browser_family: Chrome
@@ -2430,19 +2189,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.0; FS8009 Build/NRD90M
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Z3
   os_family: Android
   browser_family: Android Browser
@@ -2450,19 +2207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Blackphone 2 Build/MOB31Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SJ
+    brand: Silent Circle
     model: Blackphone 2
   os_family: Android
   browser_family: Chrome
@@ -2470,19 +2225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; SELFIX_SLASH6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SL
+    brand: Selfix
     model: Slash 6
   os_family: Android
   browser_family: Chrome
@@ -2490,19 +2243,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; SELFIX VOYAGER-V45) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SL
+    brand: Selfix
     model: Voyager V45
   os_family: Android
   browser_family: Chrome
@@ -2510,19 +2261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; roar E80 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: Roar E80
   os_family: Android
   browser_family: Chrome
@@ -2530,19 +2279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; roar V20 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: Roar V20
   os_family: Android
   browser_family: Chrome
@@ -2550,19 +2297,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Symphony_W128) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: W128
   os_family: Android
   browser_family: Unknown
@@ -2570,19 +2315,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Symphony W68 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: W68
   os_family: Android
   browser_family: Android Browser
@@ -2590,19 +2333,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Symphony_W72) U2/1.0.0 UCBrowser/8.9.2.373 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.9.2.373"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: W72
   os_family: Android
   browser_family: Unknown
@@ -2610,19 +2351,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; bn-bd; Symphony W82 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: W82
   os_family: Android
   browser_family: Android Browser
@@ -2630,19 +2369,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SYMPHONY_W90 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SM
+    brand: Symphony
     model: W90
   os_family: Android
   browser_family: Android Browser
@@ -2650,19 +2387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H4433 Build/50.1.A.11.36) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: H4433
   os_family: Android
   browser_family: Chrome
@@ -2670,19 +2405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; J8170) AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2690,19 +2423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; J9110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2710,19 +2441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; J8110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2730,19 +2459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 802SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2750,19 +2477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-03L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2770,19 +2495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV40 Build/55.1.C.0.302; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1
   os_family: Android
   browser_family: Chrome
@@ -2790,19 +2513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I3113) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
@@ -2810,19 +2531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I3123) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
@@ -2830,19 +2549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I4113 Build/53.0.A.6.92; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10
   os_family: Android
   browser_family: Chrome
@@ -2850,19 +2567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I4193) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 Dual
   os_family: Android
   browser_family: Chrome
@@ -2870,19 +2585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; A001SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 II
   os_family: Android
   browser_family: Chrome
@@ -2890,19 +2603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; XQ-AU52) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 EdgA/45.07.4.5057
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "45.07.4.5057"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 II
   os_family: Android
   browser_family: Internet Explorer
@@ -2910,19 +2621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I4293) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -2930,19 +2639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I3223) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -2950,19 +2657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I4213) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -2970,19 +2675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 901SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5
   os_family: Android
   browser_family: Chrome
@@ -2990,19 +2693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5
   os_family: Android
   browser_family: Chrome
@@ -3010,19 +2711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; J8270) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5
   os_family: Android
   browser_family: Chrome
@@ -3030,19 +2729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-01M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5
   os_family: Android
   browser_family: Chrome
@@ -3050,19 +2747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; J8210 Build/55.1.A.9.75; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5
   os_family: Android
   browser_family: Chrome
@@ -3070,19 +2765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; J9210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5 Dual
   os_family: Android
   browser_family: Chrome
@@ -3090,19 +2783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 902SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 8
   os_family: Android
   browser_family: Chrome
@@ -3110,19 +2801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 8
   os_family: Android
   browser_family: Chrome
@@ -3130,19 +2819,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; SonySO-04E Build/10.3.1.B.0.224) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia A
   os_family: Android
   browser_family: Android Browser
@@ -3150,19 +2837,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; SO-04F Build/14.3.B.0.362) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia A2
   os_family: Android
   browser_family: Unknown
@@ -3170,19 +2855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SO-04G Build/23.5.B.0.303) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia A4
   os_family: Android
   browser_family: Chrome
@@ -3190,19 +2873,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Xperia Arc S Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Arc S
   os_family: Android
   browser_family: Android Browser
@@ -3210,19 +2891,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; ja-jp; SonyEricssonSO-02C Build/4.0.1.C.1.24) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco
   os_family: Android
   browser_family: Android Browser
@@ -3230,19 +2909,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; SonyEricssonSO-03D Build/6.0.A.5.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco HD
   os_family: Android
   browser_family: Android Browser
@@ -3250,19 +2927,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; LT26w Build/6.1.A.2.55) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco S
   os_family: Android
   browser_family: Android Browser
@@ -3270,19 +2945,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SonyEricssonLT26w Build/6.1.A.2.45) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco S
   os_family: Android
   browser_family: Android Browser
@@ -3290,19 +2963,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; SonyLT26w Build/6.2.B.1.96) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco S
   os_family: Android
   browser_family: Android Browser
@@ -3310,19 +2981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; LT26w Build/6.2.B.1.96) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia arco S
   os_family: Android
   browser_family: Chrome
@@ -3330,19 +2999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2305 Build/16.0.B.2.6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C
   os_family: Android
   browser_family: Chrome
@@ -3350,19 +3017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2304 Build/16.0.B.1.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C
   os_family: Android
   browser_family: Chrome
@@ -3370,7 +3035,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; S39h Build/16.0.A.0.47) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -3379,7 +3043,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C
   os_family: Android
   browser_family: Unknown
@@ -3387,19 +3051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2533 Build/19.2.A.0.344) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C3
   os_family: Android
   browser_family: Chrome
@@ -3407,19 +3069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2502 Build/19.2.A.0.383) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C3 Dual
   os_family: Android
   browser_family: Chrome
@@ -3427,19 +3087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E5306 Build/27.1.A.1.106) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4
   os_family: Android
   browser_family: Chrome
@@ -3447,19 +3105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E5353 Build/27.2.A.0.155) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4
   os_family: Android
   browser_family: Chrome
@@ -3467,19 +3123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E5303 Build/27.3.A.0.129) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4
   os_family: Android
   browser_family: Chrome
@@ -3487,19 +3141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E5343 Build/27.1.B.1.106) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4 Dual
   os_family: Android
   browser_family: Chrome
@@ -3507,19 +3159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E5363 Build/27.2.B.0.169) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4 Dual
   os_family: Android
   browser_family: Chrome
@@ -3527,19 +3177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E5333 Build/27.3.B.0.129) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C4 Dual
   os_family: Android
   browser_family: Chrome
@@ -3547,19 +3195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E5506 Build/29.0.A.0.161) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C5 Ultra
   os_family: Android
   browser_family: Chrome
@@ -3567,19 +3213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E5553 Build/29.1.A.0.101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C5 Ultra
   os_family: Android
   browser_family: Chrome
@@ -3587,19 +3231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E5563 Build/29.2.B.0.129) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C5 Ultra Dual
   os_family: Android
   browser_family: Chrome
@@ -3607,19 +3249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E5533 Build/29.2.B.0.122; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia C5 Ultra Dual
   os_family: Android
   browser_family: Chrome
@@ -3627,19 +3267,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; SonyC1505 Build/11.3.A.0.59) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3647,19 +3285,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-au; SonyC1504 Build/11.3.A.0.58) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3667,19 +3303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; SonyC1505 Build/11.3.A.2.13) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3687,19 +3321,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; SonyC1505v Build/11.3.A.2.13) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3707,19 +3339,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SonyC1504 Build/11.3.A.2.23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3727,19 +3357,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; SonyC1505-o Build/11.3.A.2.13) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Android Browser
@@ -3747,19 +3375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; C1504 Build/11.3.A.2.13) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Chrome
@@ -3767,7 +3393,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; C1505 Build/11.3.A.2.23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -3776,7 +3401,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: Android
   browser_family: Unknown
@@ -3784,19 +3409,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; C1505) U2/1.0.0 UCBrowser/8.8.1.359 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E
   os_family: GNU/Linux
   browser_family: Opera
@@ -3804,19 +3427,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SonyC1604 Build/11.3.A.1.39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E Dual
   os_family: Android
   browser_family: Android Browser
@@ -3824,19 +3445,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SonyC1605 Build/11.3.A.2.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E Dual
   os_family: Android
   browser_family: Android Browser
@@ -3844,19 +3463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; C1604 Build/11.3.A.1.39) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E Dual
   os_family: Android
   browser_family: Chrome
@@ -3864,19 +3481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; C1605 Build/11.3.A.1.39) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E Dual
   os_family: Android
   browser_family: Chrome
@@ -3884,19 +3499,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.1; en-US; C1605) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E Dual
   os_family: Android
   browser_family: Unknown
@@ -3904,19 +3517,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-nz; D2004 Build/20.0.A.1.21) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E1
   os_family: Android
   browser_family: Android Browser
@@ -3924,19 +3535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2005 Build/20.0.A.1.21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E1
   os_family: Android
   browser_family: Chrome
@@ -3944,19 +3553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2105 Build/20.0.B.0.68) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E1 Dual
   os_family: Android
   browser_family: Chrome
@@ -3964,19 +3571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2114 Build/20.0.B.0.85) AppleWebKit/537.36 (KHTML like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E1 Dual
   os_family: Android
   browser_family: Chrome
@@ -3984,19 +3589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2104 Build/20.1.B.0.64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.128 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.128"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E1 Dual
   os_family: Android
   browser_family: Chrome
@@ -4004,19 +3607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2203 Build/18.4.A.1.25) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3
   os_family: Android
   browser_family: Chrome
@@ -4024,19 +3625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2206 Build/18.4.C.0.25) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.122 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.122"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3
   os_family: Android
   browser_family: Chrome
@@ -4044,19 +3643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2243 Build/18.4.C.1.29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3
   os_family: Android
   browser_family: Chrome
@@ -4064,19 +3661,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; D2202 Build/18.4.A.1.25) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3
   os_family: Android
   browser_family: Unknown
@@ -4084,19 +3679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2212 Build/18.4.B.1.20) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 Mobile UCBrowser/3.4.1.483
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.4.1.483"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3 Dual
   os_family: Android
   browser_family: Unknown
@@ -4104,19 +3697,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; E3 Dual Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.9.7.1153 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1153"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E3 Dual
   os_family: Android
   browser_family: Unknown
@@ -4124,19 +3715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2105 Build/24.0.A.5.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4
   os_family: Android
   browser_family: Chrome
@@ -4144,19 +3733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2104 Build/24.0.A.1.34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4
   os_family: Android
   browser_family: Chrome
@@ -4164,19 +3751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2124 Build/24.0.B.5.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4
   os_family: Android
   browser_family: Chrome
@@ -4184,19 +3769,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-US; E2115 Build/24.0.B.5.14) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.10.0.796 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.10.0.796"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4
   os_family: Android
   browser_family: Unknown
@@ -4204,19 +3787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2006 Build/25.0.A.1.28) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4G
   os_family: Android
   browser_family: Chrome
@@ -4224,19 +3805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2053 Build/25.0.A.1.28) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4G
   os_family: Android
   browser_family: Chrome
@@ -4244,19 +3823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2003 Build/25.0.A.2.31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4G
   os_family: Android
   browser_family: Chrome
@@ -4264,19 +3841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2033 Build/25.0.B.2.31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4g Dual
   os_family: Android
   browser_family: Chrome
@@ -4284,19 +3859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; E2043 Build/25.0.B.2.35) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E4g Dual
   os_family: Android
   browser_family: Chrome
@@ -4304,19 +3877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3311 Build/37.0.A.1.105) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia E5
   os_family: Android
   browser_family: Chrome
@@ -4324,19 +3895,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; ST27I Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia go
   os_family: Android
   browser_family: Android Browser
@@ -4344,19 +3913,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; es-bo; ST27i Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia go
   os_family: Android
   browser_family: Android Browser
@@ -4364,19 +3931,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; th-th; ST27a Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia go
   os_family: Android
   browser_family: Android Browser
@@ -4384,19 +3949,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-za; SonyST27i Build/6.2.A.1.100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia go
   os_family: Android
   browser_family: Android Browser
@@ -4404,19 +3967,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyST27a Build/6.2.A.1.100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia go
   os_family: Android
   browser_family: Android Browser
@@ -4424,19 +3985,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; SO-04D Build/7.0.D.1.130) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YJApp-ANDROID jp.co.yahoo.android.ybrowser/1.4.0
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Yahoo! Japan Browser
-    short_name: YJ
     version: "1.4.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia GX
   os_family: Android
   browser_family: Chrome
@@ -4444,19 +4003,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LT28i Build/6.1.E.2.68) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4464,19 +4021,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; SonyEricssonLT28h Build/6.1.E.0.233) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4484,19 +4039,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; SonyEricssonLT28i Build/6.1.E.1.19) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4504,19 +4057,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyEricssonLT28at Build/6.1.C.1.105) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4524,19 +4075,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; LT28h Build/6.1.E.0.233) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4544,19 +4093,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; SonyLT28h Build/6.2.B.0.211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ion
   os_family: Android
   browser_family: Android Browser
@@ -4564,19 +4111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ie; ST26i Build/11.0.A.7.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia J
   os_family: Android
   browser_family: Android Browser
@@ -4584,19 +4129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; SonyST26i Build/11.0.A.7.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia J
   os_family: Android
   browser_family: Android Browser
@@ -4604,19 +4147,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyST26i-o Build/11.0.A.7.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia J
   os_family: Android
   browser_family: Android Browser
@@ -4624,19 +4165,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; th-th; ST26a Build/11.0.A.3.28) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia J
   os_family: Android
   browser_family: Android Browser
@@ -4644,19 +4183,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyST26a Build/11.2.A.0.21) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia J
   os_family: Android
   browser_family: Android Browser
@@ -4664,19 +4201,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyC2104 Build/15.0.A.1.36) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L
   os_family: Android
   browser_family: Android Browser
@@ -4684,19 +4219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2104 Build/15.3.A.1.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L
   os_family: Android
   browser_family: Chrome
@@ -4704,19 +4237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2105 Build/15.3.A.1.14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L
   os_family: Android
   browser_family: Chrome
@@ -4724,19 +4255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3313 Build/43.0.A.2.27) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L1
   os_family: Android
   browser_family: Chrome
@@ -4744,19 +4273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3311 Build/43.0.A.3.39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L1
   os_family: Android
   browser_family: Chrome
@@ -4764,19 +4291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3312 Build/43.0.A.4.46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L1 Dual
   os_family: Android
   browser_family: Chrome
@@ -4784,19 +4309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; H3311 Build/49.0.A.4.55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L2
   os_family: Android
   browser_family: Chrome
@@ -4804,19 +4327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; H3321) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L2
   os_family: Android
   browser_family: Chrome
@@ -4824,19 +4345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; H4311 Build/49.0.A.2.62) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L2 Dual
   os_family: Android
   browser_family: Chrome
@@ -4844,19 +4363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; H4331 Build/49.0.A.6.46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L2 Dual
   os_family: Android
   browser_family: Chrome
@@ -4864,19 +4381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; I3312) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L3
   os_family: Android
   browser_family: Chrome
@@ -4884,19 +4399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; I4332) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L3 Dual
   os_family: Android
   browser_family: Chrome
@@ -4904,19 +4417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; I4312 Build/54.0.A.5.85; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 YandexSearch/7.21
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L3 Dual
   os_family: Android
   browser_family: Chrome
@@ -4924,19 +4435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XQ-AD51) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia L4
   os_family: Android
   browser_family: Chrome
@@ -4944,19 +4453,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-be; SonyC1905 Build/15.1.A.1.9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M
   os_family: Android
   browser_family: Android Browser
@@ -4964,19 +4471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyC1904 Build/15.1.C.1.17) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M
   os_family: Android
   browser_family: Android Browser
@@ -4984,19 +4489,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; nl-be; C1905 Build/15.1.C.2.8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M
   os_family: Android
   browser_family: Android Browser
@@ -5004,19 +4507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; C1904 Build/15.1.C.2.8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M
   os_family: Android
   browser_family: Chrome
@@ -5024,19 +4525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2005 Build/15.2.A.1.12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M Dual
   os_family: Android
   browser_family: Chrome
@@ -5044,19 +4543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C2004 Build/15.2.A.2.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M Dual
   os_family: Android
   browser_family: Chrome
@@ -5064,19 +4561,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.3; D2305 Build/18.0.A.1.30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36 '
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2
   os_family: Android
   browser_family: Chrome
@@ -5084,19 +4579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2306 Build/18.0.C.1.15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2
   os_family: Android
   browser_family: Chrome
@@ -5104,19 +4597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2303 Build/18.0.C.1.13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2
   os_family: Android
   browser_family: Chrome
@@ -5124,19 +4615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D2403 Build/18.3.C.0.39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2 Aqua
   os_family: Android
   browser_family: Chrome
@@ -5144,7 +4633,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; D2406 Build/18.3.C.0.40) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FBAN/FB4A;FBAV/22.0.0.15.13;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -5153,7 +4641,7 @@
     version: "22.0.0.15.13"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2 Aqua
   os_family: Android
   browser_family: Unknown
@@ -5161,19 +4649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D2302 Build/18.0.B.1.23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M2 Dual
   os_family: Android
   browser_family: Chrome
@@ -5181,19 +4667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E2353 Build/26.1.A.3.111) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua
   os_family: Android
   browser_family: Chrome
@@ -5201,19 +4685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E2333 Build/26.1.B.3.109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua
   os_family: Android
   browser_family: Chrome
@@ -5221,19 +4703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E2306 Build/26.1.A.3.111; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua
   os_family: Android
   browser_family: Chrome
@@ -5241,7 +4721,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.0; E2303 Build/26.1.A.2.167; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/54.0.0.23.62;]'
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
@@ -5250,7 +4729,7 @@
     version: "54.0.0.23.62"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua
   os_family: Android
   browser_family: Unknown
@@ -5258,19 +4737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; E2363 Build/26.1.B.3.109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua Dual
   os_family: Android
   browser_family: Chrome
@@ -5278,19 +4755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; E2312 Build/26.3.B.0.131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M4 Aqua Dual
   os_family: Android
   browser_family: Chrome
@@ -5298,19 +4773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E5603 Build/30.2.A.0.100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M5
   os_family: Android
   browser_family: Chrome
@@ -5318,19 +4791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E5633 Build/30.1.B.1.55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia M5 Dual
   os_family: Android
   browser_family: Chrome
@@ -5338,19 +4809,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-ch; Xperia Mini Pro Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Mini Pro
   os_family: Android
   browser_family: Android Browser
@@ -5358,19 +4827,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; SonyST23i Build/11.0.A.5.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia miro
   os_family: Android
   browser_family: Android Browser
@@ -5378,19 +4845,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; bg-bg; ST23i Build/11.0.A.5.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia miro
   os_family: Android
   browser_family: Android Browser
@@ -5398,19 +4863,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-mx; SonyST23a Build/11.0.A.5.8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia miro
   os_family: Android
   browser_family: Android Browser
@@ -5418,19 +4881,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; SonyST23iv Build/11.0.A.5.8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia miro
   os_family: Android
   browser_family: Android Browser
@@ -5438,19 +4899,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; ST23i Build/11.0.A.5.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia miro
   os_family: Android
   browser_family: Android Browser
@@ -5458,19 +4917,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; fr-fr; Xperia Neo V Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Neo V
   os_family: Android
   browser_family: Android Browser
@@ -5478,19 +4935,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-in; LT22i Build/6.0.B.1.564) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Android Browser
@@ -5498,19 +4953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-be; SonyEricssonLT22i-o Build/6.0.B.3.187) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Android Browser
@@ -5518,19 +4971,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-ch; SonyEricssonLT22i Build/6.0.B.1.564) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Android Browser
@@ -5538,19 +4989,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; LT22i Build/6.1.1.B.1.75) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Android Browser
@@ -5558,19 +5007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LT22i Build/6.1.1.B.1.54) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Chrome
@@ -5578,19 +5025,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; es-mx; SonyLT22i Build/6.2.A.1.100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Android Browser
@@ -5598,19 +5043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xperia P Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Chrome
@@ -5618,19 +5061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Chrome
@@ -5638,19 +5079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-gb; LT26i Build/6.0.A.3.62) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5658,19 +5097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-be; SonyEricssonLT26i Build/6.0.A.3.73) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5678,19 +5115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; SonyEricssonLT26i-o Build/6.0.A.3.75) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5698,19 +5133,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-hk; LT26i Build/6.1.A.2.45) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5718,19 +5151,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-be; SonyLT26iv Build/6.2.B.1.96) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5738,19 +5169,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ch; SonyLT26i Build/6.2.B.1.96) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Android Browser
@@ -5758,19 +5187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xperia S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Chrome
@@ -5778,19 +5205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Chrome
@@ -5798,19 +5223,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; LT26ii Build/6.1.A.2.50) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SL
   os_family: Android
   browser_family: Android Browser
@@ -5818,19 +5241,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.2; en-US; LT26ii) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SL
   os_family: Android
   browser_family: Unknown
@@ -5838,19 +5259,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyC5306 Build/12.0.A.1.284) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Android Browser
@@ -5858,19 +5277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; SonyC5303 Build/12.0.A.1.257) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Android Browser
@@ -5878,19 +5295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; C5306 Build/12.0.A.1.284) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Chrome
@@ -5898,19 +5313,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; en-US; C5303) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Unknown
@@ -5918,19 +5331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C5303 Build/12.1.A.0.266) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Chrome
@@ -5938,19 +5349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C5302 Build/12.1.A.1.201) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Chrome
@@ -5958,19 +5367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia SP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Chrome
@@ -5978,19 +5385,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; SO-05D Build/7.0.D.1.117) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SX
   os_family: Android
   browser_family: Android Browser
@@ -5998,19 +5403,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; LT30p Build/7.0.A.1.303) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T
   os_family: Android
   browser_family: Android Browser
@@ -6018,19 +5421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyLT30p Build/7.0.A.1.303) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T
   os_family: Android
   browser_family: Android Browser
@@ -6038,19 +5439,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyLT30p-o Build/7.0.A.1.303) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T
   os_family: Android
   browser_family: Android Browser
@@ -6058,19 +5457,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; LT30p Build/9.1.A.1.141) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 Maxthon/4.1.5.2000
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.1.5.2000"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T
   os_family: Android
   browser_family: Unknown
@@ -6078,19 +5475,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyLT30a Build/9.1.A.1.140) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T LTE
   os_family: Android
   browser_family: Android Browser
@@ -6098,7 +5493,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; LT30a Build/9.1.A.0.489) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -6107,7 +5501,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T LTE
   os_family: Android
   browser_family: Unknown
@@ -6115,19 +5509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D5106 Build/18.1.A.1.13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T3
   os_family: Android
   browser_family: Chrome
@@ -6135,19 +5527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D5103 Build/18.1.A.0.16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T3
   os_family: Android
   browser_family: Chrome
@@ -6155,19 +5545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D5102 Build/18.2.A.1.14) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia T3
   os_family: Android
   browser_family: Chrome
@@ -6175,19 +5563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ie; ST21i Build/11.0.A.4.22) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo
   os_family: Android
   browser_family: Android Browser
@@ -6195,19 +5581,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SonyST21i-o Build/11.0.A.4.22) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo
   os_family: Android
   browser_family: Android Browser
@@ -6215,19 +5599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; SonyST21i Build/11.0.A.0.16) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo
   os_family: Android
   browser_family: Android Browser
@@ -6235,19 +5617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ST21i Build/11.0.A.4.22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo
   os_family: Android
   browser_family: Chrome
@@ -6255,19 +5635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; SonyST21i2 Build/11.0.A.6.8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo dual
   os_family: Android
   browser_family: Android Browser
@@ -6275,19 +5653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SonyST21a2 Build/11.0.A.1.12) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo dual
   os_family: Android
   browser_family: Android Browser
@@ -6295,19 +5671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; hu-hu; ST21i2 Build/11.0.A.6.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia tipo dual
   os_family: Android
   browser_family: Android Browser
@@ -6315,19 +5689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; LT29i Build/9.2.A.1.199) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia TX
   os_family: Android
   browser_family: Chrome
@@ -6335,19 +5707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia TX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia TX
   os_family: Android
   browser_family: Chrome
@@ -6355,19 +5725,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-au; ST25a Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6375,19 +5743,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; es-es; SonyEricssonST25i-o Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6395,19 +5761,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-be; SonyEricssonST25iv Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6415,19 +5779,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; it-it; SonyEricssonST25i Build/6.0.B.3.184) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6435,19 +5797,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; ST25i Build/6.0.B.3.188) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Unknown
@@ -6455,19 +5815,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-co; ST25a Build/6.1.1.B.1.54) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6475,19 +5833,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-pt; ST25i Build/6.1.1.B.1.54) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6495,19 +5851,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-; SonyST25i Build/6.2.A.1.100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia U
   os_family: Android
   browser_family: Android Browser
@@ -6515,7 +5869,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; SOL22 Build/10.3.1.D.0.257) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YJApp-ANDROID jp.co.yahoo.android.yjtop/3.15.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -6524,7 +5877,7 @@
     version: "3.15.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia UL
   os_family: Android
   browser_family: Unknown
@@ -6532,19 +5885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; SonyLT25i Build/9.1.A.1.140) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia V
   os_family: Android
   browser_family: Android Browser
@@ -6552,19 +5903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; LT25i Build/9.1.A.1.140) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia V
   os_family: Android
   browser_family: Chrome
@@ -6572,19 +5921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xperia V Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia V
   os_family: Android
   browser_family: Chrome
@@ -6592,19 +5939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia V
   os_family: Android
   browser_family: Chrome
@@ -6612,19 +5957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F5121 Build/34.0.A.2.292) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X
   os_family: Android
   browser_family: Chrome
@@ -6632,19 +5975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F5321 Build/34.1.A.3.49) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Compact
   os_family: Android
   browser_family: Chrome
@@ -6652,19 +5993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SO-02J Build/34.4.B.0.252) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Compact
   os_family: Android
   browser_family: Chrome
@@ -6672,19 +6011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; F5122 Build/34.3.A.0.194) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Dual
   os_family: Android
   browser_family: Chrome
@@ -6692,19 +6029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SOV33 Build/35.0.D.0.326) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Performance
   os_family: Android
   browser_family: Chrome
@@ -6712,19 +6047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SO-04H Build/35.0.B.2.360) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Performance
   os_family: Android
   browser_family: Chrome
@@ -6732,19 +6065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 502SO Build/39.2.D.0.232; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Performance
   os_family: Android
   browser_family: Android Browser
@@ -6752,19 +6083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; F8131 Build/41.2.A.7.8; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Performance
   os_family: Android
   browser_family: Chrome
@@ -6772,19 +6101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; F8132 Build/41.2.A.7.8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia X Performance Dual
   os_family: Android
   browser_family: Chrome
@@ -6792,19 +6119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3111 Build/33.2.A.2.35) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA
   os_family: Android
   browser_family: Chrome
@@ -6812,19 +6137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3113 Build/33.2.A.3.81) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA
   os_family: Android
   browser_family: Chrome
@@ -6832,19 +6155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3115 Build/33.2.A.2.16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA
   os_family: Android
   browser_family: Chrome
@@ -6852,19 +6173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F3112 Build/33.3.A.0.131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Dual
   os_family: Android
   browser_family: Chrome
@@ -6872,19 +6191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F3116 Build/33.3.A.0.131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Dual
   os_family: Android
   browser_family: Chrome
@@ -6892,19 +6209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3213 Build/36.0.A.1.100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Ultra
   os_family: Android
   browser_family: Chrome
@@ -6912,19 +6227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F3211 Build/36.0.A.1.111) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Ultra
   os_family: Android
   browser_family: Chrome
@@ -6932,19 +6245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F3215 Build/36.1.A.0.182) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Ultra
   os_family: Android
   browser_family: Chrome
@@ -6952,19 +6263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F3216 Build/36.1.A.0.179) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Ultra Dual
   os_family: Android
   browser_family: Chrome
@@ -6972,19 +6281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F3212 Build/36.1.A.0.182) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA Ultra Dual
   os_family: Android
   browser_family: Chrome
@@ -6992,19 +6299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3116 Build/40.0.A.5.66) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1
   os_family: Android
   browser_family: Chrome
@@ -7012,19 +6317,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; G3123 Build/40.0.A.5.66) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile '
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1
   os_family: Android
   browser_family: Chrome
@@ -7032,19 +6335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3423 Build/48.0.A.1.66) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Plus
   os_family: Android
   browser_family: Chrome
@@ -7052,19 +6353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3412 Build/48.0.A.1.131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Plus
   os_family: Android
   browser_family: Chrome
@@ -7072,19 +6371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; G3416 Build/48.1.A.2.21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Plus
   os_family: Android
   browser_family: Chrome
@@ -7092,19 +6389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; G3421) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Plus
   os_family: Android
   browser_family: Chrome
@@ -7112,19 +6407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3426 Build/48.0.A.1.131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Plus Dual
   os_family: Android
   browser_family: Chrome
@@ -7132,19 +6425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G3221 Build/42.0.A.1.90; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA1 Ultra
   os_family: Android
   browser_family: Chrome
@@ -7152,19 +6443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H3133 Build/50.1.A.13.83) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2
   os_family: Android
   browser_family: Chrome
@@ -7172,19 +6461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H3113 Build/50.1.A.5.59) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2
   os_family: Android
   browser_family: Chrome
@@ -7192,19 +6479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H3123) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2
   os_family: Android
   browser_family: Chrome
@@ -7212,19 +6497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H4113 Build/50.1.A.5.59) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Dual
   os_family: Android
   browser_family: Chrome
@@ -7232,19 +6515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H4133 Build/50.1.A.10.40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Dual
   os_family: Android
   browser_family: Chrome
@@ -7252,19 +6533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H4413) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Plus Dual
   os_family: Android
   browser_family: Chrome
@@ -7272,19 +6551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H4493) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Plus Dual
   os_family: Android
   browser_family: Chrome
@@ -7292,19 +6569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H4213 Build/50.1.A.5.59) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Ultra
   os_family: Android
   browser_family: Chrome
@@ -7312,19 +6587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H3223 Build/50.1.A.10.40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XA2 Ultra
   os_family: Android
   browser_family: Chrome
@@ -7332,19 +6605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F8331 Build/39.0.A.1.250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ
   os_family: Android
   browser_family: Chrome
@@ -7352,19 +6623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 601SO Build/39.0.D.1.25) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ
   os_family: Android
   browser_family: Chrome
@@ -7372,19 +6641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F8332 Build/39.0.A.1.250; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ
   os_family: Android
   browser_family: Chrome
@@ -7392,19 +6659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SO-01J Build/39.2.B.0.288) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ
   os_family: Android
   browser_family: Chrome
@@ -7412,19 +6677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SOV34 Build/41.3.C.1.120) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ
   os_family: Android
   browser_family: Chrome
@@ -7432,19 +6695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; G8141 Build/45.0.A.1.244) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ Premium
   os_family: Android
   browser_family: Chrome
@@ -7452,19 +6713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SO-04J Build/45.0.B.2.143) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ Premium
   os_family: Android
   browser_family: Chrome
@@ -7472,19 +6731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SO-04K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ Premium
   os_family: Android
   browser_family: Chrome
@@ -7492,19 +6749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 701SO Build/47.1.D.9.18) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1
   os_family: Android
   browser_family: Chrome
@@ -7512,19 +6767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SOV36 Build/47.1.C.9.34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1
   os_family: Android
   browser_family: Chrome
@@ -7532,19 +6785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; G8342 Build/47.1.A.12.235; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1
   os_family: Android
   browser_family: Chrome
@@ -7552,19 +6803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SO-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1
   os_family: Android
   browser_family: Chrome
@@ -7572,19 +6821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SO-02K Build/47.1.F.1.59) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1 Compact
   os_family: Android
   browser_family: Chrome
@@ -7592,19 +6839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; G8441 Build/47.1.A.5.51) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 OPR/43.0.
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ1 Compact
   os_family: Android
   browser_family: Opera
@@ -7612,19 +6857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H8216 Build/51.1.A.2.183) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7632,19 +6875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H8324 Build/51.1.A.4.225) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7652,19 +6893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SOV37 Build/51.1.C.0.374) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7672,19 +6911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H8314 Build/51.1.A.11.51) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7692,19 +6929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H8296) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7712,19 +6947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 702SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7732,19 +6965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-03K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7752,19 +6983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H8276 Build/51.1.A.3.159) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2
   os_family: Android
   browser_family: Chrome
@@ -7772,19 +7001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-05K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2 Compact
   os_family: Android
   browser_family: Chrome
@@ -7792,19 +7019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; H8266 Build/51.1.A.2.213) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2 Dual
   os_family: Android
   browser_family: Chrome
@@ -7812,19 +7037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H8166) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2 Premium Dual
   os_family: Android
   browser_family: Chrome
@@ -7832,19 +7055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV38) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ2 Premium Dual
   os_family: Android
   browser_family: Chrome
@@ -7852,19 +7073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H8416 Build/52.0.A.1.220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7872,19 +7091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H9436) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7892,19 +7109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; H9493) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7912,19 +7127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SO-01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7932,19 +7145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 801SO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7952,19 +7163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZ3
   os_family: Android
   browser_family: Chrome
@@ -7972,19 +7181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; G8232 Build/41.2.A.0.235) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZs
   os_family: Android
   browser_family: Chrome
@@ -7992,19 +7199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; G8231 Build/41.2.A.0.235) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZs
   os_family: Android
   browser_family: Chrome
@@ -8012,19 +7217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SOV35 Build/41.2.C.0.251) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZs
   os_family: Android
   browser_family: Chrome
@@ -8032,19 +7235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SO-03J Build/41.2.B.0.265) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZs
   os_family: Android
   browser_family: Chrome
@@ -8052,19 +7253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 602SO Build/41.2.D.0.249) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia XZs
   os_family: Android
   browser_family: Chrome
@@ -8072,19 +7271,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyC6616 Build/10.1.1.A.1.319) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Android Browser
@@ -8092,19 +7289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; C6606 Build/10.1.1.B.0.166) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -8112,7 +7307,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ja-jp; SO-02E Build/10.1.D.0.343) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -8121,7 +7315,7 @@
     version: "3.4.16.1149292"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Unknown
@@ -8129,19 +7323,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; en-US; C6603) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Unknown
@@ -8149,19 +7341,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-gb; SonyC6603 Build/10.4.B.0.569) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Android Browser
@@ -8169,19 +7359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C6603 Build/10.4.B.0.569) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -8189,19 +7377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C6616 Build/10.4.B.0.569) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -8209,19 +7395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C6602 Build/10.4.1.B.0.101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -8229,19 +7413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -8249,19 +7431,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; SonyC6903 Build/14.1.G.1.518) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Android Browser
@@ -8269,19 +7449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C6903 Build/14.1.G.1.518) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8289,19 +7467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SO-01F Build/14.1.H.0.542) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8309,19 +7485,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-ca; C6906 Build/14.2.A.0.290) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.16
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.16"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Android Browser
@@ -8329,19 +7503,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-ca; SonyC6906 Build/14.2.A.0.290) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Android Browser
@@ -8349,19 +7521,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; L39h Build/14.2.A.1.136) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Android Browser
@@ -8369,7 +7539,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; C6916 Build/14.2.C.0.159) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ARM
   client:
@@ -8378,7 +7547,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Unknown
@@ -8386,19 +7555,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; ja-jp; SonySO-02F Build/14.3.B.0.310) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Android Browser
@@ -8406,19 +7573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C6902 Build/14.3.A.0.681) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8426,19 +7591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C6943 Build/14.3.A.0.681) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8446,19 +7609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xperia Z1 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8466,19 +7627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SO-02F Build/14.3.B.0.288) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1
   os_family: Android
   browser_family: Chrome
@@ -8486,19 +7645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; D5503 Build/14.2.A.1.114) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1 Compact
   os_family: Android
   browser_family: Chrome
@@ -8506,19 +7663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xperia Z1 Compact Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1 Compact
   os_family: Android
   browser_family: Chrome
@@ -8526,19 +7681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z1 Compact) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1 Compact
   os_family: Android
   browser_family: Chrome
@@ -8546,19 +7699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D6502 Build/17.1.1.A.0.402) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z2
   os_family: Android
   browser_family: Chrome
@@ -8566,19 +7717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; D6503 Build/17.1.A.2.55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z2
   os_family: Android
   browser_family: Chrome
@@ -8586,19 +7735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SO-03F Build/17.1.1.B.3.195) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z2
   os_family: Android
   browser_family: Chrome
@@ -8606,19 +7753,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; pt-br; D6543 Build/17.1.A.2.36) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z2
   os_family: Android
   browser_family: Unknown
@@ -8626,19 +7771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; D6563 Build/23.4.A.1.232) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z2a
   os_family: Android
   browser_family: Chrome
@@ -8646,19 +7789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; D6653 Build/23.0.A.2.93) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8666,19 +7807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; D6603 Build/23.0.A.2.93) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8686,19 +7825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SO-01G Build/23.0.B.1.38) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8706,19 +7843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SOL26 Build/23.1.G.2.244) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8726,19 +7861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 401SO Build/23.1.F.0.464) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8746,19 +7879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; D6616 Build/23.1.C.0.399; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8766,19 +7897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; D6646 Build/23.4.A.1.232) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8786,19 +7915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; D6643) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3
   os_family: Android
   browser_family: Chrome
@@ -8806,19 +7933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; D5803 Build/23.0.A.2.105) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -8826,19 +7951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; D5833 Build/23.0.1.A.5.77) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -8846,19 +7969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SO-02G Build/23.0.B.1.38) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 NaverMatome-Android/4.0.6
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -8866,19 +7987,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; en-US; D6683 Build/23.1.2.E.0.13) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.2.1188 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3 Dual
   os_family: Android
   browser_family: Unknown
@@ -8886,19 +8005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; D6633 Build/23.5.A.1.291) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3 Dual
   os_family: Android
   browser_family: Chrome
@@ -8906,19 +8023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; E6553 Build/28.0.A.8.251) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3+
   os_family: Android
   browser_family: Chrome
@@ -8926,19 +8041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; E6533 Build/32.4.A.0.160) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3+
   os_family: Android
   browser_family: Chrome
@@ -8946,19 +8059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; D6708 Build/23.1.D.0.509) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z3v
   os_family: Android
   browser_family: Chrome
@@ -8966,19 +8077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 402SO Build/32.1.D.0.419) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -8986,19 +8095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SO-03G Build/32.3.D.0.132) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -9006,19 +8113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SOV31 Build/32.3.C.0.336) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -9026,19 +8131,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; E6508 Build/28.0.A.7.27) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/47.0.2526.76 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z4v
   os_family: Android
   browser_family: Chrome
@@ -9046,19 +8149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 501SO Build/32.1.D.0.349) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5
   os_family: Android
   browser_family: Chrome
@@ -9066,19 +8167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; E6653 Build/32.2.A.0.253) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5
   os_family: Android
   browser_family: Chrome
@@ -9086,19 +8185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SO-01H Build/32.3.E.0.136) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5
   os_family: Android
   browser_family: Chrome
@@ -9106,19 +8203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SOV32 Build/32.3.C.0.403; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 MxBrowser/4.5.10.1300
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.5.10.1300"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5
   os_family: Android
   browser_family: Unknown
@@ -9126,19 +8221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; E6603 Build/32.4.A.0.160) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5
   os_family: Android
   browser_family: Chrome
@@ -9146,19 +8239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E5803 Build/32.0.A.4.11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Compact
   os_family: Android
   browser_family: Chrome
@@ -9166,19 +8257,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; SO-02H Build/32.1.F.1.75)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Compact
   os_family: Android
   browser_family: Android Browser
@@ -9186,19 +8275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; E6633 Build/32.2.A.0.253) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Dual
   os_family: Android
   browser_family: Chrome
@@ -9206,19 +8293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6883 Build/32.0.A.6.115; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Premium
   os_family: Android
   browser_family: Chrome
@@ -9226,19 +8311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; E6853 Build/32.2.A.0.253) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36 4473
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Premium
   os_family: Android
   browser_family: Chrome
@@ -9246,7 +8329,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SO-03H Build/32.3.E.0.140; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 Line/8.3.1/IAB
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -9255,7 +8337,7 @@
     version: "8.3.1"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Premium
   os_family: Android
   browser_family: Unknown
@@ -9263,19 +8345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; E6833 Build/32.4.A.0.160) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z5 Premium Dual
   os_family: Android
   browser_family: Chrome
@@ -9283,19 +8363,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ca; SonyC6506 Build/10.1.A.1.395) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Android Browser
@@ -9303,19 +8381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C6502 Build/10.3.1.A.2.67) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Chrome
@@ -9323,19 +8399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; C6506 Build/10.3.A.0.423) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Chrome
@@ -9343,19 +8417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C6503 Build/10.4.1.B.0.101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Chrome
@@ -9363,19 +8435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia ZL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Chrome
@@ -9383,19 +8453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; C5502 Build/10.4.1.B.0.101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZR
   os_family: Android
   browser_family: Chrome
@@ -9403,19 +8471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; C5503 Build/10.6.A.0.454) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZR
   os_family: Android
   browser_family: Chrome
@@ -9425,7 +8491,7 @@
   client: null
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: M5364
   os_family: Unknown
   browser_family: Unknown
@@ -9433,13 +8499,12 @@
   user_agent: SpiceM5395/MTK Release/01.01.2012 Browser/wap2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: M5395
   os_family: Real-time OS
   browser_family: Unknown
@@ -9447,19 +8512,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; Spice Mi-349) U2/1.0.0 UCBrowser/9.3.2.349 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.2.349"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: Mi-349
   os_family: Android
   browser_family: Unknown
@@ -9467,19 +8530,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.9; en-US; Spice_Mi-422) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: Mi-422
   os_family: Android
   browser_family: Unknown
@@ -9487,19 +8548,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Spice Mi-502 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: Mi-502
   os_family: Android
   browser_family: Android Browser
@@ -9507,19 +8566,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SpiceMI-520 Build/SpiceMi520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SP
+    brand: Spice
     model: MI-520
   os_family: Android
   browser_family: Chrome
@@ -9527,19 +8584,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; ru-ru; ACTOMA ACE Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.85 Mobile Safari/537.36 XiaoMi/MiuiBrowser/8.1.4
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "8.1.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Actoma Ace
   os_family: Android
   browser_family: Android Browser
@@ -9547,19 +8602,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SANTIN ANT.W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: ANT.W
   os_family: Android
   browser_family: Chrome
@@ -9567,19 +8620,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.4; SANTIN #Armor) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Armor
   os_family: Android
   browser_family: Chrome
@@ -9587,19 +8638,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BiTBiZ_V58 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: BiTBiZ V58
   os_family: Android
   browser_family: Chrome
@@ -9607,19 +8656,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; SANTIN #Candy U7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Candy U7
   os_family: Android
   browser_family: Chrome
@@ -9627,19 +8674,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Candy U7 Pro Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Candy U7 Pro
   os_family: Android
   browser_family: Chrome
@@ -9647,19 +8692,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; SANTIN #Dante) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Dante
   os_family: Android
   browser_family: Chrome
@@ -9667,19 +8710,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DREAMPLUS03A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Dream Plus 03A
   os_family: Android
   browser_family: Chrome
@@ -9687,19 +8728,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SANTIN GALAZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Galaz
   os_family: Android
   browser_family: Chrome
@@ -9707,19 +8746,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN GreenOrange Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Green Orange
   os_family: Android
   browser_family: Chrome
@@ -9727,19 +8764,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN halove) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Halove
   os_family: Android
   browser_family: Chrome
@@ -9747,19 +8782,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN JS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: JS
   os_family: Android
   browser_family: Chrome
@@ -9767,19 +8800,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN monica) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Monica
   os_family: Android
   browser_family: Chrome
@@ -9787,19 +8818,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; Santin_N1 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: N1
   os_family: Android
   browser_family: Chrome
@@ -9807,19 +8836,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SANTIN N3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: N3
   os_family: Android
   browser_family: Chrome
@@ -9827,19 +8854,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; SANTIN NEWDUN AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Newdun
   os_family: Android
   browser_family: Chrome
@@ -9847,19 +8872,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN POWER Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: Power
   os_family: Android
   browser_family: Chrome
@@ -9867,19 +8890,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN S6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: S6
   os_family: Android
   browser_family: Chrome
@@ -9887,19 +8908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN V9 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36 OPT/2.1
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Touch
-    short_name: OO
     version: "2.1"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: V9
   os_family: Android
   browser_family: Opera
@@ -9907,19 +8926,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SANTIN YSL-Y7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SQ
+    brand: Santin
     model: YSL-Y7
   os_family: Android
   browser_family: Chrome
@@ -9927,19 +8944,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SCHR9GR Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SS
+    brand: SWISSMOBILITY
     model: SCHON R9
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-15.yml
+++ b/Tests/fixtures/smartphone-15.yml
@@ -3,19 +3,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; es-LA; Sky_3.5) U2/1.0.0 UCBrowser/9.1.1.420 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.1.420"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: "3.5"
   os_family: Android
   browser_family: Unknown
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SKY 4.0D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: 4.0D
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SKY 4.5LM Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: 4.5LM
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0(Linux; Android 7.0; SKY 5.0LM Build/NRD90M)AppleWebKit/537.36(KHTML, like Gecko)Chrome/64.0.3282.137MobileSafari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: 5.0LM
   os_family: Android
   browser_family: Chrome
@@ -83,7 +75,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; Sky 5.5Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/45.0.0.38.146;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -92,7 +83,7 @@
     version: "45.0.0.38.146"
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: 5.5Q
   os_family: Android
   browser_family: Unknown
@@ -100,19 +91,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; Sky_7.0W) U2/1.0.0 UCBrowser/10.7.9.856 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.9.856"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: 7.0W
   os_family: Android
   browser_family: Unknown
@@ -120,19 +109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elite 5.0M Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Elite 5.0M
   os_family: Android
   browser_family: Chrome
@@ -140,19 +127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elite_5_5_Octa Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Elite 5.5 Octa
   os_family: Android
   browser_family: Chrome
@@ -160,19 +145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elite 5.5L+ Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Elite 5.5L+
   os_family: Android
   browser_family: Chrome
@@ -180,19 +163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Elite 6.0L Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Elite 6.0L
   os_family: Android
   browser_family: Chrome
@@ -200,19 +181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Fuego 4.0T Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Fuego 4.0T
   os_family: Android
   browser_family: Chrome
@@ -220,19 +199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Fuego 5.0+ Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Fuego 5.0+
   os_family: Android
   browser_family: Chrome
@@ -240,19 +217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Platinum_5.0M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Platinum 5.0M
   os_family: Android
   browser_family: Chrome
@@ -260,19 +235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Platinum_M5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SW
+    brand: Sky
     model: Platinum 5.0M
   os_family: Android
   browser_family: Chrome
@@ -280,19 +253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; Android edition by sfr STARADDICT Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: Staraddict
   os_family: Android
   browser_family: Android Browser
@@ -300,19 +271,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Smartphone Android by SFR STARADDICT II Build/IceCreamSandwich) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: Staraddict 2
   os_family: Android
   browser_family: Android Browser
@@ -320,19 +289,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; STARADDICT II Plus Build/GXI_ZTEV1.0.0B02) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: Staraddict 2 Plus
   os_family: Android
   browser_family: Android Browser
@@ -340,19 +307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; STARADDICT 4 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: Staraddict 4
   os_family: Android
   browser_family: Chrome
@@ -360,19 +325,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; Android Edition Starnaute Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarNaute
   os_family: Android
   browser_family: Android Browser
@@ -380,19 +343,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; STARNAUTE II Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarNaute 2
   os_family: Android
   browser_family: Android Browser
@@ -400,19 +361,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; Starshine Build/HuaweiU8180) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarShine
   os_family: Android
   browser_family: Android Browser
@@ -420,19 +379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; STARSHINE II Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarShine 2
   os_family: Android
   browser_family: Android Browser
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; Android Edition StarText Build/V1.0.0B06) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarText
   os_family: Android
   browser_family: Android Browser
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; STARTEXT II Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, comme Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarText 2
   os_family: Android
   browser_family: Android Browser
@@ -480,19 +433,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; Android Edition StarTrail Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarTrail
   os_family: Android
   browser_family: Android Browser
@@ -500,19 +451,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; STARTRAIL II Build/HuaweiU8655) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarTrail 2
   os_family: Android
   browser_family: Android Browser
@@ -520,19 +469,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2;fr-fr; STARTRAIL4 Build/BQ_ZTEV1.0.0B04) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarTrail 4
   os_family: Android
   browser_family: Android Browser
@@ -540,7 +487,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; STARTRAIL 4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -549,7 +495,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarTrail 4
   os_family: Android
   browser_family: Unknown
@@ -557,19 +503,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; STARXTREM Build/GM_ZTEV1.0.0B03) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: SX
+    brand: SFR
     model: StarXtrem
   os_family: Android
   browser_family: Android Browser
@@ -577,19 +521,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; hu-hu; Telenor_One_Touch_C Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: T2
+    brand: Telenor
     model: One Touch C
   os_family: Android
   browser_family: Android Browser
@@ -597,19 +539,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; Telenor_Smart_Pro Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: T2
+    brand: Telenor
     model: Smart Pro
   os_family: Android
   browser_family: Android Browser
@@ -617,19 +557,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Telenor Touch Plus Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: T2
+    brand: Telenor
     model: Touch Plus
   os_family: Android
   browser_family: Android Browser
@@ -637,19 +575,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; Trevi_PHABLET_4C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T3
+    brand: Trevi
     model: Phablet 4 C
   os_family: Android
   browser_family: Android Browser
@@ -657,19 +593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PHABLET 4S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T3
+    brand: Trevi
     model: Phablet 4 S
   os_family: Android
   browser_family: Chrome
@@ -677,19 +611,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.3; it-it; Phablet 4.5Q Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T3
+    brand: Trevi
     model: Phablet 4.5Q
   os_family: Android
   browser_family: Android Browser
@@ -697,19 +629,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; Trevi_PHABLET_5_S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T3
+    brand: Trevi
     model: Phablet 5 S
   os_family: Android
   browser_family: Android Browser
@@ -717,19 +647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Knight 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.56 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.56"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: Knight 2
   os_family: Android
   browser_family: Chrome
@@ -737,19 +665,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; thl T100S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: T100S
   os_family: Android
   browser_family: Android Browser
@@ -757,19 +683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; thl__T100S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: T100S
   os_family: Android
   browser_family: Chrome
@@ -777,19 +701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Thl_T11 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: T11
   os_family: Android
   browser_family: Chrome
@@ -797,19 +719,17 @@
   user_agent: 'ThL T3 Linux/3.4.0 Android/4.1.2  Release/12.24.2012 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.1.2'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: T3
   os_family: Android
   browser_family: Android Browser
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; thl T6 pro Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 bdbrowser_i18n/3.2.0.3
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "3.2.0.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: T6 pro
   os_family: Android
   browser_family: Baidu
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; ThL W11 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: W11
   os_family: Android
   browser_family: Android Browser
@@ -857,19 +773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-SM410 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T8
+    brand: Touchmate
     model: TM-SM410
   os_family: Android
   browser_family: Chrome
@@ -877,19 +791,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-SM500N Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T8
+    brand: Touchmate
     model: TM-SM500N
   os_family: Android
   browser_family: Chrome
@@ -897,19 +809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TOUCHMATE TM-SM540 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T8
+    brand: Touchmate
     model: TM-SM540
   os_family: Android
   browser_family: Chrome
@@ -917,19 +827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Coto W418 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T9
+    brand: Top House
     model: Coto W418
   os_family: Android
   browser_family: Chrome
@@ -937,19 +845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; COTO_T40017) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T9
+    brand: Top House
     model: T40017
   os_family: Android
   browser_family: Chrome
@@ -957,19 +863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TECNO CB7j) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Camon i4
   os_family: Android
   browser_family: Chrome
@@ -977,19 +881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ru-ru; TECNO CB7 Build/PPR1.180610.011;) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Camon i4
   os_family: Android
   browser_family: Chrome
@@ -997,19 +899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TECNO ID6 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Camon iClick 2
   os_family: Android
   browser_family: Chrome
@@ -1017,19 +917,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO D1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: D1
   os_family: Android
   browser_family: Android Browser
@@ -1037,19 +935,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; TECNO D3 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: D3
   os_family: Android
   browser_family: Android Browser
@@ -1057,19 +953,17 @@
   user_agent: TECNO D5 Linux/3.0.13 Android/4.0.4 Release/01.28.2013 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: D5
   os_family: Android
   browser_family: Android Browser
@@ -1077,19 +971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TECNO F4 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: F4 Pro
   os_family: Android
   browser_family: Chrome
@@ -1097,19 +989,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; fr-fr; TECNO F7 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: F7
   os_family: Android
   browser_family: Android Browser
@@ -1117,19 +1007,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO H5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: H5
   os_family: Android
   browser_family: Android Browser
@@ -1137,19 +1025,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; L3 Build/TECNOL3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: L3
   os_family: Android
   browser_family: Android Browser
@@ -1157,19 +1043,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO M3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/1.4 Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "1.4"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: M3
   os_family: Android
   browser_family: Baidu
@@ -1177,19 +1061,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; TECNO_M3) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: M3
   os_family: Android
   browser_family: Unknown
@@ -1197,19 +1079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO M7 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: M7
   os_family: Android
   browser_family: Android Browser
@@ -1217,19 +1097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TECNO N3 Build/master) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: N3
   os_family: Android
   browser_family: Android Browser
@@ -1237,19 +1115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; TECNO_N7 Build/TECNOTECNO_N7) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: N7
   os_family: Android
   browser_family: Android Browser
@@ -1257,19 +1133,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; TECNO_P3) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: P3
   os_family: Android
   browser_family: Unknown
@@ -1277,19 +1151,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TECNO P3S Build/master) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: P3S
   os_family: Android
   browser_family: Android Browser
@@ -1297,19 +1169,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO P5 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: P5
   os_family: Android
   browser_family: Unknown
@@ -1317,19 +1187,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO P9 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: P9
   os_family: Android
   browser_family: Android Browser
@@ -1337,19 +1205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Phantom6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Phantom 6
   os_family: Android
   browser_family: Chrome
@@ -1357,19 +1223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Phantom6-Plus Build/NMF26O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Phantom 6 Plus
   os_family: Android
   browser_family: Chrome
@@ -1377,19 +1241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TECNO LB8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Pouvoir 3 Plus
   os_family: Android
   browser_family: Chrome
@@ -1397,19 +1259,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; TECNO Q1 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.3.413 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.3.413"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: Q1
   os_family: Android
   browser_family: Unknown
@@ -1417,19 +1277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO S3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: S3
   os_family: Android
   browser_family: Android Browser
@@ -1437,19 +1295,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TECNO S3C Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: S3C
   os_family: Android
   browser_family: Unknown
@@ -1457,19 +1313,17 @@
   user_agent: Mozilla/5.0 (Linux;U;Android 2.3.5;fr-fr;TECNO T3 Build/master) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: T3
   os_family: Android
   browser_family: Android Browser
@@ -1477,19 +1331,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en; TECNO_T3) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: T3
   os_family: Android
   browser_family: Unknown
@@ -1499,13 +1351,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.0.291"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: t36
   os_family: Unknown
   browser_family: Unknown
@@ -1515,7 +1366,7 @@
   client: null
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: T611
   os_family: Unknown
   browser_family: Unknown
@@ -1523,7 +1374,6 @@
   user_agent: '[FBAN/FB4A;FBAV/73.0.0.18.66;FBBV/28132076;FBDM/{density=1.5,width=480,height=854};FBLC/fr_FR;FBCR/Orange Cm;FBMF/TECNO;FBBD/TECNO;FBPN/com.facebook.katana;FBDV/TECNO-W3;FBSV/6.0;FBOP/1;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
@@ -1532,7 +1382,7 @@
     version: "73.0.0.18.66"
   device:
     type: smartphone
-    brand: TB
+    brand: Tecno Mobile
     model: W3
   os_family: Android
   browser_family: Unknown
@@ -1540,19 +1390,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 7040N Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: 7040N
   os_family: Android
   browser_family: Chrome
@@ -1560,19 +1408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; TCL A916 Build/FSR) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: A916
   os_family: Android
   browser_family: Android Browser
@@ -1580,19 +1426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5152D Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: C5
   os_family: Android
   browser_family: Chrome
@@ -1600,19 +1444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 5199I Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: C9
   os_family: Android
   browser_family: Chrome
@@ -1620,19 +1462,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; TCL-D662/EG27_YMYM_V0.6; 480*800; CTC/2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: D662
   os_family: Android
   browser_family: Android Browser
@@ -1640,19 +1480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TCLGalaG60(9108A) Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: Gala G60
   os_family: Android
   browser_family: Chrome
@@ -1660,7 +1498,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; TCL i718M Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 MicroMessenger/5.4.0.66_r807534.480 NetType/cmnet
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -1669,7 +1506,7 @@
     version: "5.4.0.66.r807534.480"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: i718M
   os_family: Android
   browser_family: Unknown
@@ -1677,7 +1514,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; TCL J636D+ Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MicroMessenger/6.0.0.54_r849063.501 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -1686,7 +1522,7 @@
     version: "6.0.0.54.r849063.501"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: J636D+
   os_family: Android
   browser_family: Unknown
@@ -1694,7 +1530,6 @@
   user_agent: TCL J706T_TD/1.0 Linux/3.4.5 Android/4.1.2 Release/08.27.2013 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 baiduboxapp/4.2 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -1703,7 +1538,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: J706T
   os_family: Android
   browser_family: Unknown
@@ -1711,19 +1546,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5133A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: L5
   os_family: Android
   browser_family: Chrome
@@ -1731,19 +1564,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5159J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: L9
   os_family: Android
   browser_family: Chrome
@@ -1751,19 +1582,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5159A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: L9
   os_family: Android
   browser_family: Chrome
@@ -1771,19 +1600,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A502DL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: LX
   os_family: Android
   browser_family: Chrome
@@ -1791,7 +1618,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; TCL M2M Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.74_r1098891.543 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -1800,7 +1626,7 @@
     version: "6.1.0.74.r1098891.543"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: M2M
   os_family: Android
   browser_family: Unknown
@@ -1808,19 +1634,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; TCL P301M Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser-CMCC/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P301M
   os_family: Android
   browser_family: Unknown
@@ -1828,19 +1652,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; TCL P331M Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser-CMCC/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P331M
   os_family: Android
   browser_family: Unknown
@@ -1848,7 +1670,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; TCL P332U Build/KOT49H) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1857,7 +1678,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P332U
   os_family: Android
   browser_family: Unknown
@@ -1865,19 +1686,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; TCL P360W Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P360W
   os_family: Android
   browser_family: Unknown
@@ -1885,19 +1704,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TCL_P561U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P561U
   os_family: Android
   browser_family: Chrome
@@ -1905,19 +1722,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0; zh-cn; TCL_P620M Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P620M
   os_family: Android
   browser_family: Unknown
@@ -1925,19 +1740,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; TCL P728M Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser-CMCC/9.5.2.394 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: P728M
   os_family: Android
   browser_family: Unknown
@@ -1945,19 +1758,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; T780H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: Plex
   os_family: Android
   browser_family: Chrome
@@ -1965,19 +1776,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; TCL S960 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: S960
   os_family: Android
   browser_family: Unknown
@@ -1985,19 +1794,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TCL_W939 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: W939
   os_family: Android
   browser_family: Android Browser
@@ -2005,19 +1812,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TCL Y910 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: Y910
   os_family: Android
   browser_family: Chrome
@@ -2025,19 +1830,17 @@
   user_agent: TCL-Z206_TD/1.0 Nucleus/1.3 JRDSZ36_10A/V01.01 Release/01.01.2011 Browser/Opera Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera/9.80 (MTK; Nucleus; Opera Mobi/4000; U; zh-CN) Presto/2.5.28 Version/10.10
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: "1.3"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "10.10"
     engine: Presto
     engine_version: "2.5.28"
   device:
     type: smartphone
-    brand: TC
+    brand: TCL
     model: Z206
   os_family: Real-time OS
   browser_family: Opera
@@ -2045,19 +1848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Telego_JOY2 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TG
+    brand: Telego
     model: Joy 2
   os_family: Android
   browser_family: Chrome
@@ -2065,19 +1866,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Telego Mate Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TG
+    brand: Telego
     model: Mate
   os_family: Android
   browser_family: Chrome
@@ -2085,19 +1884,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TELEGO-W503 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TG
+    brand: Telego
     model: W503
   os_family: Android
   browser_family: Chrome
@@ -2107,7 +1904,7 @@
   client: null
   device:
     type: smartphone
-    brand: TH
+    brand: TiPhone
     model: T67
   os_family: Unknown
   browser_family: Unknown
@@ -2115,19 +1912,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Foxtrot) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TL
+    brand: Telefunken
     model: Foxtrot
   os_family: Android
   browser_family: Chrome
@@ -2135,19 +1930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TELEFUNKEN Outdoor LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TL
+    brand: Telefunken
     model: Outdoor LTE
   os_family: Android
   browser_family: Chrome
@@ -2155,19 +1948,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; TF-SP5001 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TL
+    brand: Telefunken
     model: TF-SP5001
   os_family: Android
   browser_family: Android Browser
@@ -2175,19 +1966,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11) T-Mobile_Cleopatra
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.11"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: Cleopatra
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -2195,19 +1984,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; T-Mobile_Espresso Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: Espresso
   os_family: Android
   browser_family: Android Browser
@@ -2215,19 +2002,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; T-Mobile G1 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: G1
   os_family: Android
   browser_family: Android Browser
@@ -2235,19 +2020,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; T-Mobile G2 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: G2
   os_family: Android
   browser_family: Android Browser
@@ -2255,19 +2038,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) T-Mobile_LEO
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: LEO
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -2275,19 +2056,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.3; en-us; T-Mobile myTouch 3G Build/FRK76C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: myTouch 3G
   os_family: Android
   browser_family: Android Browser
@@ -2295,19 +2074,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; T-Mobile myTouch 3G Slide Build/GRI40; XM8-11162011) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: myTouch 3G Slide
   os_family: Android
   browser_family: Android Browser
@@ -2315,19 +2092,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.6; en-US; T-Mobile_myTouch_Q) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: myTouch Q
   os_family: Android
   browser_family: Unknown
@@ -2335,19 +2110,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; T-Mobile_myTouch_Q) U2/1.0.0 UCBrowser/9.0.2.389 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: myTouch Q
   os_family: GNU/Linux
   browser_family: Opera
@@ -2355,19 +2128,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; REVVL 2 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: REVVL 2
   os_family: Android
   browser_family: Chrome
@@ -2375,19 +2146,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; REVVL 2 PLUS Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: REVVL 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -2395,19 +2164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; REVVLRY) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: REVVL Plus
   os_family: Android
   browser_family: Chrome
@@ -2417,13 +2184,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q03C"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: Vairy Touch II
   os_family: Unknown
   browser_family: Unknown
@@ -2431,19 +2197,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; T-Mobile Vivacity Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TM
+    brand: T-Mobile
     model: Vivacity
   os_family: Android
   browser_family: Android Browser
@@ -2451,19 +2215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 5014G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: 5014G
   os_family: Android
   browser_family: Chrome
@@ -2471,19 +2233,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; EVERY35 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Every35
   os_family: Android
   browser_family: Android Browser
@@ -2491,19 +2251,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; TLINK350) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink350
   os_family: Android
   browser_family: Unknown
@@ -2511,19 +2269,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TLINK350 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink350
   os_family: Android
   browser_family: Android Browser
@@ -2531,19 +2287,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TLINK351 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink351
   os_family: Android
   browser_family: Android Browser
@@ -2551,19 +2305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; TLINK355 Build/TLINK355_THOMSON_2013/07/02,00:26:27) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink355
   os_family: Android
   browser_family: Android Browser
@@ -2571,19 +2323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TLINK405 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink405
   os_family: Android
   browser_family: Chrome
@@ -2591,19 +2341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TLINK455 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink455
   os_family: Android
   browser_family: Chrome
@@ -2611,19 +2359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; TLINK475 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TN
+    brand: Thomson
     model: Tlink475
   os_family: Android
   browser_family: Chrome
@@ -2631,19 +2377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tech Pad +Q545 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TP
+    brand: TechPad
     model: +Q545
   os_family: Android
   browser_family: Chrome
@@ -2651,19 +2395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Techpad X5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TP
+    brand: TechPad
     model: X5
   os_family: Android
   browser_family: Chrome
@@ -2671,19 +2413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tmovi Infinit Lite Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TQ
+    brand: Timovi
     model: Infinit Lite
   os_family: Android
   browser_family: Chrome
@@ -2691,19 +2431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Infinit_Lite_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TQ
+    brand: Timovi
     model: Infinit Lite 2
   os_family: Android
   browser_family: Chrome
@@ -2711,19 +2449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tmovi Prime Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TQ
+    brand: Timovi
     model: Prime
   os_family: Android
   browser_family: Chrome
@@ -2731,19 +2467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TMOVI_YEAH_BEAT Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TQ
+    brand: Timovi
     model: Yeah Beat
   os_family: Android
   browser_family: Chrome
@@ -2751,19 +2485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tmovi YeahLIVE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TQ
+    brand: Timovi
     model: Yeah LIVE
   os_family: Android
   browser_family: Chrome
@@ -2771,19 +2503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Turbo-X_A2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TR
+    brand: Turbo-X
     model: A2
   os_family: Android
   browser_family: Chrome
@@ -2791,19 +2521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Turbo-X_e3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TR
+    brand: Turbo-X
     model: E3
   os_family: Android
   browser_family: Chrome
@@ -2811,19 +2539,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; el-gr; Turbo-X pi Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TR
+    brand: Turbo-X
     model: pi
   os_family: Android
   browser_family: Android Browser
@@ -2831,19 +2557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Turbox_S3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TR
+    brand: Turbo-X
     model: S3
   os_family: Android
   browser_family: Chrome
@@ -2851,19 +2575,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr; TSB_CLOUD_COMPANION;TOSHIBA_AC_AND_AZ) AppleWebkit/533.1(KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: AC AND AZ
   os_family: Android
   browser_family: Android Browser
@@ -2871,19 +2593,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; TOSHIBA_FOLIO_AND_A Build/TOSHIBA_FOLIO_AND_A) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1; Maxthon (4.0.4.1000);
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: FOLIO AND A
   os_family: Android
   browser_family: Unknown
@@ -2891,19 +2611,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; ja-jp; IS04 Build/FFK300) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: Regza IS04
   os_family: Android
   browser_family: Android Browser
@@ -2911,19 +2629,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; IS11T Build/FGK401) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: Regza IS11T
   os_family: Android
   browser_family: Android Browser
@@ -2931,19 +2647,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0; ja-jp; T-01C Build/FFR002) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: Regza T-01C
   os_family: Android
   browser_family: Android Browser
@@ -2951,19 +2665,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ja-jp; T-01D Build/V09R40A) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: Regza T-01D
   os_family: Android
   browser_family: Android Browser
@@ -2971,19 +2683,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; T-02D Build/V15R47B) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: Regza T-02D
   os_family: Android
   browser_family: Android Browser
@@ -2991,19 +2701,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) Toshiba-TG01-orange/ 02/ PPC; 480x800
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: TS
+    brand: Toshiba
     model: TG01-orange
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3011,19 +2719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; StarTrail TT Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TU
+    brand: Tunisie Telecom
     model: StarTrail by TT
   os_family: Android
   browser_family: Chrome
@@ -3031,19 +2737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; NuclearSX-SP5 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TV
+    brand: TVC
     model: Nuclear SX-SP5
   os_family: Android
   browser_family: Android Browser
@@ -3051,19 +2755,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; Amazing A4 Build/JRO03C)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing A4
   os_family: Android
   browser_family: Android Browser
@@ -3071,19 +2773,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Amazing A4S Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing A4S
   os_family: Android
   browser_family: Android Browser
@@ -3091,19 +2791,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Amazing A5S Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing A5S
   os_family: Android
   browser_family: Android Browser
@@ -3111,19 +2809,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Amazing A8 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing A8
   os_family: Android
   browser_family: Android Browser
@@ -3131,19 +2827,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Amazing X2 Build/KVT49L)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X2
   os_family: Android
   browser_family: Android Browser
@@ -3151,19 +2845,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Amazing X3 Build/KVT49L)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X3
   os_family: Android
   browser_family: Android Browser
@@ -3171,19 +2863,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Amazing_X3s Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X3S
   os_family: Android
   browser_family: Android Browser
@@ -3191,19 +2881,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; Amazing X5 Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X5
   os_family: Android
   browser_family: Android Browser
@@ -3211,19 +2899,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Amazing X5s Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X5S
   os_family: Android
   browser_family: Android Browser
@@ -3231,19 +2917,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; Amazing X6 Build/LRX22G)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TW
+    brand: TWM
     model: Amazing X6
   os_family: Android
   browser_family: Android Browser
@@ -3251,19 +2935,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-tw; TOOKY A19 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: A19
   os_family: Android
   browser_family: Android Browser
@@ -3271,19 +2953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-tw; TOOKY A9PLUS Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: A9 Plus
   os_family: Android
   browser_family: Android Browser
@@ -3291,19 +2971,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; TOOKY T1982 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: T1982
   os_family: Android
   browser_family: Android Browser
@@ -3311,19 +2989,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; TOOKY T83 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: T83
   os_family: Android
   browser_family: Android Browser
@@ -3331,19 +3007,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; TOOKY T86 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: T86
   os_family: Android
   browser_family: Android Browser
@@ -3351,19 +3025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; TOOKY T88 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: T88
   os_family: Android
   browser_family: Chrome
@@ -3371,19 +3043,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; TOOKY W1 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/4.3.16.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.3.16.2"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: TY
+    brand: Tooky
     model: W1
   os_family: Android
   browser_family: Baidu
@@ -3391,19 +3061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-4982 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: iX-Maxi
   os_family: Android
   browser_family: Chrome
@@ -3411,19 +3079,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; TM-5201 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: Rock
   os_family: Android
   browser_family: Chrome
@@ -3431,19 +3097,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 2.2.2; ru-ru; TM-3000 Build/FRG83G AppleWebKit/533.1 KHTML, like Gecko Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-3000
   os_family: Android
   browser_family: Android Browser
@@ -3451,19 +3115,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 2.3.5; ru-ru; TM-3200R Build/GRJ90 AppleWebKit/533.1 KHTML, like Gecko Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-3200R
   os_family: Android
   browser_family: Android Browser
@@ -3471,19 +3133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TM-3204R Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Mobile Safari/537.36 OPR/29.0.1809.93516
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "29.0.1809.93516"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-3204R
   os_family: Android
   browser_family: Opera
@@ -3491,19 +3151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TM-4003 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4003
   os_family: Android
   browser_family: Chrome
@@ -3511,19 +3169,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Texet TM-4083 Build/1472117945)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4083
   os_family: Android
   browser_family: Android Browser
@@ -3531,19 +3187,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.1.2; TM-4377 Build/JZO54K AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4377
   os_family: Android
   browser_family: Chrome
@@ -3551,19 +3205,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.0.4; ru-ru; TM-4504 Build/IMM76D AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4504
   os_family: Android
   browser_family: Android Browser
@@ -3571,19 +3223,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; TM-4510 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4510
   os_family: Android
   browser_family: Chrome
@@ -3591,19 +3241,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; TM-4513 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-4513
   os_family: Android
   browser_family: Chrome
@@ -3611,19 +3259,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 5.1; en-US; TM-5003 Build/LMY47I AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/10.10.8.820 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.10.8.820"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5003
   os_family: Android
   browser_family: Unknown
@@ -3631,19 +3277,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.0; TM-5005 Build/NRD90M
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5005
   os_family: Android
   browser_family: Android Browser
@@ -3651,19 +3295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TM-5017 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5017
   os_family: Android
   browser_family: Chrome
@@ -3671,19 +3313,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; en-US; TM-5071 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.5.1121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.5.1121"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5071
   os_family: Android
   browser_family: Unknown
@@ -3691,19 +3331,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; ru-RU; TM-5073 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 Quark/2.4.4.993 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "2.4.4.993"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5073
   os_family: Android
   browser_family: Chrome
@@ -3711,19 +3349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TM-5074) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5074
   os_family: Android
   browser_family: Chrome
@@ -3731,19 +3367,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; TM-5075 Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5075
   os_family: Android
   browser_family: Opera
@@ -3751,19 +3385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TM-5076) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5076
   os_family: Android
   browser_family: Chrome
@@ -3771,19 +3403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TM-5077) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5077
   os_family: Android
   browser_family: Chrome
@@ -3791,19 +3421,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 2.3.5; ru-ru; TM-5200 Build/GRJ90 AppleWebKit/533.1 KHTML, like Gecko Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5200
   os_family: Android
   browser_family: Android Browser
@@ -3811,19 +3439,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.4; TM-5204 Build/IMM76D AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5204
   os_family: Android
   browser_family: Chrome
@@ -3831,19 +3457,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.2; ru-ru; TM-5277 Build/JZO54K AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5277
   os_family: Android
   browser_family: Android Browser
@@ -3851,19 +3475,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.0.4; ru-ru; TM-5377 Build/IMM76D AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5377
   os_family: Android
   browser_family: Android Browser
@@ -3871,19 +3493,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-5505 Build/LMY47I AppleWebKit/537.36 KHTML, like Gecko Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5505
   os_family: Android
   browser_family: Chrome
@@ -3891,19 +3511,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 5.1; en-US; TM-5513 Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.5.0.1109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.5.0.1109"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5513
   os_family: Android
   browser_family: Unknown
@@ -3911,19 +3529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TM-5571 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5571
   os_family: Android
   browser_family: Chrome
@@ -3931,19 +3547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TM-5581 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-5581
   os_family: Android
   browser_family: Chrome
@@ -3951,19 +3565,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-6003 Build/LMY47I AppleWebKit/537.36 KHTML, like Gecko Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: TM-6003
   os_family: Android
   browser_family: Chrome
@@ -3971,19 +3583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-5508 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Cosmo
   os_family: Android
   browser_family: Chrome
@@ -3991,19 +3601,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-4082R/X-driver Build/KOT49H; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/63.0.3239.111 Mobile Safari/537.36 Puffin/7.5.3.20547AP
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.5.3.20547"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Driver Quad
   os_family: Android
   browser_family: Unknown
@@ -4011,19 +3619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X-Force(TM-5009) Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Force
   os_family: Android
   browser_family: Chrome
@@ -4031,19 +3637,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; X-ForceTM-5009 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Force
   os_family: Android
   browser_family: Chrome
@@ -4051,19 +3655,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0; X-ForceTM-5009 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/36.2.2254.1304
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "36.2.2254.1304"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Force
   os_family: Android
   browser_family: Opera
@@ -4071,19 +3673,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; TM-5006 Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Line
   os_family: Android
   browser_family: Android Browser
@@ -4091,19 +3691,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-5503 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Mage
   os_family: Android
   browser_family: Chrome
@@ -4111,19 +3709,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; TM-5016 Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Maxi 2
   os_family: Android
   browser_family: Android Browser
@@ -4131,19 +3727,17 @@
   user_agent: 'Mozilla/5.0 Linux; U; Android 4.4.2;  zh-cn; TM-3500; Android/4.4.2; Release/09.25.2015  AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Maxi 2
   os_family: Android
   browser_family: Android Browser
@@ -4151,19 +3745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TM_5011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Omega
   os_family: Android
   browser_family: Chrome
@@ -4171,19 +3763,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; X-PlusTM-5577 Build/LMY47I AppleWebKit/537.36 KHTML, like Gecko Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Plus
   os_family: Android
   browser_family: Chrome
@@ -4191,19 +3781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-Plus(TM-5577) Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Plus
   os_family: Android
   browser_family: Chrome
@@ -4211,19 +3799,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; TM-4503 Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Quad
   os_family: Android
   browser_family: Android Browser
@@ -4231,19 +3817,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; TM-5010 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Selfie
   os_family: Android
   browser_family: Chrome
@@ -4251,19 +3835,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.4.2; TM-5007 Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Shine
   os_family: Android
   browser_family: Android Browser
@@ -4271,19 +3853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-4071 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Smart
   os_family: Android
   browser_family: Chrome
@@ -4291,19 +3871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-4515 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: TZ
+    brand: teXet
     model: X-Style
   os_family: Android
   browser_family: Chrome
@@ -4311,19 +3889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; A101S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: U1
+    brand: Uhans
     model: A101S
   os_family: Android
   browser_family: Chrome
@@ -4331,19 +3907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VisionBook P50 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UA
+    brand: Umax
     model: VisionBook P50 LTE
   os_family: Android
   browser_family: Chrome
@@ -4351,19 +3925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VisionBook P55 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UA
+    brand: Umax
     model: VisionBook P55 LTE
   os_family: Android
   browser_family: Chrome
@@ -4371,19 +3943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VisionBook P55 LTE Pro Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UA
+    brand: Umax
     model: VisionBook P55 LTE Pro
   os_family: Android
   browser_family: Chrome
@@ -4391,19 +3961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; USCC-E6762 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UC
+    brand: U.S. Cellular
     model: Kyocera DuraForce
   os_family: Android
   browser_family: Chrome
@@ -4411,19 +3979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; UHAPPY UP320 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UH
+    brand: Uhappy
     model: UP320
   os_family: Android
   browser_family: Chrome
@@ -4431,19 +3997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UP350 Build/F200C_JBT_A2.37M0.MUL.P1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UH
+    brand: Uhappy
     model: UP350
   os_family: Android
   browser_family: Chrome
@@ -4451,19 +4015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; UP520 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UH
+    brand: Uhappy
     model: UP520
   os_family: Android
   browser_family: Chrome
@@ -4471,19 +4033,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; UP720 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: UH
+    brand: Uhappy
     model: UP720
   os_family: Android
   browser_family: Android Browser
@@ -4491,19 +4051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; UP920 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UH
+    brand: Uhappy
     model: UP920
   os_family: Android
   browser_family: Chrome
@@ -4511,19 +4069,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; UTOK 450D Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: UK
+    brand: UTOK
     model: 450D
   os_family: Android
   browser_family: Android Browser
@@ -4531,19 +4087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; UTOK 451D Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: UK
+    brand: UTOK
     model: 451D
   os_family: Android
   browser_family: Android Browser
@@ -4551,19 +4105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Armor Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor
   os_family: Android
   browser_family: Chrome
@@ -4571,7 +4123,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Armor_2 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/147.0.0.44.75;]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ARM
   client:
@@ -4580,7 +4131,7 @@
     version: "147.0.0.44.75"
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 2
   os_family: Android
   browser_family: Unknown
@@ -4588,19 +4139,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Armor_3 Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 3
   os_family: Android
   browser_family: Android Browser
@@ -4608,19 +4157,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Armor 5S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 5S
   os_family: Android
   browser_family: Chrome
@@ -4628,19 +4175,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Armor_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 6
   os_family: Android
   browser_family: Chrome
@@ -4648,19 +4193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Armor_6S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 6S
   os_family: Android
   browser_family: Chrome
@@ -4668,19 +4211,17 @@
   user_agent: mozilla/5.0 (linux; android 9; armor_7) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.106 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 7
   os_family: Android
   browser_family: Chrome
@@ -4688,19 +4229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Armor_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor X
   os_family: Android
   browser_family: Chrome
@@ -4708,19 +4247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Armor_X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor X2
   os_family: Android
   browser_family: Chrome
@@ -4728,19 +4265,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Armor_X3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor X3
   os_family: Android
   browser_family: Chrome
@@ -4748,19 +4283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Armor X5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor X5
   os_family: Android
   browser_family: Chrome
@@ -4768,19 +4301,17 @@
   user_agent: mozilla/5.0 (linux; android 9; armor_x6) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.106 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor X6
   os_family: Android
   browser_family: Chrome
@@ -4788,19 +4319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Be one Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be One
   os_family: Android
   browser_family: Chrome
@@ -4808,19 +4337,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; be_one_lite Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.8.976"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be One Lite
   os_family: Android
   browser_family: Unknown
@@ -4828,19 +4355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Be_Pure Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be Pure
   os_family: Android
   browser_family: Chrome
@@ -4848,19 +4373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Be_Pure_lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be Pure Lite
   os_family: Android
   browser_family: Chrome
@@ -4868,19 +4391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Be Touch Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be Touch
   os_family: Android
   browser_family: Chrome
@@ -4888,19 +4409,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Be Touch 3 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be Touch 3
   os_family: Android
   browser_family: Chrome
@@ -4908,19 +4427,17 @@
   user_agent: Mozilla/5.0(Linux; Android 4.4.2; Be_X Build/KOT49H)AppleWebKit/537.36(KHTML, like Gecko)Chrome/57.0.2987.132MobileSafari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Be X
   os_family: Android
   browser_family: Chrome
@@ -4928,19 +4445,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Gemini Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Gemini Pro
   os_family: Android
   browser_family: Chrome
@@ -4948,19 +4463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Power_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Power 3
   os_family: Android
   browser_family: Chrome
@@ -4968,19 +4481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Power_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Power 5
   os_family: Android
   browser_family: Chrome
@@ -4988,19 +4499,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Power_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Power 6
   os_family: Android
   browser_family: Chrome
@@ -5008,19 +4517,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; Ulefone_S1_Pro AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: S1 Pro
   os_family: Android
   browser_family: Chrome
@@ -5028,19 +4535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; S10_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: S10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5048,19 +4553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ulefone S7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -5068,19 +4571,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; Ulefone S7 AppleWebKit/537.36 KHTML, like Gecko Chrome/76.0.3809.45 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.45"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -5088,19 +4589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ulefone S8 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: S8
   os_family: Android
   browser_family: Chrome
@@ -5108,19 +4607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; U007 Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: U007 Pro
   os_family: Android
   browser_family: Chrome
@@ -5128,19 +4625,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; U008 Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36 YandexSearch/7.15 '
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: U008 Pro
   os_family: Android
   browser_family: Chrome
@@ -5148,19 +4643,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; Ulefone_X AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: X
   os_family: Android
   browser_family: Chrome
@@ -5168,19 +4661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; A5_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: A5 Pro
   os_family: Android
   browser_family: Chrome
@@ -5188,19 +4679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI_Diamond) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Diamond
   os_family: Android
   browser_family: Chrome
@@ -5208,19 +4697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI_Diamond_X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Diamond X
   os_family: Android
   browser_family: Chrome
@@ -5228,19 +4715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI_Diamond_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Diamond X
   os_family: Android
   browser_family: Chrome
@@ -5248,19 +4733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; UMI eMAX Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: eMAX
   os_family: Android
   browser_family: Chrome
@@ -5268,19 +4751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI_London) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: London
   os_family: Android
   browser_family: Chrome
@@ -5288,19 +4769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; UMI_MAX Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: MAX
   os_family: Android
   browser_family: Chrome
@@ -5308,19 +4787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI TOUCH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Touch
   os_family: Android
   browser_family: Chrome
@@ -5328,19 +4805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI TOUCH X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.50 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.50"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Touch X
   os_family: Android
   browser_family: Chrome
@@ -5348,19 +4823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMI TOUCH X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Touch X
   os_family: Android
   browser_family: Chrome
@@ -5368,19 +4841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; UMIDIGI X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: X
   os_family: Android
   browser_family: Chrome
@@ -5388,19 +4859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; UMIDIGI Z Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UM
+    brand: UMIDIGI
     model: Z
   os_family: Android
   browser_family: Chrome
@@ -5408,19 +4877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U903 Build/U903) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Air
   os_family: Android
   browser_family: Chrome
@@ -5428,19 +4895,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U905 Build/U905) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Air 5.5
   os_family: Android
   browser_family: Chrome
@@ -5448,19 +4913,17 @@
   user_agent: Mozilla/5.0 (Android 5.1.1; U5151 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Bolt
   os_family: Android
   browser_family: Chrome
@@ -5468,19 +4931,17 @@
   user_agent: Mozilla/5.0 (Android 5.1.1; U5151 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.9 NTENTBrowser/4.2.0.181 (CellularOne-US) Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: NTENT Browser
-    short_name: NT
     version: "4.2.0.181"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Bolt
   os_family: Android
   browser_family: Unknown
@@ -5488,19 +4949,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; U513 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.582 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.582"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Drone XT
   os_family: Android
   browser_family: Unknown
@@ -5508,19 +4967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; U615 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Quattro M
   os_family: Android
   browser_family: Chrome
@@ -5528,19 +4985,17 @@
   user_agent: Mozilla/5.0 (Android 5.1; U613 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) NTENTBrowser/1.0.0.547 (CellularOne-US) Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: NTENT Browser
-    short_name: NT
     version: "1.0.0.547"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Quattro S
   os_family: Android
   browser_family: Unknown
@@ -5548,19 +5003,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; U710 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Quattro U710
   os_family: Android
   browser_family: Android Browser
@@ -5568,19 +5021,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U611 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Quattro X
   os_family: Android
   browser_family: Chrome
@@ -5588,7 +5039,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; U720 Build/KOT49H) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 search/1.0 baiduboxapp/7.0 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -5597,7 +5047,7 @@
     version: "7.0"
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Quattro Z
   os_family: Android
   browser_family: Unknown
@@ -5605,19 +5055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U-830 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UO
+    brand: Unnecto
     model: Rush
   os_family: Android
   browser_family: Chrome
@@ -5625,19 +5073,17 @@
   user_agent: uniscope77_bu3_cu_ics2 Linux/3.0.13 Android/4.0.4 Release/05.03.2013 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: US
+    brand: Uniscope
     model: 77 bu3 cu ics2
   os_family: Android
   browser_family: Android Browser
@@ -5645,19 +5091,17 @@
   user_agent: uniscope_T5588_TD/V1 Linux/3.4.5 Android/4.2.2 Release/08.22.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: US
+    brand: Uniscope
     model: T5588
   os_family: Android
   browser_family: Android Browser
@@ -5665,19 +5109,17 @@
   user_agent: uniscope_U1205_TD/V1 Linux/3.4.5 Android/4.2.2 Release/08.22.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: US
+    brand: Uniscope
     model: U1205
   os_family: Android
   browser_family: Android Browser
@@ -5685,19 +5127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; Uniscope US618 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: US
+    brand: Uniscope
     model: US618
   os_family: Android
   browser_family: Unknown
@@ -5705,19 +5145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; Uniscope US818 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: US
+    brand: Uniscope
     model: US818
   os_family: Android
   browser_family: Android Browser
@@ -5725,19 +5163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; UNONU UM405 LITE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UU
+    brand: Unonu
     model: UM405 LITE
   os_family: Android
   browser_family: Chrome
@@ -5745,19 +5181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; U452TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U452TL
   os_family: Android
   browser_family: Chrome
@@ -5765,19 +5199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; U504TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U504TL
   os_family: Android
   browser_family: Chrome
@@ -5785,19 +5217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; U671C Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U671C
   os_family: Android
   browser_family: Chrome
@@ -5805,19 +5235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; U673C Build/U673C_01.01.08; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U673C
   os_family: Android
   browser_family: Chrome
@@ -5825,19 +5253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; U680C Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30/TansoDL
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U680C
   os_family: Android
   browser_family: Android Browser
@@ -5845,19 +5271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; U683CL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U683CL
   os_family: Android
   browser_family: Chrome
@@ -5865,19 +5289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; U693CL Build/U693CL_01.01.05; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UX
+    brand: Unimax
     model: U693CL
   os_family: Android
   browser_family: Chrome
@@ -5885,19 +5307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Jelly-Pro Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UZ
+    brand: Unihertz
     model: Jelly Pro
   os_family: Android
   browser_family: Chrome
@@ -5905,19 +5325,17 @@
   user_agent: Mozilla / 5.0 (Linux; Android 9; Titan) AppleWebKit / 537.36 (KHTML, как Gecko) Chrome / 79.0.3945.116 Mobile Safari / 537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: UZ
+    brand: Unihertz
     model: Titan
   os_family: Android
   browser_family: Chrome
@@ -5925,19 +5343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T5SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V0
+    brand: VKworld
     model: T5 SE
   os_family: Android
   browser_family: Chrome
@@ -5945,19 +5361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VK700-MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V0
+    brand: VKworld
     model: VK700 Max
   os_family: Android
   browser_family: Chrome
@@ -5965,19 +5379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; VOTO-T8100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: T8100
   os_family: Android
   browser_family: Android Browser
@@ -5985,7 +5397,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; VOTO VT808 Build/IML74K) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.0.3)
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
@@ -5994,7 +5405,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT808
   os_family: Android
   browser_family: Unknown
@@ -6002,19 +5413,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; VOTO_VT818_TD/1.0 Android/4.0.3 Release/7.1.2013 Browser/AppleWebKit534.30 Build/MocorDroid4.0.3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360 Aphone Browser (6.9.9.14)
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.9.9.14"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT818
   os_family: Android
   browser_family: Unknown
@@ -6022,19 +5431,17 @@
   user_agent: MQQBrowser/4.3/Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; VOTO_VT818_TD/1.0 Android/4.0.3 Release/7.1.2013 Browser/AppleWebKit534.30 Build/MocorDroid4.0.3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "4.3"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT818
   os_family: Android
   browser_family: Unknown
@@ -6042,19 +5449,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; VOTO VT818+ Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT818+
   os_family: Android
   browser_family: Unknown
@@ -6062,7 +5467,6 @@
   user_agent: VOTO VT888_TD/Linux/3.4.39 Android/4.3 Release/08.15.2013 Browser/AppleWebkit534.30 Mobile Safari/534.30 MicroMessenger/5.4.0.66_r807534.480 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -6071,7 +5475,7 @@
     version: "5.4.0.66.r807534.480"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT888
   os_family: Android
   browser_family: Unknown
@@ -6079,19 +5483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; VT888 Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT888
   os_family: Android
   browser_family: Chrome
@@ -6099,19 +5501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; VT898 Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: VT898
   os_family: Android
   browser_family: Chrome
@@ -6119,19 +5519,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; VOTO X2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V1
+    brand: Voto
     model: X2
   os_family: Android
   browser_family: Android Browser
@@ -6139,19 +5537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Gyga_QS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Gyga QS
   os_family: Android
   browser_family: Chrome
@@ -6159,19 +5555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Jax Mini Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Jax Mini
   os_family: Android
   browser_family: Chrome
@@ -6179,19 +5573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JAX_N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Jax N
   os_family: Android
   browser_family: Chrome
@@ -6199,19 +5591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Jax_S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Jax S
   os_family: Android
   browser_family: Chrome
@@ -6219,19 +5609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Jax_S_A7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Jax S A7
   os_family: Android
   browser_family: Chrome
@@ -6239,19 +5627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Volt S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Volt S
   os_family: Android
   browser_family: Chrome
@@ -6259,19 +5645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Volt_S_A7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Volt S A7
   os_family: Android
   browser_family: Chrome
@@ -6279,19 +5663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Volt_X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Volt X
   os_family: Android
   browser_family: Chrome
@@ -6299,19 +5681,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; Xylo Q Build/LMY47I AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Xylo Q
   os_family: Android
   browser_family: Chrome
@@ -6319,19 +5699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Zun X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Zun X
   os_family: Android
   browser_family: Chrome
@@ -6339,19 +5717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Zun X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Zun X
   os_family: Android
   browser_family: Chrome
@@ -6359,19 +5735,17 @@
   user_agent: Mozilla/5.0(Linux; Android 6.0; ZUN XO Build/MRA58K)AppleWebKit/537.36(KHTML, like Gecko)Chrome/59.0.3071.125MobileSafari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V2
+    brand: Vonino
     model: Zun XO
   os_family: Android
   browser_family: Chrome
@@ -6379,19 +5753,17 @@
   user_agent: Mozilla/5.0 (Linux;Android 6.0;XA Pro Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V3
+    brand: Vinsoc
     model: XA Pro
   os_family: Android
   browser_family: Chrome
@@ -6399,19 +5771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIVAX_Fly3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Fly 3
   os_family: Android
   browser_family: Chrome
@@ -6419,19 +5789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Fly5_lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Fly 5 Lite
   os_family: Android
   browser_family: Chrome
@@ -6439,19 +5807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Fun_S500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Fun S500
   os_family: Android
   browser_family: Chrome
@@ -6459,19 +5825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Vivax Point X551 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Point X551
   os_family: Android
   browser_family: Chrome
@@ -6479,19 +5843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Vivax SMART Point X5010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Smart Point X5010
   os_family: Android
   browser_family: Chrome
@@ -6499,19 +5861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Venture V12 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V6
+    brand: VGO TEL
     model: Venture V12
   os_family: Android
   browser_family: Chrome
@@ -6519,19 +5879,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Venture V2 Build/JDQ39) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V6
+    brand: VGO TEL
     model: Venture V2
   os_family: Android
   browser_family: Android Browser
@@ -6539,19 +5897,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; VENTURE V7 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.10.8.820 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.10.8.820"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: V6
+    brand: VGO TEL
     model: Venture V7
   os_family: Android
   browser_family: Unknown
@@ -6559,19 +5915,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; Venture V8 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140270
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140270"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V6
+    brand: VGO TEL
     model: Venture V8
   os_family: Android
   browser_family: Opera
@@ -6579,19 +5933,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; VSUN ILLUSION AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V9
+    brand: Vsun
     model: Illusion
   os_family: Android
   browser_family: Chrome
@@ -6599,19 +5951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VSUN RACE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V9
+    brand: Vsun
     model: Race
   os_family: Android
   browser_family: Chrome
@@ -6619,19 +5969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Vsun V9 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V9
+    brand: Vsun
     model: V9
   os_family: Android
   browser_family: Chrome
@@ -6639,19 +5987,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; Videocon_A10) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: VD
+    brand: Videocon
     model: A10
   os_family: Android
   browser_family: Unknown
@@ -6659,19 +6005,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-in; Videocon A10 Build/MocorDroid2.3.5_Trout) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VD
+    brand: Videocon
     model: A10
   os_family: Android
   browser_family: Android Browser
@@ -6679,19 +6023,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; en-us; Videocon A27i Build/HMJ25) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: smartphone
-    brand: VD
+    brand: Videocon
     model: A27i
   os_family: Android
   browser_family: Android Browser
@@ -6699,19 +6041,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; V502430 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VD
+    brand: Videocon
     model: Kryton 3
   os_family: Android
   browser_family: Android Browser
@@ -6719,19 +6059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; ASTER P Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/9.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "9.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VE
+    brand: Vertu
     model: Aster P
   os_family: Android
   browser_family: Unknown
@@ -6739,19 +6077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CONSTELLATION X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VE
+    brand: Vertu
     model: Constellation X
   os_family: Android
   browser_family: Chrome
@@ -6759,19 +6095,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-gb; Vodafone 845 Build/B219) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: "845"
   os_family: Android
   browser_family: Android Browser
@@ -6779,19 +6113,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; de-de; Vodafone 858 Build/Vodafone858C02B617) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: "858"
   os_family: Android
   browser_family: Android Browser
@@ -6799,19 +6131,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.2.1; en-US; Vodafone_858) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: "858"
   os_family: Android
   browser_family: Unknown
@@ -6819,19 +6149,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-; Vodafone 975N Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30 SVN/130HCN2
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 3
   os_family: Android
   browser_family: Android Browser
@@ -6839,19 +6167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Vodafone 975 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30 SVN/070HVG3
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 3
   os_family: Android
   browser_family: Android Browser
@@ -6859,19 +6185,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; Vodafone 785 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30 SVN/120HJG1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 4 Mini
   os_family: Android
   browser_family: Android Browser
@@ -6879,19 +6203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Vodafone 985N Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 4 Power
   os_family: Android
   browser_family: Chrome
@@ -6899,19 +6221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Vodafone Smart 4 turbo Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 4 turbo
   os_family: Android
   browser_family: Chrome
@@ -6919,19 +6239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Vodafone 890N Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 SWV/265.21IT
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 4 Turbo
   os_family: Android
   browser_family: Chrome
@@ -6939,19 +6257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Vodafone Smart 4G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart 4G
   os_family: Android
   browser_family: Chrome
@@ -6959,19 +6275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; VFD320 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart C9
   os_family: Android
   browser_family: Chrome
@@ -6979,19 +6293,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; VodafoneSmartChat-MSM7225A-V02c-Sep272012-Vodafone-IE/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Chat
   os_family: Android
   browser_family: Android Browser
@@ -6999,19 +6311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; VFD 510 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart E8
   os_family: Android
   browser_family: Chrome
@@ -7019,19 +6329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; VFD 513 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart E8
   os_family: Android
   browser_family: Chrome
@@ -7039,19 +6347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; VF695 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 SVN/050HJG1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart First 6
   os_family: Android
   browser_family: Chrome
@@ -7059,19 +6365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VFD 200 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart First 7
   os_family: Android
   browser_family: Chrome
@@ -7079,19 +6383,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; VF-696 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Grand 6
   os_family: Android
   browser_family: Chrome
@@ -7099,19 +6401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; el-gr; Vodafone Smart II Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 SVN/01022
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart II
   os_family: Android
   browser_family: Android Browser
@@ -7119,19 +6419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VF685 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Kicka
   os_family: Android
   browser_family: Chrome
@@ -7139,19 +6437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Vodafone 875 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Mini
   os_family: Android
   browser_family: Chrome
@@ -7159,19 +6455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VFD 100 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Mini
   os_family: Android
   browser_family: Chrome
@@ -7179,19 +6473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VFD 300 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Mini 7
   os_family: Android
   browser_family: Chrome
@@ -7199,19 +6491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VFD 610 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart N8
   os_family: Android
   browser_family: Chrome
@@ -7219,19 +6509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; VFD 720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart N9
   os_family: Android
   browser_family: Chrome
@@ -7239,19 +6527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VFD 900 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Platinum 7
   os_family: Android
   browser_family: Chrome
@@ -7259,19 +6545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; VF-895N Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Prime 6
   os_family: Android
   browser_family: Chrome
@@ -7279,19 +6563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VFD 600 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Prime 7
   os_family: Android
   browser_family: Chrome
@@ -7299,19 +6581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VF-795 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Speed 6
   os_family: Android
   browser_family: Chrome
@@ -7319,19 +6599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VFD 500 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Turbo 7
   os_family: Android
   browser_family: Chrome
@@ -7339,19 +6617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VFD 502 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Turbo 7
   os_family: Android
   browser_family: Chrome
@@ -7359,19 +6635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Vodafone Smart ultra 6 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Ultra 6
   os_family: Android
   browser_family: Chrome
@@ -7379,19 +6653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VFD 700 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart Ultra 7
   os_family: Android
   browser_family: Chrome
@@ -7399,19 +6671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; VFD 820 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VF
+    brand: Vodafone
     model: Smart X9
   os_family: Android
   browser_family: Chrome
@@ -7419,19 +6689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VORAGO CELL-500 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VG
+    brand: Vorago
     model: CELL-500
   os_family: Android
   browser_family: Chrome
@@ -7439,19 +6707,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Active 1+ Build/PKQ1.190118.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VH
+    brand: Vsmart
     model: Active 1 Plus
   os_family: Android
   browser_family: Android Browser
@@ -7459,19 +6725,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Bee 3 Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VH
+    brand: Vsmart
     model: Bee 3
   os_family: Android
   browser_family: Android Browser
@@ -7479,19 +6743,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Joy 1+ Build/PKQ1.190414.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VH
+    brand: Vsmart
     model: Joy 1 Plus
   os_family: Android
   browser_family: Android Browser
@@ -7499,19 +6761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; vk6050 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 6050 Build
   os_family: Android
   browser_family: Chrome
@@ -7519,19 +6779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; vk6735 Build/vkworld) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 6735 Build
   os_family: Android
   browser_family: Chrome
@@ -7539,19 +6797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; vk700 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 700 Build
   os_family: Android
   browser_family: Chrome
@@ -7559,19 +6815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VK700 Pro Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 700 Pro Build
   os_family: Android
   browser_family: Chrome
@@ -7579,19 +6833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VK700 Pro Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 700 Pro Build
   os_family: Android
   browser_family: Chrome
@@ -7599,19 +6851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; VK700X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VK
+    brand: VK Mobile
     model: 700X Build
   os_family: Android
   browser_family: Chrome
@@ -7619,19 +6869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; verykool Cyprus II Jr S6004 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VL
+    brand: Verykool
     model: Cyprus II Jr S6004
   os_family: Android
   browser_family: Chrome
@@ -7639,7 +6887,6 @@
   user_agent: '[FBAN/FB4A;FBAV/79.0.0.0.52;FBBV/30370547;FBDM/{density=1.5,width=480,height=854};FBLC/es_ES;FBCR/TIGO;FBMF/verykool;FBBD/verykool;FBPN/com.facebook.katana;FBDV/verykoolS5004;FBSV/4.4.2;FBOP/1;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ARM
   client:
@@ -7648,7 +6895,7 @@
     version: "79.0.0.0.52"
   device:
     type: smartphone
-    brand: VL
+    brand: Verykool
     model: Lotus JR.
   os_family: Android
   browser_family: Unknown
@@ -7656,19 +6903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; verykools5019 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VL
+    brand: Verykool
     model: s5019
   os_family: Android
   browser_family: Chrome
@@ -7676,19 +6921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; verykoolSL5200 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VL
+    brand: Verykool
     model: SL5200
   os_family: Android
   browser_family: Chrome
@@ -7696,19 +6939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; verykool Wave Pro s5021 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VL
+    brand: Verykool
     model: Wave Pro s5021
   os_family: Android
   browser_family: Chrome
@@ -7716,19 +6957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Creon F5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VN
+    brand: Venso
     model: Creon F5
   os_family: Android
   browser_family: Chrome
@@ -7736,19 +6975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CX-508) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VN
+    brand: Venso
     model: CX-508
   os_family: Android
   browser_family: Chrome
@@ -7756,19 +6993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Venso CX-551) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VN
+    brand: Venso
     model: CX-551
   os_family: Android
   browser_family: Chrome
@@ -7776,19 +7011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Reiv 500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VN
+    brand: Venso
     model: Reiv 500
   os_family: Android
   browser_family: Chrome
@@ -7796,19 +7029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Apollo Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: Apollo Lite
   os_family: Android
   browser_family: Chrome
@@ -7816,19 +7047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Apollo X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: Apollo X
   os_family: Android
   browser_family: Chrome
@@ -7836,19 +7065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; vernee_M5 Build/vernee_M5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.53 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.53"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -7856,7 +7083,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 7.0; Mars pro Build/NRD90M)'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -7865,7 +7091,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: Mars Pro
   os_family: Android
   browser_family: Unknown
@@ -7873,19 +7099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Thor E Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.132 YaBrowser/18.1.0.527.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.1.0.527.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: Thor E
   os_family: Android
   browser_family: Unknown
@@ -7893,19 +7117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Thor Plus Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VR
+    brand: Vernee
     model: Thor Plus
   os_family: Android
   browser_family: Chrome
@@ -7913,19 +7135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-US; ViewSonic A8+ Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.5.892 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.5.892"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VS
+    brand: ViewSonic
     model: A8 Plus
   os_family: Android
   browser_family: Unknown
@@ -7933,19 +7153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ViewSonic V500 Build/KVT49L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: VS
+    brand: ViewSonic
     model: V500
   os_family: Android
   browser_family: Chrome
@@ -7953,19 +7171,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; ViewPhone3 Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VS
+    brand: ViewSonic
     model: ViewPhone 3
   os_family: Android
   browser_family: Android Browser
@@ -7973,19 +7189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; VSP145M Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus 4.5
   os_family: Android
   browser_family: Chrome
@@ -7993,19 +7207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; VSP250g Build/G517) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus 5.0V
   os_family: Android
   browser_family: Chrome
@@ -8013,19 +7225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VSP250s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus 5.0X
   os_family: Android
   browser_family: Chrome
@@ -8033,19 +7243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VSP355s Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus 5.5X
   os_family: Android
   browser_family: Chrome
@@ -8053,19 +7261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Venus GO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus Go
   os_family: Android
   browser_family: Chrome
@@ -8073,19 +7279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Venus_V3_5040_2GB Build/VASP434) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus V3
   os_family: Android
   browser_family: Chrome
@@ -8093,19 +7297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V3_5580_Dual) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus V3 5580 Dual
   os_family: Android
   browser_family: Chrome
@@ -8113,19 +7315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Venus V5 Build/VTE1160) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus V5
   os_family: Android
   browser_family: Chrome
@@ -8133,19 +7333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Venus V6 Build/VR1070; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus V6
   os_family: Android
   browser_family: Chrome
@@ -8153,19 +7351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Venus Z10 Build/VR1240) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus Z10
   os_family: Android
   browser_family: Chrome
@@ -8173,19 +7369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Venus Z20 Build/VR1200; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VT
+    brand: Vestel
     model: Venus Z20
   os_family: Android
   browser_family: Chrome
@@ -8193,19 +7387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VP5004A Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VU
+    brand: Vulcan
     model: VP5004A
   os_family: Android
   browser_family: Chrome
@@ -8213,7 +7405,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1824A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36 T7/11.19 SP-engine/2.15.0 baiduboxapp/11.19.5.10 (Baidu; P1 10)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -8222,7 +7413,7 @@
     version: "11.19.5.10"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO
   os_family: Android
   browser_family: Unknown
@@ -8230,19 +7421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1824BA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO
   os_family: Android
   browser_family: Chrome
@@ -8250,19 +7439,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; V1955A Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.0.3.1083 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.3.1083"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO 3
   os_family: Android
   browser_family: Unknown
@@ -8270,19 +7457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2024A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.4.12.0
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.4.12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO 5
   os_family: Android
   browser_family: Unknown
@@ -8290,19 +7475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2025A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -8310,19 +7493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1914A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Neo
   os_family: Android
   browser_family: Chrome
@@ -8330,19 +7511,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; V1981A Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.0.2.1082 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.2.1082"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Neo 3
   os_family: Android
   browser_family: Unknown
@@ -8350,19 +7529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-cn; V1936A Build/PKQ1.190806.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Neo 855
   os_family: Android
   browser_family: Unknown
@@ -8370,19 +7547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1936AL Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Neo 855
   os_family: Android
   browser_family: Chrome
@@ -8390,19 +7565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1922A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Pro
   os_family: Android
   browser_family: Chrome
@@ -8410,19 +7583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1916A Build/PKQ1.190714.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -8430,19 +7601,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; V2023A Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.3.1093 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.3.1093"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO U1
   os_family: Android
   browser_family: Unknown
@@ -8450,19 +7619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1986A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Z1
   os_family: Android
   browser_family: Chrome
@@ -8470,19 +7637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2012A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Z1x
   os_family: Android
   browser_family: Chrome
@@ -8490,19 +7655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1919A Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Z5x
   os_family: Android
   browser_family: Chrome
@@ -8510,19 +7673,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1805 Build/OPM1.171019.026A
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex
   os_family: Android
   browser_family: Android Browser
@@ -8530,19 +7691,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; V1923A Build/PKQ1.190714.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.2.1289 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.2.1289"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex 3
   os_family: Android
   browser_family: Unknown
@@ -8550,19 +7709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1924A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex 3 5G
   os_family: Android
   browser_family: Chrome
@@ -8570,19 +7727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1950A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/20.0.2.1
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "20.0.2.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex 3S
   os_family: Android
   browser_family: Unknown
@@ -8590,19 +7745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1821T Build/PKQ1.181016.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex Dual Display
   os_family: Android
   browser_family: Chrome
@@ -8610,19 +7763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-us; V1821A Build/PKQ1.181016.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/9.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "9.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Nex Dual Display
   os_family: Android
   browser_family: Unknown
@@ -8630,19 +7781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Vivo ONE Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 OPR/43.0.2246.121183
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.0.2246.121183"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: One
   os_family: Android
   browser_family: Opera
@@ -8650,19 +7799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1831A Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S1
   os_family: Android
   browser_family: Chrome
@@ -8670,19 +7817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1831T Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S1
   os_family: Android
   browser_family: Chrome
@@ -8690,19 +7835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1832A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S1 Pro
   os_family: Android
   browser_family: Chrome
@@ -8710,19 +7853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1832T Build/PKQ1.190302.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S1 Pro
   os_family: Android
   browser_family: Chrome
@@ -8730,19 +7871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; vivo S3+ Build/IMM76D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.1.275 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.1.275"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S3+
   os_family: Android
   browser_family: Unknown
@@ -8750,19 +7889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1932A Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S5
   os_family: Android
   browser_family: Chrome
@@ -8770,19 +7907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1962A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S6 5G
   os_family: Android
   browser_family: Chrome
@@ -8790,19 +7925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2020CA Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -8810,19 +7943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2020A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -8830,19 +7961,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; vivo S7t Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S7t
   os_family: Android
   browser_family: Unknown
@@ -8850,19 +7979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1941A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -8870,19 +7997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; V1928A Build/PKQ1.190626.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.5.1290 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.5.1290"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: U3X
   os_family: Android
   browser_family: Unknown
@@ -8890,19 +8015,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; zh-CN; vivo V1 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V1
   os_family: Android
   browser_family: Unknown
@@ -8910,19 +8033,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1804 Build/OPM1.171019.011
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V11 Pro
   os_family: Android
   browser_family: Android Browser
@@ -8930,19 +8051,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1806 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V11i
   os_family: Android
   browser_family: Android Browser
@@ -8950,19 +8069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; 1819 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V15
   os_family: Android
   browser_family: Chrome
@@ -8970,19 +8087,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 9; vivo 1818 Build/PKQ1.181203.001
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V15 Pro
   os_family: Android
   browser_family: Android Browser
@@ -8990,19 +8105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; vivo 1909) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V17 Pro
   os_family: Android
   browser_family: Chrome
@@ -9010,19 +8123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; vivo 1601 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5
   os_family: Android
   browser_family: Chrome
@@ -9030,19 +8141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; vivo 1601) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5
   os_family: Android
   browser_family: Chrome
@@ -9050,19 +8159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; vivo 1609 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5 Lite
   os_family: Android
   browser_family: Chrome
@@ -9070,19 +8177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; vivo 1611) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5 Plus
   os_family: Android
   browser_family: Chrome
@@ -9090,19 +8195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; vivo 1713 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5s
   os_family: Android
   browser_family: Chrome
@@ -9110,19 +8213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; vivo 1612 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V5s
   os_family: Android
   browser_family: Chrome
@@ -9130,19 +8231,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1718 Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V7
   os_family: Android
   browser_family: Android Browser
@@ -9150,19 +8249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; vivo 1716 Build/MOB31E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.131"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V7 Plus
   os_family: Android
   browser_family: Chrome
@@ -9170,19 +8267,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1723 Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V9
   os_family: Android
   browser_family: Android Browser
@@ -9190,19 +8285,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1727 Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: V9 Youth
   os_family: Android
   browser_family: Android Browser
@@ -9210,19 +8303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; vivo X1 Build/JRO03C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.2.365 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.2.365"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X1
   os_family: Android
   browser_family: Unknown
@@ -9230,19 +8321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; vivo 1721) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X20
   os_family: Android
   browser_family: Chrome
@@ -9250,19 +8339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo X20Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X20 Plus
   os_family: Android
   browser_family: Chrome
@@ -9270,19 +8357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1725 Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X21
   os_family: Android
   browser_family: Chrome
@@ -9290,19 +8375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1814A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X21S
   os_family: Android
   browser_family: Chrome
@@ -9310,19 +8393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1814T Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X21S
   os_family: Android
   browser_family: Chrome
@@ -9330,19 +8411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1809T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X23
   os_family: Android
   browser_family: Chrome
@@ -9350,19 +8429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1816A Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X23
   os_family: Android
   browser_family: Chrome
@@ -9370,19 +8447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1809A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X23
   os_family: Android
   browser_family: Chrome
@@ -9390,19 +8465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1816T Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/039941 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X23
   os_family: Android
   browser_family: Unknown
@@ -9410,19 +8483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1829T Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27
   os_family: Android
   browser_family: Chrome
@@ -9430,19 +8501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1838A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27
   os_family: Android
   browser_family: Chrome
@@ -9450,19 +8519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1829A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27
   os_family: Android
   browser_family: Chrome
@@ -9470,19 +8537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1838T Build/PKQ1.190302.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/7.8.10.5
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "7.8.10.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27
   os_family: Android
   browser_family: Unknown
@@ -9490,19 +8555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1836T Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27 Pro
   os_family: Android
   browser_family: Chrome
@@ -9510,19 +8573,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; V1836A Build/PKQ1.181030.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X27 Pro
   os_family: Android
   browser_family: Unknown
@@ -9530,19 +8591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1938CT Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X30
   os_family: Android
   browser_family: Chrome
@@ -9550,19 +8609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1938T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X30 Pro
   os_family: Android
   browser_family: Chrome
@@ -9570,19 +8627,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; BBG-vivo X3V/PD1227V_A_1.12.8; 720*1280; CTC/2.0) AppleWebKit/537.36 (KHTML,like Gecko) Version/4.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X3V
   os_family: Android
   browser_family: Android Browser
@@ -9590,19 +8645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2001A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.0.10.1
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.0.10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X50
   os_family: Android
   browser_family: Unknown
@@ -9610,19 +8663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2005A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X50 Pro
   os_family: Android
   browser_family: Chrome
@@ -9630,19 +8681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2011A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.1.14.2
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.1.14.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X50 Pro Plus
   os_family: Android
   browser_family: Unknown
@@ -9650,19 +8699,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; VIV-vivo X5Max V/PD1408V_A_1.18.1; 1080*1920; CTC/2.0) AppleWebKit/537.36 (KHTML,like Gecko) Version/4.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X5Max V
   os_family: Android
   browser_family: Android Browser
@@ -9670,19 +8717,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; VIV-vivo X5Pro V/PD1421V_A_1.13.5; 1080*1920; CTC/2.0) AppleWebKit/537.36 (KHTML,like Gecko) Version/4.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X5Pro V
   os_family: Android
   browser_family: Android Browser
@@ -9690,19 +8735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; vivo X9Plus Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X9 Plus
   os_family: Android
   browser_family: Chrome
@@ -9710,7 +8753,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; vivo Xplay Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/5.0 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -9719,7 +8761,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Xplay
   os_family: Android
   browser_family: Unknown
@@ -9727,19 +8769,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; vivo Y11i T Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y11i T
   os_family: Android
   browser_family: Android Browser
@@ -9747,19 +8787,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 9; vivo 1902 Build/PPR1.180610.011
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y17
   os_family: Android
   browser_family: Android Browser
@@ -9767,19 +8805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; vivo 1915 Build/PPR1.180610.011; en-us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y19
   os_family: Android
   browser_family: Chrome
@@ -9787,19 +8823,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; vivo Y19t Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360browser(securitypay,securityinstalled); 360(android,uppayplugin); 360 Aphone Browser (6.0.1)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.0.1"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y19t
   os_family: Android
   browser_family: Unknown
@@ -9807,19 +8841,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.1; zh-CN; vivo_Y19t) U2/1.0.0 UCBrowser/8.8.3.272 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.3.272"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y19t
   os_family: Android
   browser_family: Unknown
@@ -9827,7 +8859,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1901A Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36 T7/11.17 SP-engine/2.13.0 baiduboxapp/11.17.0.13 (Baidu; P1 9)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
@@ -9836,7 +8867,7 @@
     version: "11.17.0.13"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y3
   os_family: Android
   browser_family: Unknown
@@ -9844,19 +8875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1901T Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y3
   os_family: Android
   browser_family: Chrome
@@ -9864,19 +8893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1930A Build/PKQ1.190616.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y3 Standard
   os_family: Android
   browser_family: Chrome
@@ -9884,19 +8911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1965A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y50
   os_family: Android
   browser_family: Chrome
@@ -9904,19 +8929,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 6.0.1; vivo 1606 Build/MMB29M
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y53i
   os_family: Android
   browser_family: Android Browser

--- a/Tests/fixtures/smartphone-16.yml
+++ b/Tests/fixtures/smartphone-16.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; vivo 1603) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y55l
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; vivo 1610 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.0.2672.49578
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.0.2672.49578"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y55s
   os_family: Android
   browser_family: Opera
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1934A Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/7.6.81.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "7.6.81.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y5s
   os_family: Android
   browser_family: Unknown
@@ -63,19 +57,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.1.2; vivo 1719 Build/N2G47H
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y65
   os_family: Android
   browser_family: Android Browser
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; vivo 1714 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/ Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y69
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2002A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.0.10.0
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.0.10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y70s
   os_family: Android
   browser_family: Unknown
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1724) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y71
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1801 Build/OPM1.171019.011
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y71i
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1731CA Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y73
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1913A Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y7s
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1913T Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/7.8.10.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "7.8.10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y7s
   os_family: Android
   browser_family: Unknown
@@ -223,19 +201,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1808 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81
   os_family: Android
   browser_family: Android Browser
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1803 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1808i) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1812 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/5.5.2
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "5.5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81i
   os_family: Android
   browser_family: Unknown
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1732T Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81s
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; V1732A Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.6.0.1040 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.6.0.1040"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y81s
   os_family: Android
   browser_family: Unknown
@@ -343,19 +309,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1726 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y83 Pro
   os_family: Android
   browser_family: Android Browser
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1730EA Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y89
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1811 Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y91
   os_family: Android
   browser_family: Android Browser
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1817 Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y91
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; VIV-vivo Y913/PD1304CV_A_1.18.2; 854*480; CTC/2.0) AppleWebKit/537.36 (KHTML,like Gecko) Version/4.0 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y913
   os_family: Android
   browser_family: Android Browser
@@ -443,19 +399,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; vivo 1820 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y91i
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1816 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y91i
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1814 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 YaApp_Android/9.36 YaSearchBrowser/9.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1815 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 YaApp_Android/9.35 YaSearchBrowser/9.35
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1818T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; V1818A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.5.90.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.5.90.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93
   os_family: Android
   browser_family: Unknown
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1818CT Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93s
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; V1818CA Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.0.1187 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.0.1187"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y93s
   os_family: Android
   browser_family: Unknown
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; vivo 1807) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y95
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1813T Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y97
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1813A Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/7.1.0.1
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "7.1.0.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y97
   os_family: Android
   browser_family: Unknown
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1945A Build/PKQ1.190626.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Y9s
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1801A0 Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/6.6.3.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "6.6.3.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z1
   os_family: Android
   browser_family: Unknown
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1730DA Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z1i
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1730DT Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z1i
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; vivo 1917 Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/6.5.1.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "6.5.1.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z1x
   os_family: Android
   browser_family: Unknown
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1813BA Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z3
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V1813BT Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/039408 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z3
   os_family: Android
   browser_family: Unknown
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1730GA Build/PKQ1.180819.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z3x
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1921A Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z5
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1911A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z5x
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; V1990A Build/PKQ1.181030.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.0.2.1082 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.2.1082"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z5x (2020)
   os_family: Android
   browser_family: Unknown
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V1963A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/7.6.18.3
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "7.6.18.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: Z6
   os_family: Android
   browser_family: Unknown
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Baccara Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Baccara
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Eagle_4G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Eagle 4G
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Impress Action Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/42.0.2311.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "42.0.2311.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Action
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Impress Alfa Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Alfa
   os_family: Android
   browser_family: Chrome
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Impress Bravo Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Bravo
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Impress_Calypso Build/XING29N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Calypso
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IMPRESS CLICK Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: IMPRESS CLICK
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Impress Cult Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Cult
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Impress_Dune Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Dune
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Impress_Eagle Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Eagle
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Impress_Energy Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 YandexSearch/6.10
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Energy
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ImpressMAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Max
   os_family: Android
   browser_family: Chrome
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Impress_Wolf) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress Wolf
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Impress XXL Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Impress XXL
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lion_Dual Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VX
+    brand: Vertex
     model: Lion Dual
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SP5026i-Scorpio Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: W1
+    brand: Woo
     model: Scorpio
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; Wigor V4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 YaBrowser/19.12.1.121.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.12.1.121.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: W2
+    brand: Wigor
     model: V4
   os_family: Android
   browser_family: Unknown
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us ; Walton Primo Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/444
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.3.0.143"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo
   os_family: Android
   browser_family: Unknown
@@ -1263,19 +1137,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; WALTON_Primo_C1) U2/1.0.0 UCBrowser/9.0.2.389 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo C1
   os_family: GNU/Linux
   browser_family: Opera
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Primo D2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo D2
   os_family: Android
   browser_family: Android Browser
@@ -1303,19 +1173,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Primo_D4) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo D4
   os_family: Android
   browser_family: Unknown
@@ -1323,19 +1191,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Primo D6 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo D6
   os_family: Android
   browser_family: Android Browser
@@ -1343,19 +1209,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Primo D8 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo D8
   os_family: Android
   browser_family: Android Browser
@@ -1363,19 +1227,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Primo E8 Build/6.0)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo E8
   os_family: Android
   browser_family: Android Browser
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo F7 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo F7
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Primo G4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo G4
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Primo G6 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo G6
   os_family: Android
   browser_family: Android Browser
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Primo G7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo G7
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Primo H4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo H4
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo H6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo H6
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Primo_HM Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo HM
   os_family: Android
   browser_family: Android Browser
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo R4 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo R4
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Primo R6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo R6
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Primo S3 mini Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Mobile Safari/537.36 OPR/29.0.1809.91837
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "29.0.1809.91837"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo S3 mini
   os_family: Android
   browser_family: Opera
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo_S5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo S5
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Primo S6 infinity) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo S6 Infinity
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo X4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo X4
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Primo X4 Pro Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WA
+    brand: Walton
     model: Primo X4 Pro
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Wileyfox Spark AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.979.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.979.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Spark
   os_family: Android
   browser_family: Unknown
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Wileyfox Spark + Build/MMB29X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Spark +
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Wileyfox Spark + AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Spark +
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Wileyfox Spark X AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.2.730.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.2.730.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Spark X
   os_family: Android
   browser_family: Unknown
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Wileyfox Storm) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Storm
   os_family: Android
   browser_family: Chrome
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Wileyfox Swift Build/MOB30R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift
   os_family: Android
   browser_family: Chrome
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Wileyfox Swift AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Swift 2 Build/MHC19Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift 2
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; Swift 2 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift 2
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Swift 2 Plus Build/MHC19Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; Swift 2 Plus AppleWebKit/537.36 KHTML, like Gecko Chrome/77.0.3828.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3828.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; Swift 2 X AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WF
+    brand: Wileyfox
     model: Swift 2 X
   os_family: Android
   browser_family: Chrome
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; AT-AS43D3 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WG
+    brand: Wolfgang
     model: AT-AS43D3
   os_family: Android
   browser_family: Chrome
@@ -1923,19 +1731,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; AT-AS45D1 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WG
+    brand: Wolfgang
     model: AT-AS45D1
   os_family: Android
   browser_family: Android Browser
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BARRY Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Barry
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BIRDY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Birdy
   os_family: Android
   browser_family: Chrome
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BLOOM Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Bloom
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; CINK FIVE Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink FIVE
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; CINK KING Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink KING
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; CINK PEAX Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink PEAX
   os_family: Android
   browser_family: Android Browser
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ro-ro; CINK PEAX 2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink Peax 2
   os_family: Android
   browser_family: Android Browser
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; CINK PEAX 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink Peax 2
   os_family: Android
   browser_family: Chrome
@@ -2103,19 +1893,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; en-US; CINK_PEAX_2) U2/1.0.0 UCBrowser/9.1.1.420 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.1.420"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink PEAX 2
   os_family: Android
   browser_family: Unknown
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; WIKO-CINK SLIM Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink SLIM
   os_family: Android
   browser_family: Android Browser
@@ -2143,19 +1929,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.1; en-US; CINK_SLIM) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink SLIM
   os_family: Android
   browser_family: Unknown
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; CINK+ Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Cink+
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; DARKFULL Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Darkfull
   os_family: Android
   browser_family: Android Browser
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; DARKMOON Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Darkmoon
   os_family: Android
   browser_family: Chrome
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; DARKNIGHT Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Darknight
   os_family: Android
   browser_family: Android Browser
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; DARKSIDE Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Darkside
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; FREDDY Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Freddy
   os_family: Android
   browser_family: Chrome
@@ -2283,7 +2055,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; GETAWAY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/24.0.0.30.15;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2292,7 +2063,7 @@
     version: "24.0.0.30.15"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Getaway
   os_family: Android
   browser_family: Unknown
@@ -2300,19 +2071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GOA Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Goa
   os_family: Android
   browser_family: Chrome
@@ -2320,7 +2089,6 @@
   user_agent: Deezer/5.4.22.54 (Android; 7.0; Mobile; fr) WIKO HARRY
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -2329,7 +2097,7 @@
     version: "5.4.22.54"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Harry
   os_family: Android
   browser_family: Unknown
@@ -2337,19 +2105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HARRY Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Harry
   os_family: Android
   browser_family: Chrome
@@ -2357,19 +2123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HIGHWAY Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Highway
   os_family: Android
   browser_family: Chrome
@@ -2377,19 +2141,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; HIGHWAY_SIGNS) U2/1.0.0 UCBrowser/9.2.0.419 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.419"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Highway SIGNS
   os_family: Android
   browser_family: Unknown
@@ -2397,19 +2159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IGGY Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Iggy
   os_family: Android
   browser_family: Chrome
@@ -2417,19 +2177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; JERRY Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry
   os_family: Android
   browser_family: Chrome
@@ -2437,19 +2195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; JERRY) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry
   os_family: Android
   browser_family: Chrome
@@ -2457,19 +2213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JERRY2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry 2
   os_family: Android
   browser_family: Chrome
@@ -2477,19 +2231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JERRY2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry 2
   os_family: Android
   browser_family: Chrome
@@ -2497,19 +2249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; W_K300 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry 3
   os_family: Android
   browser_family: Chrome
@@ -2517,19 +2267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; JERRY MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jerry Max
   os_family: Android
   browser_family: Chrome
@@ -2537,19 +2285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; it-it; JIMMY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Jimmy
   os_family: Android
   browser_family: Chrome
@@ -2557,7 +2303,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; KITE Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/24.0.0.30.15;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2566,7 +2311,7 @@
     version: "24.0.0.30.15"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Kite
   os_family: Android
   browser_family: Unknown
@@ -2574,19 +2319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LENNY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny
   os_family: Android
   browser_family: Chrome
@@ -2594,19 +2337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LENNY2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 2
   os_family: Android
   browser_family: Chrome
@@ -2614,19 +2355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LENNY2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 2
   os_family: Android
   browser_family: Chrome
@@ -2634,7 +2373,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; LENNY3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/134.0.0.25.91;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -2643,7 +2381,7 @@
     version: "134.0.0.25.91"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 3
   os_family: Android
   browser_family: Unknown
@@ -2651,19 +2389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LENNY3 MAX Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 3 Max
   os_family: Android
   browser_family: Chrome
@@ -2671,19 +2407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenny4 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 4
   os_family: Android
   browser_family: Chrome
@@ -2691,19 +2425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenny4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 4
   os_family: Android
   browser_family: Chrome
@@ -2711,19 +2443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenny4 Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 4 Plus
   os_family: Android
   browser_family: Chrome
@@ -2731,19 +2461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; W_K400) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Lenny 5
   os_family: Android
   browser_family: Chrome
@@ -2751,19 +2479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; U307AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Life 2
   os_family: Android
   browser_family: Chrome
@@ -2771,7 +2497,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; OZZY Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.4.15.1143430.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -2780,7 +2505,7 @@
     version: "3.4.15.1143430"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ozzy
   os_family: Android
   browser_family: Unknown
@@ -2788,19 +2513,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; OZZY Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ozzy
   os_family: Android
   browser_family: Unknown
@@ -2808,19 +2531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PULP Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Pulp
   os_family: Android
   browser_family: Chrome
@@ -2828,19 +2549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PULP 4G Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Pulp 4G
   os_family: Android
   browser_family: Chrome
@@ -2848,19 +2567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PULP FAB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Pulp Fab
   os_family: Android
   browser_family: Chrome
@@ -2868,19 +2585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PULP FAB 4G Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Pulp Fab 4G
   os_family: Android
   browser_family: Chrome
@@ -2888,19 +2603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PULP FAB 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Pulp Fab 4G
   os_family: Android
   browser_family: Chrome
@@ -2908,19 +2621,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; RAINBOW Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow
   os_family: Android
   browser_family: Android Browser
@@ -2928,19 +2639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RAINBOW 4G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow 4G
   os_family: Android
   browser_family: Chrome
@@ -2948,19 +2657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RAINBOW JAM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow JAM
   os_family: Android
   browser_family: Chrome
@@ -2968,19 +2675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; RAINBOW LITE 4G Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow LITE 4G
   os_family: Android
   browser_family: Chrome
@@ -2988,19 +2693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; RAINBOW UP Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow UP
   os_family: Android
   browser_family: Chrome
@@ -3008,19 +2711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RAINBOW UP 4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Rainbow UP 4G
   os_family: Android
   browser_family: Chrome
@@ -3028,19 +2729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-U300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ride
   os_family: Android
   browser_family: Chrome
@@ -3048,19 +2747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RIDGE Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ridge
   os_family: Android
   browser_family: Chrome
@@ -3068,19 +2765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; RIDGE 4G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ridge 4G
   os_family: Android
   browser_family: Chrome
@@ -3088,19 +2783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; RIDGE FAB 4G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Ridge Fab 4G
   os_family: Android
   browser_family: Chrome
@@ -3108,7 +2801,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; ROBBY Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/148.0.0.51.62;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -3117,7 +2809,7 @@
     version: "148.0.0.51.62"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Robby
   os_family: Android
   browser_family: Unknown
@@ -3125,19 +2817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SLIDE Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Slide
   os_family: Android
   browser_family: Chrome
@@ -3145,19 +2835,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; STAIRWAY Build/JOP40D)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Stairway
   os_family: Android
   browser_family: Android Browser
@@ -3165,19 +2853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; STAIRWAY Build/JOP40D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Stairway
   os_family: Android
   browser_family: Chrome
@@ -3185,19 +2871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SUBLIM Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sublim
   os_family: Android
   browser_family: Android Browser
@@ -3205,19 +2889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUNNY Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunny
   os_family: Android
   browser_family: Chrome
@@ -3225,19 +2907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUNNY2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunny 2
   os_family: Android
   browser_family: Chrome
@@ -3245,19 +2925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Sunny2 Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunny 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -3265,19 +2943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Sunny3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunny 3
   os_family: Android
   browser_family: Chrome
@@ -3285,19 +2961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K360-TV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunny 4 Plus
   os_family: Android
   browser_family: Chrome
@@ -3305,19 +2979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SUNSET Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunset
   os_family: Android
   browser_family: Chrome
@@ -3325,19 +2997,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; SUNSET2 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunset 2
   os_family: Android
   browser_family: Android Browser
@@ -3345,19 +3015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SUNSET2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Sunset 2
   os_family: Android
   browser_family: Chrome
@@ -3365,19 +3033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TOMMY Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy
   os_family: Android
   browser_family: Chrome
@@ -3385,19 +3051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TOMMY2 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy 2
   os_family: Android
   browser_family: Chrome
@@ -3405,19 +3069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Tommy2 Plus Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -3425,19 +3087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; W_K600 Build/N6F26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy 3
   os_family: Android
   browser_family: Chrome
@@ -3445,19 +3105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Tommy3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy 3
   os_family: Android
   browser_family: Chrome
@@ -3465,7 +3123,6 @@
   user_agent: com.google.android.apps.searchlite/114914 (Linux; U; Android 8.1.0; it_IT; W_C200SN; Build/O11019; Cronet/74.0.3729.182)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -3474,7 +3131,7 @@
     version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Tommy 3
   os_family: Android
   browser_family: Unknown
@@ -3482,7 +3139,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 6.0; U FEEL LITE Build/MRA58K)'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -3491,7 +3147,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: U Feel Lite
   os_family: Android
   browser_family: Unknown
@@ -3499,7 +3155,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 7.1.1; U FEEL PRIME Build/NMF26F)'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
@@ -3508,7 +3163,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: U Feel Prime
   os_family: Android
   browser_family: Unknown
@@ -3516,7 +3171,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; U PULSE Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 Instagram 51.0.0.20.85 Android (24/7.0; 320dpi; 720x1184; WIKO; U PULSE; v3961; mt6735; fr_FR; 115211358)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -3525,7 +3179,7 @@
     version: "51.0.0.20.85"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: U Pulse
   os_family: Android
   browser_family: Unknown
@@ -3533,19 +3187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; U PULSE LITE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: U Pulse Lite
   os_family: Android
   browser_family: Chrome
@@ -3553,19 +3205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; W_C800 Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 2
   os_family: Android
   browser_family: Chrome
@@ -3573,19 +3223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; View2 Go) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 2 Go
   os_family: Android
   browser_family: Chrome
@@ -3593,19 +3241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-P311-OPE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3
   os_family: Android
   browser_family: Chrome
@@ -3613,19 +3259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-P311-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3
   os_family: Android
   browser_family: Chrome
@@ -3633,19 +3277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-V800-TVM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3 Lite
   os_family: Android
   browser_family: Chrome
@@ -3653,19 +3295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-V800-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3 Lite
   os_family: Android
   browser_family: Chrome
@@ -3673,19 +3313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-V800-OPE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3 Lite
   os_family: Android
   browser_family: Chrome
@@ -3693,19 +3331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-P611-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -3713,7 +3349,6 @@
   user_agent: Deezer/5.4.23.14 (Android; 8.1.0; Mobile; fr) WIKO WC300
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -3722,7 +3357,7 @@
     version: "5.4.23.14"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View Lite
   os_family: Android
   browser_family: Unknown
@@ -3730,7 +3365,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; WC300 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 GSA/8.10.22.21.arm
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
@@ -3739,7 +3373,7 @@
     version: "8.10.22.21"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View Lite
   os_family: Android
   browser_family: Unknown
@@ -3747,19 +3381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; W_P200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: View Max
   os_family: Android
   browser_family: Chrome
@@ -3767,19 +3399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; WAX Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Wax
   os_family: Android
   browser_family: Chrome
@@ -3787,7 +3417,6 @@
   user_agent: Deezer/5.4.21.97 (Android; 7.1.1; Mobile; fr) WIKO WIM Lite
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
@@ -3796,7 +3425,7 @@
     version: "5.4.21.97"
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: WIM Lite
   os_family: Android
   browser_family: Unknown
@@ -3804,19 +3433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; WIM Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: WIM Lite
   os_family: Android
   browser_family: Chrome
@@ -3824,19 +3451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K420-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y50
   os_family: Android
   browser_family: Chrome
@@ -3844,19 +3469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K510-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y60
   os_family: Android
   browser_family: Chrome
@@ -3864,19 +3487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K510-TVM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y60
   os_family: Android
   browser_family: Chrome
@@ -3884,19 +3505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K510-SUN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y60
   os_family: Android
   browser_family: Chrome
@@ -3904,19 +3523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-K510-OPE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y60
   os_family: Android
   browser_family: Chrome
@@ -3924,19 +3541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-V720-EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y80
   os_family: Android
   browser_family: Chrome
@@ -3944,19 +3559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; W-V720-OPE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WI
+    brand: Wiko
     model: Y80
   os_family: Android
   browser_family: Chrome
@@ -3964,19 +3577,17 @@
   user_agent: mozilla/5.0 (linux; android 4.2.2; mismart wink ;) build/jdq39) applewebkit/537.36 (khtml, like gecko) chrome/32.0.1700.99 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WL
+    brand: Wolder
     model: miSmart wink ;)
   os_family: Android
   browser_family: Chrome
@@ -3984,19 +3595,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; WIAM #24 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WL
+    brand: Wolder
     model: 'Wiam #24'
   os_family: Android
   browser_family: Chrome
@@ -4004,19 +3613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; WOLDER_WIAM_65) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WL
+    brand: Wolder
     model: 'Wiam #65'
   os_family: Android
   browser_family: Chrome
@@ -4024,19 +3631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; weplus_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WM
+    brand: Weimei
     model: WePlus 3
   os_family: Android
   browser_family: Chrome
@@ -4044,19 +3649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Wink_City_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WN
+    brand: Wink
     model: City S
   os_family: Android
   browser_family: Chrome
@@ -4064,19 +3667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Wink_City_SE Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WN
+    brand: Wink
     model: City SE
   os_family: Android
   browser_family: Chrome
@@ -4084,19 +3685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wieppo S5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WP
+    brand: Wieppo
     model: S5
   os_family: Android
   browser_family: Chrome
@@ -4104,19 +3703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wieppo S6 Lite Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WP
+    brand: Wieppo
     model: S6 Lite
   os_family: Android
   browser_family: Chrome
@@ -4124,19 +3721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wieppo S8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WP
+    brand: Wieppo
     model: S8
   os_family: Android
   browser_family: Chrome
@@ -4144,19 +3739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NOTE GRACE V Build/1467862545; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WS
+    brand: Winds
     model: Note Grace V
   os_family: Android
   browser_family: Chrome
@@ -4164,19 +3757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZEN 4.5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 YaBrowser/15.4.2272.3842.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.4.2272.3842.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WY
+    brand: Wexler
     model: ZEN 4.5
   os_family: Android
   browser_family: Unknown
@@ -4184,19 +3775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ZEN 4.7 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.115 YaBrowser/15.2.2214.3725.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.2.2214.3725.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: WY
+    brand: Wexler
     model: ZEN 4.7
   os_family: Android
   browser_family: Unknown
@@ -4204,19 +3793,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-US; WEXLER. ZEN 5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.1.565 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.1.565"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: WY
+    brand: Wexler
     model: ZEN 5
   os_family: Android
   browser_family: Unknown
@@ -4224,19 +3811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; NEON_RAY Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X1
+    brand: Safaricom
     model: Neon Ray
   os_family: Android
   browser_family: Chrome
@@ -4244,19 +3829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-BO V10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V10
   os_family: Android
   browser_family: Chrome
@@ -4264,19 +3847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-BO V11 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V11
   os_family: Android
   browser_family: Chrome
@@ -4284,19 +3865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XBO V7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V7
   os_family: Android
   browser_family: Chrome
@@ -4304,19 +3883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XBO V8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V8
   os_family: Android
   browser_family: Chrome
@@ -4324,19 +3901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-BO V8+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V8+
   os_family: Android
   browser_family: Chrome
@@ -4344,19 +3919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-BO V9+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: X3
+    brand: X-BO
     model: V9+
   os_family: Android
   browser_family: Chrome
@@ -4364,19 +3937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XGODY Y17 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XG
+    brand: Xgody
     model: Y17
   os_family: Android
   browser_family: Chrome
@@ -4384,19 +3955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SKR-H0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark
   os_family: Android
   browser_family: Chrome
@@ -4404,19 +3973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SKR-A0 Build/G66X1906251CN00MPP; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark
   os_family: Android
   browser_family: Chrome
@@ -4424,19 +3991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SKW-H0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 2
   os_family: Android
   browser_family: Chrome
@@ -4444,19 +4009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SKW-A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 2
   os_family: Android
   browser_family: Chrome
@@ -4464,19 +4027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DLT-A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -4484,19 +4045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DLT-H0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -4504,19 +4063,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; SHARK KLE-A0 Build/KLEN2004201CN00MP3) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 3
   os_family: Android
   browser_family: Unknown
@@ -4524,19 +4081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SHARK MBU-A0 Build/MOBS2005071CN00MP3; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -4544,19 +4099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AWM-A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Black Shark Helo
   os_family: Android
   browser_family: Chrome
@@ -4564,19 +4117,17 @@
   user_agent: Xiaomi_2013022_TD/V1 Linux/3.4.5 Android/4.2.1 Release/03.11.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi
   os_family: Android
   browser_family: Android Browser
@@ -4584,19 +4135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; 2013023 Build/HM2013023) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi
   os_family: Android
   browser_family: Android Browser
@@ -4604,19 +4153,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; 2014011 Build/HM2014011) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360 Aphone Browser (6.9.0)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.9.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 1S
   os_family: Android
   browser_family: Unknown
@@ -4624,19 +4171,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; 2014011 Build/HM2014011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 1S
   os_family: Android
   browser_family: Android Browser
@@ -4644,19 +4189,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-us; 2014817 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.0.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.0.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2
   os_family: Android
   browser_family: Android Browser
@@ -4664,19 +4207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 2014818 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 3G
   os_family: Android
   browser_family: Chrome
@@ -4684,19 +4225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 2014818 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 3G
   os_family: Android
   browser_family: Chrome
@@ -4704,19 +4243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 2014812 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 4G
   os_family: Android
   browser_family: Android Browser
@@ -4724,19 +4261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 2014811 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100502004
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 4G
   os_family: Android
   browser_family: Chrome
@@ -4744,19 +4279,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; it-it; 2014811 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 4G
   os_family: Android
   browser_family: Android Browser
@@ -4764,19 +4297,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; it-it; 2014813 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 2 4G
   os_family: Android
   browser_family: Android Browser
@@ -4784,19 +4315,17 @@
   user_agent: Xiaomi_2014501_TD-LTE/V1 Linux/3.10.0 Android/4.4 Release/04.07.2014 Browser/AppleWebKit537.36 Chrome/30.0.0.0 Mobile Safari/537.36 System/Android 4.4 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 4G
   os_family: Android
   browser_family: Android Browser
@@ -4804,19 +4333,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; 2014501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 4G
   os_family: Android
   browser_family: Android Browser
@@ -4824,19 +4351,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; 2014501 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Hongmi 4G
   os_family: Android
   browser_family: Unknown
@@ -4844,19 +4369,17 @@
   user_agent: Xiaomi_M2001J2E_TD-LTE/V1 Linux/4.19.72 Android/10 Release/15.11.2019 Browser/AppleWebKit537.36 Mobile Safari/537.36 System/Android 10 XiaoMi/MiuiBrowser/11.0.13
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "11.0.13"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10
   os_family: Android
   browser_family: Android Browser
@@ -4864,19 +4387,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; M2002J9E Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.5.5.1035 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.5.5.1035"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10 Lite 5G
   os_family: Android
   browser_family: Unknown
@@ -4884,19 +4405,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; M2007J1SC Build/QKQ1.200419.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/13.0.28
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "13.0.28"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10 Ultra 5G
   os_family: Android
   browser_family: Android Browser
@@ -4904,19 +4423,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; MI 1S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 1S
   os_family: Android
   browser_family: Android Browser
@@ -4924,19 +4441,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; MI 1S Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 1S
   os_family: Android
   browser_family: Android Browser
@@ -4944,19 +4459,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MI 2 Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 2
   os_family: Android
   browser_family: Android Browser
@@ -4964,7 +4477,6 @@
   user_agent: com.douban.group/2.2.0(220) Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2A Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -4973,7 +4485,7 @@
     version: "2.2.0"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 2A
   os_family: Android
   browser_family: Unknown
@@ -4981,19 +4493,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; MI 2A Build/JRO03L) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 2A
   os_family: Android
   browser_family: Unknown
@@ -5001,19 +4511,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; MI 2S Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 2S
   os_family: Android
   browser_family: Android Browser
@@ -5021,19 +4529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; MI 2SC Build/JRO03L) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 2SC
   os_family: Android
   browser_family: Unknown
@@ -5041,19 +4547,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; MI 3 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 3
   os_family: Android
   browser_family: Android Browser
@@ -5061,19 +4565,17 @@
   user_agent: Xiaomi_2013061_TD/V1 Linux/3.4.5 Android/4.2.1 Release/09.18.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 3
   os_family: Android
   browser_family: Android Browser
@@ -5081,19 +4583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; MI 3W Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 3W
   os_family: Android
   browser_family: Chrome
@@ -5101,19 +4601,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; MI 3W Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 3W
   os_family: Android
   browser_family: Android Browser
@@ -5121,19 +4619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Mi-4c Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 4C
   os_family: Android
   browser_family: Chrome
@@ -5141,19 +4637,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; pl-pl; Mi-4c Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.85 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.1.1
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.1.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 4C
   os_family: Android
   browser_family: Android Browser
@@ -5161,7 +4655,6 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; MI 4LTE MIUI/V7.3.2.0.MXDCNDD) NewsArticle/5.1.3
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -5170,7 +4663,7 @@
     version: "5.1.3"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 4LTE
   os_family: Android
   browser_family: Unknown
@@ -5178,19 +4671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; MI 5s Plus Build/MXB48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 5s Plus
   os_family: Android
   browser_family: Chrome
@@ -5198,19 +4689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MI 8 Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 8 Lite
   os_family: Android
   browser_family: Chrome
@@ -5218,19 +4707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Mi9 Pro 5G Build/QKQ1.190825.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 9 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -5238,19 +4725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Mi 9 SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 9 SE
   os_family: Android
   browser_family: Chrome
@@ -5258,19 +4743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Mi 9T Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 9T Pro
   os_family: Android
   browser_family: Chrome
@@ -5278,19 +4761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Mi A1 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Mi A1
   os_family: Android
   browser_family: Chrome
@@ -5298,19 +4779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Mi A2 Lite Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI A2 Lite
   os_family: Android
   browser_family: Chrome
@@ -5318,19 +4797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Mi A2 Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI A2 Lite
   os_family: Android
   browser_family: Chrome
@@ -5338,19 +4815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MI CC 9 Meitu Edition Build/QKQ1.190828.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI CC 9
   os_family: Android
   browser_family: Chrome
@@ -5358,19 +4833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MI MAX 2 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MAX 2
   os_family: Android
   browser_family: Chrome
@@ -5378,19 +4851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MI MAX 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MAX 2
   os_family: Android
   browser_family: Chrome
@@ -5398,19 +4869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MI MAX 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MAX 3
   os_family: Android
   browser_family: Chrome
@@ -5418,19 +4887,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; de-de; MI MAX 3 Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.0.5
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "10.0.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MAX 3
   os_family: Android
   browser_family: Android Browser
@@ -5438,19 +4905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MIX Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MIX
   os_family: Android
   browser_family: Chrome
@@ -5458,7 +4923,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; MIX 2 Build/OPR1.170623.027; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043909 Mobile Safari/537.36 MicroMessenger/6.6.5.1280(0x26060536) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -5467,7 +4931,7 @@
     version: "6.6.5.1280(0x26060536)"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MIX 2
   os_family: Android
   browser_family: Unknown
@@ -5475,19 +4939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; MIX 2S Build/OPR1.170623.032; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044113 Mobile Safari/537.36 V1_AND_SQ_7.7.0_882_YYB_D PA QQ/7.7.0.3640 NetType/4G WebP/0.3.0 Pixel/1080
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MIX 2S
   os_family: Android
   browser_family: Unknown
@@ -5495,19 +4957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Mi MIX 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MIX 3
   os_family: Android
   browser_family: Chrome
@@ -5515,19 +4975,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; de-de; Mi MIX 3 Build/PKQ1.180729.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/MiuiBrowser/10.8.3-g
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "10.8.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI MIX 3
   os_family: Android
   browser_family: Android Browser
@@ -5535,19 +4993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MI PLAY) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI Play
   os_family: Android
   browser_family: Chrome
@@ -5555,19 +5011,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 8.1.0; en-US; MI_PLAY) U2/1.0.0 UCBrowser/9.8.0.534 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.0.534"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI Play
   os_family: Android
   browser_family: Unknown
@@ -5575,19 +5029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; MI-ONE Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI-ONE
   os_family: Android
   browser_family: Android Browser
@@ -5595,19 +5047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; MI-ONE C1 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025442 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI-ONE C1
   os_family: Android
   browser_family: Unknown
@@ -5615,19 +5065,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; MI-ONE_Plus Build/GINGERBREAD; 480*854) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1/UCWEB7.9.3.103/139/800'
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "7.9.3.103"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI-ONE Plus
   os_family: Android
   browser_family: Unknown
@@ -5635,19 +5083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MI-ONE Plus Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/2.2 Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "2.2"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI-ONE Plus
   os_family: Android
   browser_family: Baidu
@@ -5655,19 +5101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; MI-ONEPlus) AppleWebKit/534.13 (KHTML, like Gecko) UCBrowser/8.6.0.199 U3/0.8.0 Mobile Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.199"
     engine: WebKit
     engine_version: "534.13"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI-ONEPlus
   os_family: Android
   browser_family: Unknown
@@ -5675,19 +5119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POCOPHONE F1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Pocophone F1
   os_family: Android
   browser_family: Chrome
@@ -5695,19 +5137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POCO F1 Build/PKQ1.180729.001; wv) AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Pocophone F1
   os_family: Android
   browser_family: Chrome
@@ -5715,19 +5155,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 9; ru; POCOPHONE_F1) U2/1.0.0 UCBrowser/11.1.2.1113 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.1.2.1113"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Pocophone F1
   os_family: Android
   browser_family: Unknown
@@ -5735,19 +5173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; HM 1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 1
   os_family: Android
   browser_family: Android Browser
@@ -5755,19 +5191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; M2004J7AC Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.1.16
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "12.1.16"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 10X
   os_family: Android
   browser_family: Android Browser
@@ -5775,19 +5209,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; M2004J7BC Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/12.3.18
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "12.3.18"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 10X Pro
   os_family: Android
   browser_family: Android Browser
@@ -5795,19 +5227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; HM 1S Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 1S
   os_family: Android
   browser_family: Chrome
@@ -5815,19 +5245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; HM 1SC Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 1S
   os_family: Android
   browser_family: Android Browser
@@ -5835,19 +5263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; HM 1SW Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36 XiaoMi/MiuiBrowser/2.0.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "2.0.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 1S
   os_family: Android
   browser_family: Android Browser
@@ -5855,19 +5281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Redmi 1S Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 1S
   os_family: Android
   browser_family: Chrome
@@ -5875,19 +5299,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; wt88047 MIUI/LVY48I)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 2
   os_family: Android
   browser_family: Android Browser
@@ -5895,19 +5317,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; HM2014819 MIUI/V8.7.7.26.SWING PRO)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 2 Pro
   os_family: Android
   browser_family: Android Browser
@@ -5915,19 +5335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; HM 2A Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 2A
   os_family: Android
   browser_family: Chrome
@@ -5935,19 +5353,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 5.1.1; en-US; Redmi_3) U2/1.0.0 UCBrowser/9.7.0.520 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.0.520"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 3
   os_family: Android
   browser_family: Unknown
@@ -5955,19 +5371,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; Redmi 3S MIUI/6.12.8)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 3S
   os_family: Android
   browser_family: Android Browser
@@ -5975,19 +5389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Redmi 4A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 4A
   os_family: Android
   browser_family: Chrome
@@ -5995,19 +5407,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; ru-ru; Redmi 4A Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/Mint Browser/1.3.3
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Mint Browser
-    short_name: MT
     version: "1.3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 4A
   os_family: Android
   browser_family: Chrome
@@ -6015,7 +5425,6 @@
   user_agent: Deezer/5.4.21.97 (Android; 7.1.2; Mobile; fr) Xiaomi Redmi 4X
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
@@ -6024,7 +5433,7 @@
     version: "5.4.21.97"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 4X
   os_family: Android
   browser_family: Unknown
@@ -6032,19 +5441,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; en-us; Redmi 5 Plus Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.146 Mobile Safari/537.36 XiaoMi/MiuiBrowser/9.5.6
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "9.5.6"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 5 Plus
   os_family: Android
   browser_family: Android Browser
@@ -6052,19 +5459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Redmi 5 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 5 Plus
   os_family: Android
   browser_family: Chrome
@@ -6072,19 +5477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Redmi 5A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 5A
   os_family: Android
   browser_family: Chrome
@@ -6092,19 +5495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2004J19C Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9
   os_family: Android
   browser_family: Chrome
@@ -6112,19 +5513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3LC Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.156 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.156"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9A
   os_family: Android
   browser_family: Chrome
@@ -6132,19 +5531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3LG Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9A
   os_family: Android
   browser_family: Chrome
@@ -6152,19 +5549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Redmi K20 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi K20 Pro
   os_family: Android
   browser_family: Chrome
@@ -6172,19 +5567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 20190416Q Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: 20190416Q
   os_family: Android
   browser_family: Chrome
@@ -6192,19 +5585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 20180322D Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: E Sports
   os_family: Android
   browser_family: Chrome
@@ -6212,19 +5603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; LA2-L Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: LA2-L
   os_family: Android
   browser_family: Chrome
@@ -6232,19 +5621,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; LA2-S Build/KTU84P AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: LA2-S
   os_family: Android
   browser_family: Chrome
@@ -6252,19 +5639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; LA2-SN Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: LA2-SN
   os_family: Android
   browser_family: Chrome
@@ -6272,19 +5657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HLA Note3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: Red Pepper Note 3
   os_family: Android
   browser_family: Chrome
@@ -6292,19 +5675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 20170608S Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XL
+    brand: Xiaolajiao
     model: Red Pepper Plus
   os_family: Android
   browser_family: Chrome
@@ -6312,19 +5693,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MC-X7MINI Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: XM
+    brand: Macoox
     model: MC-X7 Mini
   os_family: Android
   browser_family: Android Browser
@@ -6332,19 +5711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XI-CE655 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XN
+    brand: Xion
     model: CE655
   os_family: Android
   browser_family: Chrome
@@ -6352,19 +5729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XI-CEU4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XN
+    brand: Xion
     model: CEU4
   os_family: Android
   browser_family: Chrome
@@ -6372,19 +5747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XI-CEU8 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XN
+    brand: Xion
     model: CEU8
   os_family: Android
   browser_family: Chrome
@@ -6392,19 +5765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLACK-1XM Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Black 1X
   os_family: Android
   browser_family: Chrome
@@ -6412,7 +5783,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Omega 5.0 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ARM
   client:
@@ -6421,7 +5791,7 @@
     version: "3.4.16.1149292"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Omega 5.0
   os_family: Android
   browser_family: Unknown
@@ -6429,19 +5799,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Omega_5.5 Build/KOT49H) AppleWebKit/528.5 (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/10.1.2.571 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.2.571"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Omega 5.5
   os_family: Android
   browser_family: Unknown
@@ -6449,19 +5817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XOLO One Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: One
   os_family: Android
   browser_family: Chrome
@@ -6469,19 +5835,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; en-US; Q1000 Opus) U2/1.0.0 UCBrowser/9.0.1.275 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.1.275"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q1000 Opus
   os_family: Android
   browser_family: Unknown
@@ -6489,19 +5853,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q1000s Plus Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q1000s Plus
   os_family: Android
   browser_family: Android Browser
@@ -6509,19 +5871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q1010i Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q1010i
   os_family: Android
   browser_family: Chrome
@@ -6529,19 +5889,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q2000 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q2000
   os_family: Android
   browser_family: Android Browser
@@ -6549,7 +5907,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q600 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -6558,7 +5915,7 @@
     version: "3.4.16.1149292"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q600
   os_family: Android
   browser_family: Unknown
@@ -6566,19 +5923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q600 Club Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q600 Club
   os_family: Android
   browser_family: Chrome
@@ -6586,19 +5941,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q700 Build/XOLOQ700) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q700
   os_family: Android
   browser_family: Android Browser
@@ -6606,7 +5959,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q700 Build/XOLOQ700) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.2.17.1009776.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -6615,7 +5967,7 @@
     version: "3.2.17.1009776"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q700
   os_family: Android
   browser_family: Unknown
@@ -6623,19 +5975,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-in; XOLO_Q800 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q800
   os_family: Android
   browser_family: Android Browser
@@ -6643,19 +5993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Q800 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: Q800
   os_family: Android
   browser_family: Android Browser
@@ -6663,19 +6011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XOLO_X1000 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XO
+    brand: Xolo
     model: X1000
   os_family: Android
   browser_family: Chrome
@@ -6683,19 +6029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Era 2X Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XR
+    brand: Xoro
     model: Era 2X
   os_family: Android
   browser_family: Chrome
@@ -6703,19 +6047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Xshitou P7 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XS
+    brand: Xshitou
     model: P7
   os_family: Android
   browser_family: Chrome
@@ -6723,19 +6065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X-TIGI_J110 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XT
+    brand: X-TIGI
     model: J110
   os_family: Android
   browser_family: Chrome
@@ -6743,19 +6083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X-TIGI_Photo P11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XT
+    brand: X-TIGI
     model: Photo P11
   os_family: Android
   browser_family: Chrome
@@ -6763,19 +6101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X_TIGI_Photo P16 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XT
+    brand: X-TIGI
     model: Photo P16
   os_family: Android
   browser_family: Chrome
@@ -6783,7 +6119,6 @@
   user_agent: com.google.android.apps.searchlite/47202 (Linux; U; Android 8.1.0; en_US; X_TIGI_V19; Build/O11019; Cronet/66.0.3359.100)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -6792,7 +6127,7 @@
     version: ""
   device:
     type: smartphone
-    brand: XT
+    brand: X-TIGI
     model: V19
   os_family: Android
   browser_family: Unknown
@@ -6800,19 +6135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X-TIGI_V28 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XT
+    brand: X-TIGI
     model: V28 LTE
   os_family: Android
   browser_family: Chrome
@@ -6820,19 +6153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZEN_U5+ Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XV
+    brand: X-View
     model: ZEN U5+
   os_family: Android
   browser_family: Chrome
@@ -6840,19 +6171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; YU5014 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Ace
   os_family: Android
   browser_family: Chrome
@@ -6860,19 +6189,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; YU4711 Build/M4B30X)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yunique
   os_family: Android
   browser_family: Android Browser
@@ -6880,19 +6207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; YU5010A Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yuphoria
   os_family: Android
   browser_family: Chrome
@@ -6900,19 +6225,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; YU5010 Build/MOB30J)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yuphoria
   os_family: Android
   browser_family: Android Browser
@@ -6920,19 +6243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; AO5510 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yureka
   os_family: Android
   browser_family: Chrome
@@ -6940,19 +6261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; YU5510A Build/HDYU5510A) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yureka Plus
   os_family: Android
   browser_family: Chrome
@@ -6960,19 +6279,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; YU5510 Build/MOB31K)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yureka Plus
   os_family: Android
   browser_family: Android Browser
@@ -6980,19 +6297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; YU5050) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y1
+    brand: Yu
     model: Yutopia
   os_family: Android
   browser_family: Chrome
@@ -7000,19 +6315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; M631Y Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y2
+    brand: 'Yes'
     model: Altitude
   os_family: Android
   browser_family: Chrome
@@ -7020,19 +6333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M651G_MY) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: Y2
+    brand: 'Yes'
     model: Altitude 2
   os_family: Android
   browser_family: Chrome
@@ -7040,19 +6351,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; YES MPY48 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: Y2
+    brand: 'Yes'
     model: MPY48
   os_family: Android
   browser_family: Android Browser
@@ -7060,19 +6369,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; YES MPY54 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: Y2
+    brand: 'Yes'
     model: MPY54
   os_family: Android
   browser_family: Android Browser
@@ -7080,19 +6387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YNDX-000SB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YD
+    brand: Yandex
     model: YNDX-000SB
   os_family: Android
   browser_family: Chrome
@@ -7100,19 +6405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YNDX000SB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YD
+    brand: Yandex
     model: YNDX-000SB
   os_family: Android
   browser_family: Chrome
@@ -7120,19 +6423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_35E2I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 3.5E2I
   os_family: Android
   browser_family: Chrome
@@ -7140,19 +6441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Andy 3.5EI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 3.5EI
   os_family: Android
   browser_family: Chrome
@@ -7160,19 +6459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_35EI2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 3.5EI2
   os_family: Android
   browser_family: Chrome
@@ -7180,19 +6477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ANDY_45EL Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4.5EL
   os_family: Android
   browser_family: Chrome
@@ -7200,19 +6495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Andy 4.7T Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4.7T
   os_family: Android
   browser_family: Chrome
@@ -7220,19 +6513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_4E2I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4E2I
   os_family: Android
   browser_family: Chrome
@@ -7240,19 +6531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4E4 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4E4
   os_family: Android
   browser_family: Chrome
@@ -7260,19 +6549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Yezz-AC4EI Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4EI
   os_family: Android
   browser_family: Chrome
@@ -7280,19 +6567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_4EI2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4EI2
   os_family: Android
   browser_family: Chrome
@@ -7300,19 +6585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ANDY_4EL2_LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 4EL2 LTE
   os_family: Android
   browser_family: Chrome
@@ -7320,19 +6603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Andy_55EI Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 55EI
   os_family: Android
   browser_family: Chrome
@@ -7340,19 +6621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_5EI Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5EI
   os_family: Android
   browser_family: Chrome
@@ -7360,19 +6639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ANDY 5EI Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5EI
   os_family: Android
   browser_family: Chrome
@@ -7380,19 +6657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ANDY_5EL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5EL
   os_family: Android
   browser_family: Chrome
@@ -7400,19 +6675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Andy 5EL2 LTE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5EL2 LTE
   os_family: Android
   browser_family: Chrome
@@ -7420,19 +6693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Andy_5ML_LTE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5ML LTE
   os_family: Android
   browser_family: Chrome
@@ -7440,19 +6711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Andy_5T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy 5T
   os_family: Android
   browser_family: Chrome
@@ -7460,19 +6729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; yezz Andy A3.5EP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy A3.5EP
   os_family: Android
   browser_family: Chrome
@@ -7480,19 +6747,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; YEZZ-A4M Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy A4M
   os_family: Android
   browser_family: Android Browser
@@ -7500,19 +6765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A5EI Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy A5EI
   os_family: Android
   browser_family: Chrome
@@ -7520,19 +6783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ANDY_C5QL Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YE
+    brand: Yezz
     model: Andy C5QL
   os_family: Android
   browser_family: Chrome
@@ -7540,19 +6801,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.3; YD206 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YO
+    brand: Yota
     model: Phone 2
   os_family: Android
   browser_family: Chrome
@@ -7560,19 +6819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; YD201) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YO
+    brand: Yota
     model: Phone 2
   os_family: Android
   browser_family: Chrome
@@ -7580,19 +6837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; YOTA 3+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YO
+    brand: Yota
     model: Phone 3 Plus
   os_family: Android
   browser_family: Chrome
@@ -7600,19 +6855,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; LA2-T Build/YUSUNLA2-T) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.6.428 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.6.428"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: YS
+    brand: Yusun
     model: LA2-T
   os_family: Android
   browser_family: Unknown
@@ -7620,19 +6873,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.6; zh-CN; YUSUN W306) U2/1.0.0 UCBrowser/9.6.2.404 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: YS
+    brand: Yusun
     model: W306
   os_family: Android
   browser_family: Unknown
@@ -7640,19 +6891,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; yusun W702 Build/ALPS.GB.FDD2.MP.V2.14) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: YS
+    brand: Yusun
     model: W702
   os_family: Android
   browser_family: Android Browser
@@ -7660,19 +6909,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; YTONE_L919_TD/1.0 Android/4.0.3 Release/6.20.2013 Browser/AppleWebKit534.30 Build/MocorDroid4.0.3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: YT
+    brand: Ytone
     model: L919
   os_family: Android
   browser_family: Android Browser
@@ -7680,19 +6927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; YTONE L985S Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YT
+    brand: Ytone
     model: L985S
   os_family: Android
   browser_family: Chrome
@@ -7700,19 +6945,17 @@
   user_agent: YTONE L988_TD/Linux/3.4.39 Android/4.3 Release/08.15.2013 Browser/AppleWebkit534.30 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: YT
+    brand: Ytone
     model: L988
   os_family: Android
   browser_family: Android Browser
@@ -7720,19 +6963,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; YTONE L999 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: YT
+    brand: Ytone
     model: L999
   os_family: Android
   browser_family: Unknown
@@ -7740,7 +6981,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; YTONE M7X Build/KTU84P) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.4.4)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -7749,7 +6989,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: YT
+    brand: Ytone
     model: M7X
   os_family: Android
   browser_family: Unknown
@@ -7757,19 +6997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YXTEL_H1 Build/HDYXTEL_H1) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YX
+    brand: Yxtel
     model: H1
   os_family: Android
   browser_family: Chrome
@@ -7777,19 +7015,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; YXTEL_U1; Android/4.4.2; Release/08.28.2015)  AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: YX
+    brand: Yxtel
     model: U1
   os_family: Android
   browser_family: Android Browser
@@ -7797,19 +7033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YXTEL_U3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: YX
+    brand: Yxtel
     model: U3
   os_family: Android
   browser_family: Chrome
@@ -7817,19 +7051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Avenzo MOB4 4G Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZA
+    brand: Avenzo
     model: Mob 4 4G
   os_family: Android
   browser_family: Chrome
@@ -7837,19 +7069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Avenzo MOB4PRO 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZA
+    brand: Avenzo
     model: Mob 4 Pro 4G
   os_family: Android
   browser_family: Chrome
@@ -7857,19 +7087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; ZEEMI M1 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M1
   os_family: Android
   browser_family: Unknown
@@ -7877,19 +7105,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; ZEEMI M4 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M4
   os_family: Android
   browser_family: Unknown
@@ -7897,7 +7123,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ZEEMI M5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 baiduboxapp/5.0 (Baidu; P1 4.4.4)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -7906,7 +7131,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M5
   os_family: Android
   browser_family: Unknown
@@ -7914,7 +7139,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ZEEMI M6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 baiduboxapp/5.0 (Baidu; P1 4.4.4)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -7923,7 +7147,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M6
   os_family: Android
   browser_family: Unknown
@@ -7931,19 +7155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; ZEEMI M7 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.0.620 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.0.620"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M7
   os_family: Android
   browser_family: Unknown
@@ -7951,19 +7173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; ZEEMI M8 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZE
+    brand: Zeemi
     model: M8
   os_family: Android
   browser_family: Unknown
@@ -7971,19 +7191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Leopardo Z5517 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZK
+    brand: Zenek
     model: Leopardo
   os_family: Android
   browser_family: Chrome
@@ -7991,19 +7209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Libelula Z6001 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZK
+    brand: Zenek
     model: Libelula
   os_family: Android
   browser_family: Chrome
@@ -8011,19 +7227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; OSO Z5007 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZK
+    brand: Zenek
     model: Oso
   os_family: Android
   browser_family: Chrome
@@ -8031,19 +7245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Pinguino Z5519 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZK
+    brand: Zenek
     model: Pingûino
   os_family: Android
   browser_family: Chrome
@@ -8051,19 +7263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Zebra Z5516) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZK
+    brand: Zenek
     model: Zebra
   os_family: Android
   browser_family: Chrome
@@ -8071,19 +7281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AdmireGlam Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Admire Glam
   os_family: Android
   browser_family: Chrome
@@ -8091,19 +7299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Admire SXY Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Admire SXY
   os_family: Android
   browser_family: Chrome
@@ -8111,19 +7317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cinemax 2+ Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax 2+
   os_family: Android
   browser_family: Chrome
@@ -8131,19 +7335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cinemax 3 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax 3
   os_family: Android
   browser_family: Chrome
@@ -8151,19 +7353,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 6.0; en-US; Cinemax_4G) U2/1.0.0 UCBrowser/10.9.0.946 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.0.946"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax 4G
   os_family: Android
   browser_family: Unknown
@@ -8171,19 +7371,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 6.0; en-US; Cinemax_Click) U2/1.0.0 UCBrowser/10.9.0.946 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.0.946"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax Click
   os_family: Android
   browser_family: Unknown
@@ -8191,19 +7389,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0;U;Adr 6.0;en-US;Cinemax-Force) U2/1.0.0 UCBrowser/10.6.8.732 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.8.732"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax-Force
   os_family: Android
   browser_family: Unknown
@@ -8211,19 +7407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Cinemax1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax1
   os_family: Android
   browser_family: Chrome
@@ -8231,19 +7425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cinemax2 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZN
+    brand: Zen
     model: Cinemax2
   os_family: Android
   browser_family: Chrome
@@ -8251,19 +7443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZA409 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZO
+    brand: Zonda
     model: Muzic
   os_family: Android
   browser_family: Chrome
@@ -8271,19 +7461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; ZOPO ZP998 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 XiaoMi/MiuiBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "1.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: C2 II
   os_family: Android
   browser_family: Android Browser
@@ -8291,19 +7479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP998 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: C2 II
   os_family: Android
   browser_family: Chrome
@@ -8311,19 +7497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZOPO_C2_MOD Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: C2 II
   os_family: Android
   browser_family: Chrome
@@ -8331,19 +7515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZP330 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Color C
   os_family: Android
   browser_family: Chrome
@@ -8351,19 +7533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP567) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Color C5i
   os_family: Android
   browser_family: Chrome
@@ -8371,19 +7551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP370) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Color S
   os_family: Android
   browser_family: Chrome
@@ -8391,19 +7569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP586) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Color X
   os_family: Android
   browser_family: Chrome
@@ -8411,19 +7587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP563) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Color X
   os_family: Android
   browser_family: Chrome
@@ -8431,19 +7605,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; ZP300 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Field
   os_family: Android
   browser_family: Android Browser
@@ -8451,19 +7623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; ZP300S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Field
   os_family: Android
   browser_family: Android Browser
@@ -8471,19 +7641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ZP300+ Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Field
   os_family: Android
   browser_family: Chrome
@@ -8491,19 +7659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP781) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Flash G5 Plus
   os_family: Android
   browser_family: Chrome
@@ -8511,19 +7677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZP1790) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Flash X2
   os_family: Android
   browser_family: Chrome
@@ -8531,19 +7695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZOPO Flash X3 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Flash X3
   os_family: Android
   browser_family: Chrome
@@ -8551,19 +7713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; ZP900 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader
   os_family: Android
   browser_family: Android Browser
@@ -8571,19 +7731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; ZP900H Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader
   os_family: Android
   browser_family: Android Browser
@@ -8591,19 +7749,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; de-de; ZP910 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100502002
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader
   os_family: Android
   browser_family: Chrome
@@ -8611,19 +7767,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; ZP950 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader Max
   os_family: Android
   browser_family: Android Browser
@@ -8631,19 +7785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; ZP950+ Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36 OPR/27.0.1698.89115
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "27.0.1698.89115"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader Max
   os_family: Android
   browser_family: Opera
@@ -8651,19 +7803,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; ZP950H Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Leader Max
   os_family: Android
   browser_family: Android Browser
@@ -8671,19 +7821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; ZP500 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Libero
   os_family: Android
   browser_family: Chrome
@@ -8691,19 +7839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ZP500+ Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Libero
   os_family: Android
   browser_family: Chrome
@@ -8711,19 +7857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ZP800H Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Libero HD
   os_family: Android
   browser_family: Chrome
@@ -8731,19 +7875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ZP810 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Libero HD
   os_family: Android
   browser_family: Chrome
@@ -8751,19 +7893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; ZP100 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Pilot
   os_family: Android
   browser_family: Chrome
@@ -8771,19 +7911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ZP980 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Scorpio
   os_family: Android
   browser_family: Chrome
@@ -8791,19 +7929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ZOPO_ZP980 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Scorpio
   os_family: Android
   browser_family: Chrome
@@ -8811,19 +7947,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; ZP200 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Shining
   os_family: Android
   browser_family: Android Browser
@@ -8831,19 +7965,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; ZP200+ Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Shining
   os_family: Android
   browser_family: Android Browser
@@ -8851,19 +7983,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; ZP200+ Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Shining
   os_family: Android
   browser_family: Android Browser
@@ -8871,19 +8001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZP951 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Speed 7
   os_family: Android
   browser_family: Chrome
@@ -8891,19 +8019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZP952 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Speed 7 Plus
   os_family: Android
   browser_family: Chrome
@@ -8911,19 +8037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZP955) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: Speed 8
   os_family: Android
   browser_family: Chrome
@@ -8931,19 +8055,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; he-il; ZP1000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP1000
   os_family: Android
   browser_family: Android Browser
@@ -8951,19 +8073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ZP1000 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP1000
   os_family: Android
   browser_family: Chrome
@@ -8971,19 +8091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP1000S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP1000S
   os_family: Android
   browser_family: Chrome
@@ -8991,19 +8109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP320) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP320
   os_family: Android
   browser_family: Chrome
@@ -9011,19 +8127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP520
   os_family: Android
   browser_family: Chrome
@@ -9031,19 +8145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP980+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP980+
   os_family: Android
   browser_family: Chrome
@@ -9051,19 +8163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; ZP990 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP990
   os_family: Android
   browser_family: Android Browser
@@ -9071,19 +8181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZP999) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZP
+    brand: Zopo
     model: ZP999
   os_family: Android
   browser_family: Chrome
@@ -9091,19 +8199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3.1; Q3623 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Braw 3G
   os_family: Android
   browser_family: Chrome
@@ -9111,19 +8217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q2626 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Care 3G
   os_family: Android
   browser_family: Chrome
@@ -9131,19 +8235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q2624 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Cheer 3G
   os_family: Android
   browser_family: Chrome
@@ -9151,19 +8253,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Q638 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: I7
   os_family: Android
   browser_family: Android Browser
@@ -9171,19 +8271,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; Q.Boss P99 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Boss P99
   os_family: Android
   browser_family: Android Browser
@@ -9191,19 +8289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.1; J77 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Dee
   os_family: Android
   browser_family: Chrome
@@ -9211,19 +8307,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; Q.Dee R09 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Dee R09
   os_family: Android
   browser_family: Android Browser
@@ -9231,19 +8325,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; Q.Good M9 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Good M9
   os_family: Android
   browser_family: Android Browser
@@ -9251,19 +8343,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Q.Hi Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Hi
   os_family: Android
   browser_family: Android Browser
@@ -9271,19 +8361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q.Hi S1 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Hi S1
   os_family: Android
   browser_family: Chrome
@@ -9291,19 +8379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q.Hot Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Hot
   os_family: Android
   browser_family: Chrome
@@ -9311,19 +8397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q.Hot P7 3G Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Hot P7 3G
   os_family: Android
   browser_family: Chrome
@@ -9331,19 +8415,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; Q.Mate R99 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Mate R99
   os_family: Android
   browser_family: Android Browser
@@ -9351,19 +8433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q.Me Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Me
   os_family: Android
   browser_family: Chrome
@@ -9371,19 +8451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q.Me Phone7 3G Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Me Phone 7 3G
   os_family: Android
   browser_family: Chrome
@@ -9391,19 +8469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q.Next B7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Next B7
   os_family: Android
   browser_family: Chrome
@@ -9411,19 +8487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q.Next J2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Next J2
   os_family: Android
   browser_family: Chrome
@@ -9431,19 +8505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q.TOP-X8 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Top X8
   os_family: Android
   browser_family: Chrome
@@ -9451,19 +8523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q.Up Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Up
   os_family: Android
   browser_family: Chrome
@@ -9471,19 +8541,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 6.0; Q.Up C5 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.Up C5
   os_family: Android
   browser_family: Android Browser
@@ -9491,19 +8559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q.You Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q.You
   os_family: Android
   browser_family: Chrome
@@ -9511,19 +8577,17 @@
   user_agent: Dalvik/1.4.0 (Linux; U; Android 4.0.3; Q2688 Build/GRK39F)
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q2688
   os_family: Android
   browser_family: Android Browser
@@ -9531,19 +8595,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 5.1.1; Q2729 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q2729
   os_family: Android
   browser_family: Android Browser
@@ -9551,19 +8613,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; Q3022 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q3022
   os_family: Android
   browser_family: Android Browser
@@ -9571,19 +8631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q328 m9 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Q328 M9
   os_family: Android
   browser_family: Chrome
@@ -9591,19 +8649,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; Q328 Build/IMM76D)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Speed 3G
   os_family: Android
   browser_family: Android Browser
@@ -9611,19 +8667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q668 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: TV I4
   os_family: Android
   browser_family: Chrome
@@ -9631,19 +8685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q2602 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: TV Next
   os_family: Android
   browser_family: Chrome
@@ -9651,19 +8703,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Q2623 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Win 3G
   os_family: Android
   browser_family: Unknown
@@ -9671,19 +8721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q2728 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZQ
+    brand: ZYQ
     model: Zone 3G
   os_family: Android
   browser_family: Chrome
@@ -9691,19 +8739,17 @@
   user_agent: Opera/9.80 (BREW; Opera Mini/5.1/27.2338; U; xx) Presto/2.8.119 320X240 ZTE F-450
   os:
     name: Brew
-    short_name: BMP
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "5.1"
     engine: Presto
     engine_version: "2.8.119"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Adamant
   os_family: Brew
   browser_family: Opera
@@ -9711,19 +8757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Z818L Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Allstar
   os_family: Android
   browser_family: Chrome
@@ -9731,19 +8775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ZTE N9120 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Avid
   os_family: Android
   browser_family: Chrome
@@ -9751,19 +8793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Z855 Build/NMF26V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Avid 4
   os_family: Android
   browser_family: Chrome
@@ -9771,19 +8811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Z828) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Avid Plus
   os_family: Android
   browser_family: Chrome
@@ -9791,19 +8829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Z833 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Avid TRIO
   os_family: Android
   browser_family: Chrome
@@ -9811,19 +8847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE A2020G Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -9831,19 +8865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE A2020 Pro Build/PKQ1.190328.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -9851,19 +8883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 902ZT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 10 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -9871,19 +8901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZTE A2017U Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7
   os_family: Android
   browser_family: Chrome
@@ -9891,7 +8919,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZTE A2017G Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Crosswalk/11.45.2454.20161222 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -9900,7 +8927,7 @@
     version: "11.45.2454.20161222"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7
   os_family: Android
   browser_family: Unknown
@@ -9908,19 +8935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZTE A2017 Build/NMF26V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-17.yml
+++ b/Tests/fixtures/smartphone-17.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZTE B2017G Build/NMF26V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7 Mini
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZTE A2018 Build/NMF26V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7s
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Z999 Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon M
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ZTE B2016 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon Mini
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZTE A2019G Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon Pro
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZTE A2015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon Tianji
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; AxonPhone A1 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: AxonPhone A1
   os_family: Android
   browser_family: Unknown
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; ZTE-BLADE Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: BLADE
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; ZTE 2050 Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade 20 Smart
   os_family: Android
   browser_family: Android Browser
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZTE BLADE A0620 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A0620
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Blade A3 2019-T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A3 (2019)
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Blade A310) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A310
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZTE Blade A452 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A452
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Blade A460 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A460
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZTE Blade A462 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A462
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Blade A465) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A465
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Blade A5 2019-T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A5 (2019)
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE A510 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A510
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; BLADE_A510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A510
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZTE BLADE A512 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A512
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Blade A0622 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A6
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; BLADE A6 MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A6 Max
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZTE BLADE A612 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A612
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE A910 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade A910
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ZTE V807 Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade C
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ZTE V809 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade C2
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; ZTE N799D Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360browser(securitypay,securityinstalled); 360(android,uppayplugin); 360 Aphone Browser (5.4.0)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "5.4.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade Eg
   os_family: Android
   browser_family: Unknown
@@ -543,7 +489,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; es-us; ZTE V829 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 [FB_IAB/FB4A;FBAV/27.0.0.25.15;]'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -552,7 +497,7 @@
     version: "27.0.0.25.15"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade G Pro
   os_family: Android
   browser_family: Unknown
@@ -560,19 +505,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; es-LA; ZTE_V829) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade G Pro
   os_family: Android
   browser_family: Unknown
@@ -580,19 +523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZTE Blade L3 Apex Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L3 Apex
   os_family: Android
   browser_family: Chrome
@@ -600,19 +541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZTE Blade L5 Plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L5 Plus
   os_family: Android
   browser_family: Chrome
@@ -620,19 +559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZTE Blade L6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L6
   os_family: Android
   browser_family: Chrome
@@ -640,19 +577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ZTE Blade L6 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L6
   os_family: Android
   browser_family: Chrome
@@ -660,19 +595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE L7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L7
   os_family: Android
   browser_family: Chrome
@@ -680,19 +613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZTE BLADE L7A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L7A
   os_family: Android
   browser_family: Chrome
@@ -700,19 +631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE Blade L8RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L8
   os_family: Android
   browser_family: Chrome
@@ -720,19 +649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE Blade L8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade L8
   os_family: Android
   browser_family: Chrome
@@ -740,19 +667,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; Blade Q Lux Build/LRX22G)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade Q Lux
   os_family: Android
   browser_family: Android Browser
@@ -760,19 +685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; 402ZT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade Q+
   os_family: Android
   browser_family: Chrome
@@ -780,19 +703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; ZTE Blade S6 Plus Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade S6 Plus
   os_family: Android
   browser_family: Chrome
@@ -800,19 +721,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; ZTE T920 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36 OPR/30.0.2254.121224
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "30.0.2254.121224"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade S7
   os_family: Android
   browser_family: Opera
@@ -820,19 +739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Z559DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade T2
   os_family: Android
   browser_family: Chrome
@@ -840,19 +757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BLADE V Ultra Build/OPR1.170623.032; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V Ultra
   os_family: Android
   browser_family: Chrome
@@ -860,19 +775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V0730 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36 OPR/43.0.2246.121183
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.0.2246.121183"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V0730
   os_family: Android
   browser_family: Opera
@@ -880,19 +793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZTE BLADE V0800 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.77 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.77"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V0800
   os_family: Android
   browser_family: Chrome
@@ -900,19 +811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE Blade V10 Vita) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V10 Vita
   os_family: Android
   browser_family: Chrome
@@ -920,19 +829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZTE Blade V1000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V1000
   os_family: Android
   browser_family: Chrome
@@ -940,19 +847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V0720 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V7 Lite
   os_family: Android
   browser_family: Chrome
@@ -960,19 +865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ZTE BLADE V7 LITE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V7 Lite
   os_family: Android
   browser_family: Chrome
@@ -980,19 +883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZTE BLADE V0820) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V8 Lite
   os_family: Android
   browser_family: Chrome
@@ -1000,19 +901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZTE BLADE V0850 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade V8 Mini
   os_family: Android
   browser_family: Chrome
@@ -1020,19 +919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Blade X9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Blade X9
   os_family: Android
   browser_family: Chrome
@@ -1040,7 +937,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; Z716BL Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/42.0.2311.137 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/99.0.0.26.69;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -1049,7 +945,7 @@
     version: "99.0.0.26.69"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Citrine LTE
   os_family: Android
   browser_family: Unknown
@@ -1057,7 +953,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; Z716BL Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/109.0.0.24.70;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -1066,7 +961,7 @@
     version: "109.0.0.24.70"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Citrine LTE
   os_family: Android
   browser_family: Unknown
@@ -1074,19 +969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-cn; Ctyon-A9 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Ctyon A9
   os_family: Android
   browser_family: Android Browser
@@ -1094,19 +987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Z233VL Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/45.0.2454.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Cymbal-C LTE
   os_family: Android
   browser_family: Chrome
@@ -1114,19 +1005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ZTE V975 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Geek
   os_family: Android
   browser_family: Chrome
@@ -1134,19 +1023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ZTE Grand Era Build/IMM76L) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand Era
   os_family: Android
   browser_family: Chrome
@@ -1154,19 +1041,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; ru; ZTE_Grand_Era) U2/1.0.0 UCBrowser/9.9.0.543 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand Era
   os_family: GNU/Linux
   browser_family: Opera
@@ -1174,19 +1059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; ZTE V9815 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand Memo LTE
   os_family: Android
   browser_family: Android Browser
@@ -1194,19 +1077,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; ZTE U9815 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand Memo LTE
   os_family: Android
   browser_family: Unknown
@@ -1214,19 +1095,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4;en-us; ZTE V970M Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X
   os_family: Android
   browser_family: Android Browser
@@ -1234,19 +1113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; ZTE V970 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X
   os_family: Android
   browser_family: Chrome
@@ -1254,19 +1131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ZTE V987 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.122 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.122"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X
   os_family: Android
   browser_family: Chrome
@@ -1274,19 +1149,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1;zh-cn; ZTE V967S Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30;
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X2
   os_family: Android
   browser_family: Android Browser
@@ -1294,19 +1167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Z959 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X3
   os_family: Android
   browser_family: Chrome
@@ -1314,19 +1185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Z956 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Grand X4
   os_family: Android
   browser_family: Chrome
@@ -1334,19 +1203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 2.3.6; X501_USA_Cricket Build/GRK39F) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Mobile Safari/537.31 OPR/14.0.1074.54070
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "14.0.1074.54070"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Groove
   os_family: Android
   browser_family: Opera
@@ -1354,19 +1221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Z963U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Imperial Max
   os_family: Android
   browser_family: Chrome
@@ -1374,19 +1239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZTE V779M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Joey Jump 2
   os_family: Android
   browser_family: Chrome
@@ -1394,19 +1257,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; vi-vn; ZTE V788D B17 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Kis Plus
   os_family: Android
   browser_family: Android Browser
@@ -1414,19 +1275,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Z936L Build/LMY47O)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Lever
   os_family: Android
   browser_family: Android Browser
@@ -1434,19 +1293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 602ZT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Libero 2
   os_family: Android
   browser_family: Chrome
@@ -1454,19 +1311,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; ZTE V882 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Lord
   os_family: Android
   browser_family: Android Browser
@@ -1474,19 +1329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MO-01J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Mono
   os_family: Android
   browser_family: Chrome
@@ -1494,19 +1347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; N818S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: N818S
   os_family: Android
   browser_family: Chrome
@@ -1514,19 +1365,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; V8000_USA_Cricket Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nova 4
   os_family: Android
   browser_family: Android Browser
@@ -1534,19 +1383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; NX608J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia N3
   os_family: Android
   browser_family: Chrome
@@ -1554,19 +1401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; NX617J Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia N3
   os_family: Android
   browser_family: Chrome
@@ -1574,19 +1419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; NX651J Build/QKQ1.200202.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Play
   os_family: Android
   browser_family: Chrome
@@ -1594,19 +1437,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; NX609J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 YaBrowser/19.9.4.104.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.9.4.104.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Red Magic
   os_family: Android
   browser_family: Unknown
@@ -1614,19 +1455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NX629J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Red Magic 3
   os_family: Android
   browser_family: Chrome
@@ -1634,19 +1473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; NX659J Build/QKQ1.200127.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Red Magic 5G
   os_family: Android
   browser_family: Chrome
@@ -1654,19 +1491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NX619J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Red Magic Mars
   os_family: Android
   browser_family: Chrome
@@ -1674,19 +1509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; NX612J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia V18
   os_family: Android
   browser_family: Chrome
@@ -1694,19 +1527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Nubia Z11 mini s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z11 mini S
   os_family: Android
   browser_family: Chrome
@@ -1714,19 +1545,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; NX569H Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.5.985 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.5.985"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z17 Mini
   os_family: Android
   browser_family: Unknown
@@ -1734,19 +1563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; ru-ru; NX569J Build/PQ3A.190605.003) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.128 Mobile Safari/537.36 XiaoMi/Mint Browser/2.4.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Mint Browser
-    short_name: MT
     version: "2.4.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z17 Mini
   os_family: Android
   browser_family: Chrome
@@ -1754,19 +1581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; NX589J Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z17 Mini S
   os_family: Android
   browser_family: Chrome
@@ -1774,19 +1599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; NX606J Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z18
   os_family: Android
   browser_family: Chrome
@@ -1794,19 +1617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; NX611J Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z18 mini
   os_family: Android
   browser_family: Unknown
@@ -1814,19 +1635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NX616J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z18S
   os_family: Android
   browser_family: Chrome
@@ -1834,19 +1653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NX627J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z20
   os_family: Android
   browser_family: Chrome
@@ -1854,19 +1671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NX406E Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z5S Mini
   os_family: Android
   browser_family: Chrome
@@ -1874,19 +1689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-US; NX404H Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.5.1171 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.5.1171"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z5S Mini
   os_family: Android
   browser_family: Unknown
@@ -1894,19 +1707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nubia Z9 Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z9 max
   os_family: Android
   browser_family: Chrome
@@ -1914,19 +1725,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.0.2; NX512J Build/LRX22G AppleWebKit/537.36 KHTML, like Gecko Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z9 max dual
   os_family: Android
   browser_family: Chrome
@@ -1934,19 +1743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Nubia Z9 mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Z9 mini
   os_family: Android
   browser_family: Chrome
@@ -1954,19 +1761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P545 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Optus X Power 2
   os_family: Android
   browser_family: Chrome
@@ -1974,19 +1779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Z5031O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Optus X Spirit 2
   os_family: Android
   browser_family: Chrome
@@ -1994,19 +1797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Optus X Start) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Optus X Start
   os_family: Android
   browser_family: Chrome
@@ -2014,19 +1815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Z6621O Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Optus X Vista
   os_family: Android
   browser_family: Chrome
@@ -2034,19 +1833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P609 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Optus X Wave
   os_family: Android
   browser_family: Chrome
@@ -2054,19 +1851,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; N9132 Build/LMY47V)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Prestige
   os_family: Android
   browser_family: Android Browser
@@ -2074,19 +1869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Z3001S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Quest Plus
   os_family: Android
   browser_family: Chrome
@@ -2094,19 +1887,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; N9130 Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Speed
   os_family: Android
   browser_family: Android Browser
@@ -2114,19 +1905,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Z930L Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Unico LTE
   os_family: Android
   browser_family: Android Browser
@@ -2134,19 +1923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; K3DX-V5G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: V5G
   os_family: Android
   browser_family: Chrome
@@ -2154,19 +1941,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; V865M Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: V865M
   os_family: Android
   browser_family: Android Browser
@@ -2174,19 +1959,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; N9510 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Warp 4G
   os_family: Android
   browser_family: Chrome
@@ -2194,7 +1977,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; N9515 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 GSA/4.1.29.1706998.arm
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ARM
   client:
@@ -2203,7 +1985,7 @@
     version: "4.1.29.1706998"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Warp Sync
   os_family: Android
   browser_family: Unknown
@@ -2211,19 +1993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; ZTE-X500 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: X500
   os_family: Android
   browser_family: Android Browser
@@ -2233,13 +2013,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q03C"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: X991
   os_family: Unknown
   browser_family: Unknown
@@ -2247,19 +2026,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; dandelion Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: ZMax 3
   os_family: Android
   browser_family: Chrome
@@ -2267,19 +2044,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Astra NXT Pro Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZX
+    brand: Ziox
     model: Astra NXT Pro
   os_family: Android
   browser_family: Chrome
@@ -2287,19 +2062,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Astra Viva 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZX
+    brand: Ziox
     model: Astra Viva 4G
   os_family: Android
   browser_family: Chrome
@@ -2307,19 +2080,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 7.0; ZIOX_F9_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 YaBrowser/19.10.1.100.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.10.1.100.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZX
+    brand: Ziox
     model: F9 Pro
   os_family: Android
   browser_family: Unknown
@@ -2327,19 +2098,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART 4G GEN C 4.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart 4G Gen C 4.0"
   os_family: Android
   browser_family: Chrome
@@ -2347,19 +2116,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART 4G GEN C 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart 4G Gen C 5.0"
   os_family: Android
   browser_family: Chrome
@@ -2367,19 +2134,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART 4G GEN C 5.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart 4G Gen C 5.5"
   os_family: Android
   browser_family: Chrome
@@ -2387,19 +2152,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; SMART_4G_Speedy_5inch Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart 4G Speedy 5
   os_family: Android
   browser_family: Android Browser
@@ -2407,19 +2170,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SMART 4G Speedy 5.0 Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart 4G Speedy 5.0 Plus
   os_family: Android
   browser_family: Chrome
@@ -2427,19 +2188,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SMART MAX 4.0 PLUS Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 11
+    brand: 'True'
     model: Smart Max 4.0 Plus
   os_family: Android
   browser_family: Chrome
@@ -2447,19 +2206,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Jumbo X1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 30
+    brand: Ovvi
     model: Jumbo X1
   os_family: Android
   browser_family: Chrome
@@ -2467,19 +2224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 1503-A01 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N4
   os_family: Android
   browser_family: Chrome
@@ -2487,19 +2242,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 1603-A03 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.97"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N4A
   os_family: Android
   browser_family: Chrome
@@ -2507,19 +2260,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; 1607-A01 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N5S
   os_family: Android
   browser_family: Unknown
@@ -2527,19 +2278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 1707-A01 Build/NMF26X; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N6
   os_family: Android
   browser_family: Chrome
@@ -2547,19 +2296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 1713-A01 Build/NMF26X; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N6 Lite
   os_family: Android
   browser_family: Chrome
@@ -2567,19 +2314,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; 1801-A01 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.2.1062 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.2.1062"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N6 Pro
   os_family: Android
   browser_family: Unknown
@@ -2587,19 +2332,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 1807-A01 Build/OPM1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N7
   os_family: Android
   browser_family: Chrome
@@ -2607,19 +2350,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; 1809-A01 Build/OPM1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N7 Pro
   os_family: Android
   browser_family: Unknown
@@ -2627,19 +2368,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 1509-A00 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.4044.145 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.4044.145"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: Q5 Plus
   os_family: Android
   browser_family: Chrome
@@ -2647,19 +2386,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 8848 M3 Build/1.6.1.59f311.20170329.user) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/35.0.1916.138 Mobile Safari/537.36 T7/7.5 baidubrowser/7.6.4.26 (Baidu; P1 6.0.1)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "7.6.4.26"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M3
   os_family: Android
   browser_family: Baidu
@@ -2667,19 +2404,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; 8848 M4 Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36 baidubrowser/7.11.4.204 (Baidu; P1 7.1.2)
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "7.11.4.204"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M4
   os_family: Android
   browser_family: Baidu
@@ -2687,19 +2422,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 8848 M5 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -2707,27 +2440,24 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 8848 M6 Build/QKQ1.200127.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M6
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Deezer/5.4.22.54 (Android; 4.4.2; Mobile; fr) LOGICOM L-EMENT 400
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2736,15 +2466,14 @@
     version: "5.4.22.54"
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: L-ement 400
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Deezer/5.4.19.9 (Android; 7.0; Mobile; fr) Maze Alpha
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -2753,15 +2482,14 @@
     version: "5.4.19.9"
   device:
     type: smartphone
-    brand: M0
+    brand: Maze
     model: Alpha
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Deezer/5.4.22.54 (Android; 7.1.1; Mobile; fr) Nextbit Robin
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
@@ -2770,15 +2498,14 @@
     version: "5.4.22.54"
   device:
     type: smartphone
-    brand: N2
+    brand: Nextbit
     model: Robin
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Deezer/5.4.22.54 (Android; 7.0; Mobile; fr) OUKITEL K3
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -2787,35 +2514,32 @@
     version: "5.4.22.54"
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: K3
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Nura 2 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OR
+    brand: Orange
     model: Nura 2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; fr-fr; Chromebook 14 (CB3-431) Build/R66-10452.99.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/8.7.11.21.x86 CrosArc/4808754 (edgar)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
@@ -2824,81 +2548,73 @@
     version: "8.7.11.21"
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Chromebook 14
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; Point_X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.3.91.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.3.91.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: V5
+    brand: Vivax
     model: Point X2
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.1.0; Polar3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 YaBrowser/19.10.1.100.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.10.1.100.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: Ioutdoor Polar 3
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 704SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Simple Smartphone 4
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; L-01J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
@@ -2908,197 +2624,177 @@
     model: V20 Pro
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; 801LV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB5 10.1"
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 501LV Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB2 8.0"
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; M2007J20CG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0P
+    brand: POCO
     model: X3 NFC
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; MO-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Mono
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SCT21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" LTE
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-M07) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36 OPR/59.1.2926.54067
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "59.1.2926.54067"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Sense Plus
   os_family: Android
   browser_family: Opera
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; N-06C Build/A3004301) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: NE
+    brand: NEC
     model: Medias Amadana
   os_family: Android
   browser_family: Android Browser
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SH-M04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos SH-M04
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; SH-M12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Dual SIM
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; L-41A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
@@ -3108,157 +2804,141 @@
     model: Style 3
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-M11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Plus
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-M13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Zero 2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SHV48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Basic
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; X2-HT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; 901ZT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Libero S10
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SHV31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S Mini
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 704KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno J
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; 802LG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
@@ -3268,351 +2948,316 @@
     model: K50
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Z-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon M
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; 908SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R5G
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; S7-SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Android One S7
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; 907SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Basic
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; A001ZT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Libero 3
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SW001SH Build/S0012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Star Wars
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; J9260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 5 Dual
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SHG01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos R5G
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SHV45-u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 9; Armor_6E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: UL
+    brand: Ulefone
     model: Armor 6E
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; 906SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Zero 2
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHV34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SHV37_u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos U
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; P-01J Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: P-smart Keitai
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYF32 Build/103.0.2600; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Easy Mobile Phone
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYF35 Build/101.0.2500; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Marvera
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-M317F Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36 YaApp_Android/9.20 YaSearchBrowser/9.20
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY M31s
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 10; en-us; RMX1973 Build/QKQ1.190918.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 HeyTapBrowser/45.7.1.9
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -3621,15 +3266,14 @@
     version: "45.7.1.9"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: 5 Pro
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 10; en-us; RMX2076 Build/QKQ1.191222.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 HeyTapBrowser/45.7.0.0
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -3638,247 +3282,223 @@
     version: "45.7.0.0"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 Pro 5G
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; ANA-NX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor P40
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; Xenium S566) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.4.108.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.4.108.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: Xenium S566
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; Xenium S266) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.5.84.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.5.84.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PH
+    brand: Philips
     model: Xenium S266
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm; Android 10; KOB2-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 YaBrowser/20.6.0.211.00 SA/1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.6.0.211.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T 8.0"
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; ART-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.5.84.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.5.84.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Lite E
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; ART-L29N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.2.70.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.2.70.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Lite E NFC
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm_64; M2002J9G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.5.84.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.5.84.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10 Lite 5G
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; arm; S5 Silk) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.116 YaBrowser/20.7.5.84.00 SA/3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.7.5.84.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: S5 Silk
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; Android 10; BV6300Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6300 Pro
   os_family: Android
   browser_family: Chrome
--
+- 
   user_agent: Mozilla/5.0 (Linux; U; Android 10; LRA-LX1 Build/HONORLRA-LX1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 OPR/43.3.2254.141404
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.3.2254.141404"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30I
   os_family: Android
   browser_family: Opera
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; WP5 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 YaBrowser/20.8.5.97.00 SA/1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.8.5.97.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OE
+    brand: Oukitel
     model: WP5 Pro
   os_family: Android
   browser_family: Unknown
--
+- 
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; P20HD_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.135 YaBrowser/20.8.2.90.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.8.2.90.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P20HD
   os_family: Android
   browser_family: Unknown

--- a/Tests/fixtures/smartphone-18.yml
+++ b/Tests/fixtures/smartphone-18.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-J727A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.0.2517.139457
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.0.2517.139457"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 (2017)
   os_family: Android
   browser_family: Opera
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T387R4 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-G8858) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A9 Star
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-S757BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J7 Crown
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 9; SM-W2018) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.215.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.0.215.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2018
   os_family: Android
   browser_family: Unknown
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.2.2; SM-A530M Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.103 Mobile Safari/537.36 YandexSearch/8.30 YandexSearchBrowser/8.30
   os:
     name: Android
-    short_name: AND
     version: "8.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.103"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-W2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2019
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-US; SM-G5306W Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.3.1199 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.3.1199"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Unknown
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-A600X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-A605X) Build/R16NW AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A6+
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-J336AZ) Build/R16NW AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Sol 3
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S550TL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY On5
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T378K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-J326AZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Sol 2
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-S320VL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Sky
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-G9308) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S7
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-T818A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N9300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N920R7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J120ZN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J120W Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-N930P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 YaBrowser/19.3.3.285.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.3.3.285.00"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 7
   os_family: Android
   browser_family: Unknown
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A720X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SAMSUNG-SM-W2016 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY W2016
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-A520X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SAMSUNG-SM-T337A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SAMSUNG-SM-T537A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G530R7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-G925X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-G928X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S6 Edge+
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J100VPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J105M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 Mini
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-J5007 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 YaApp_Android/10.70 YaSearchBrowser/10.70
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2015)
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-N920X Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 5
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G318ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Ace 4 Neo
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-E500YZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A700X Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A7
   os_family: Android
   browser_family: Chrome
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A5009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A5
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: MWP/1.0/Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; SAMSUNG; SM-W750V) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: Ativ SE
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T337V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T337T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-S820L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Prime
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-LED40M04S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: X2
+    brand: Soundmax
     model: SM-LED40M04S
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-A300XU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A3 (2015)
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG-SM-T707A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 8.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T357W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T357T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-S978L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY E5
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-S920L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-S975L Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY S4
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-A505X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A50
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-J510Y Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SM-J510G Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J5 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-J05H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J1 (2016)
   os_family: Android
   browser_family: Chrome
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T360) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab Active 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T332) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T677) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T670) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" WiFi
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677NK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677NL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677V Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T537V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SM-S357BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY J3 Orbit
   os_family: Android
   browser_family: Chrome
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; FZ-B2D Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PA
+    brand: Panasonic
     model: Toughpad FZ-B2D
   os_family: Android
   browser_family: Chrome
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; FZ-X1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: PA
+    brand: Panasonic
     model: Toughpad FZ-X1
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-G5108Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Core Max
   os_family: Android
   browser_family: Chrome
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG-SM-G530A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Grand Prime
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-G310R5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GreatCall Touch 3
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CPH1925) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 5G
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1912) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5S
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A5S
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1905) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A7
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CPH1833) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R15 Pro
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Astra NXT Pro Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZX
+    brand: Ziox
     model: Astra NXT Pro
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Aquaris_A4.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris A4.5
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Access_Q784C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 20
+    brand: Alcor
     model: Access Q784C
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TG-L800S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: TG-L800S
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ192) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ192
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ191) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ191
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ185) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ185
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ174) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ174
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ171) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ171
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ104) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ104
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ761) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ761
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IBRIT_I7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: I7
   os_family: Android
   browser_family: Chrome
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IBRIT_I5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: I5
   os_family: Android
   browser_family: Chrome
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; iBRIT_POWER6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: Power 6
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iBRIT_Speed Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: Speed Pro
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JUNIOR_8_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Junior 8 Pro
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Jade7s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IP
+    brand: iPro
     model: Jade 7s
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Jumbo X1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 30
+    brand: Ovvi
     model: Jumbo X1
   os_family: Android
   browser_family: Chrome
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Knight 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.56 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.56"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: T4
+    brand: ThL
     model: Knight 2
   os_family: Android
   browser_family: Chrome
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; itel-it1520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1520
   os_family: Android
   browser_family: Chrome
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; itel-it1512) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/D2881C
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1512
   os_family: Android
   browser_family: Chrome
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PowerFiveMaxLite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Max Lite
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PowerFiveMax2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Max 2
   os_family: Android
   browser_family: Chrome
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Rio_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AA
+    brand: AllCall
     model: Rio X
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RS8501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS8501
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Royale_X2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F7
+    brand: Fero
     model: Royale X2
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Fero_Y1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F7
+    brand: Fero
     model: Y1
   os_family: Android
   browser_family: Chrome
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia ZL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia ZL
   os_family: Android
   browser_family: Chrome
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z2 Tablet Wifi) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Z2 Tablet WiFi
   os_family: Android
   browser_family: Chrome
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z1 Compact) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z1 Compact
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia Z
   os_family: Android
   browser_family: Chrome
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z Ultra) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SO
+    brand: Sony
     model: Xperia Z Ultra
   os_family: Android
   browser_family: Chrome
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia V
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia P
   os_family: Android
   browser_family: Chrome
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia S
   os_family: Android
   browser_family: Chrome
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia SP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia SP
   os_family: Android
   browser_family: Chrome
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia TX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia TX
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; X9079) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: R9 Plus
   os_family: Android
   browser_family: Chrome
@@ -2283,19 +2055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Halo Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo Plus
   os_family: Android
   browser_family: Chrome
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Halo 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 4
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Halo2 3G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 2 3G
   os_family: Android
   browser_family: Chrome
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo 2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; InnJoo 3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -2383,19 +2145,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; Innjoo ONE 3G Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: One 3G
   os_family: Android
   browser_family: Android Browser
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; InnJoo_Pro2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Pro 2
   os_family: Android
   browser_family: Chrome
@@ -2423,19 +2181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; InnJoo 4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "4"
   os_family: Android
   browser_family: Chrome
@@ -2443,19 +2199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo X3 Build/InnJoo-X3-5.1-20161228-V1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: X3
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo 2 LTE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: 2 LTE
   os_family: Android
   browser_family: Chrome
@@ -2483,19 +2235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Halo_4_mini_LTE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 4 Mini LTE
   os_family: Android
   browser_family: Chrome
@@ -2503,19 +2253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Halo X LTE Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo X LTE
   os_family: Android
   browser_family: Chrome
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hotz_M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Hotz M1
   os_family: Android
   browser_family: Chrome
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TF) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -2563,19 +2307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Ultimate
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TFB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TFD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -2623,19 +2361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; i1002S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -2643,19 +2379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Iwork10 Flagship) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Flagship
   os_family: Android
   browser_family: Chrome
@@ -2663,19 +2397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iwork10 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -2683,19 +2415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZTE A2018 Build/NMF26V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Axon 7s
   os_family: Android
   browser_family: Chrome
@@ -2703,19 +2433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; NX651J Build/QKQ1.200202.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ZT
+    brand: ZTE
     model: Nubia Play
   os_family: Android
   browser_family: Chrome
@@ -2723,19 +2451,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; M2007J1SC Build/QKQ1.200419.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.141 Mobile Safari/537.36 XiaoMi/MiuiBrowser/13.0.28
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: MIUI Browser
-    short_name: MU
     version: "13.0.28"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10 Ultra 5G
   os_family: Android
   browser_family: Android Browser
@@ -2743,19 +2469,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-cn; XT1965-6 Build/PCW29.27-73) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G7 Plus
   os_family: Android
   browser_family: Unknown
@@ -2763,19 +2487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2176 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X7 5G
   os_family: Android
   browser_family: Chrome
@@ -2783,19 +2505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-AN10 Build/HONORTEL-AN10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -2803,19 +2523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; KKG-AN00 Build/HONORKKG-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10 Max
   os_family: Android
   browser_family: Chrome
@@ -2823,19 +2541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MXW-AN00 Build/HONORMXW-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30
   os_family: Android
   browser_family: Chrome
@@ -2843,19 +2559,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; V2023A Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.3.1093 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.3.1093"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO U1
   os_family: Android
   browser_family: Unknown
@@ -2863,19 +2577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hope7_Mate) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XT
+    brand: X-TIGI
     model: Hope 7 Mate
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDVM00 Build/QKQ1.200614.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A32
   os_family: Android
   browser_family: Chrome
@@ -2903,19 +2613,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; ASUS_I003DD Build/QKQ1.200419.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Quark/4.3.0.142 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "4.3.0.142"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 3
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MP1605 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: V6
   os_family: Android
   browser_family: Chrome
@@ -2943,19 +2649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PDYT20 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A72
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LUNA G50) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: G50
   os_family: Android
   browser_family: Chrome
@@ -2983,19 +2685,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; RMX2111 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.3.1093 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.3.1093"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: V5 5G
   os_family: Android
   browser_family: Unknown
@@ -3003,19 +2703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; ASUS ZenFone 2E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2E
   os_family: Android
   browser_family: Chrome
@@ -3023,19 +2721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; QUEST LITE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Quest Lite
   os_family: Android
   browser_family: Chrome
@@ -3043,19 +2739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P80X_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P80X EEA
   os_family: Android
   browser_family: Chrome
@@ -3063,19 +2757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P80X_ROW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P80X ROW
   os_family: Android
   browser_family: Chrome
@@ -3083,19 +2775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pearl K2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Pearl K2
   os_family: Android
   browser_family: Chrome
@@ -3103,19 +2793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Robin) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: N2
+    brand: Nextbit
     model: Robin
   os_family: Android
   browser_family: Chrome
@@ -3123,19 +2811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TR99 MINI+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: TR99 Mini Plus
   os_family: Android
   browser_family: Chrome
@@ -3143,19 +2829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TR99) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: TR99
   os_family: Android
   browser_family: Chrome
@@ -3163,19 +2847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Transpeed_6K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: 6K
   os_family: Android
   browser_family: Chrome
@@ -3183,19 +2865,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; HIGHSCREEN; WinWin) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537 UCBrowser/4.2.1.541 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: WinWin
   os_family: Windows Mobile
   browser_family: Unknown
@@ -3203,19 +2883,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; KAZAM; Thunder 450W) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Thunder 450W
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -3223,19 +2901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; ANRY-X20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7A
+    brand: Anry
     model: X20
   os_family: Android
   browser_family: Chrome
@@ -3243,19 +2919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; ANRY-S20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7A
+    brand: Anry
     model: S20
   os_family: Android
   browser_family: Chrome
@@ -3263,19 +2937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi10 pro Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi10 Pro
   os_family: Android
   browser_family: Chrome
@@ -3283,19 +2955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HiBox-hero) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: desktop
-    brand: 1C
+    brand: Chuwi
     model: HiBox Hero
   os_family: Android
   browser_family: Chrome
@@ -3303,19 +2973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HiBook pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: HiBook Pro
   os_family: Android
   browser_family: Chrome
@@ -3323,19 +2991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi10 plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi10 Plus
   os_family: Android
   browser_family: Chrome
@@ -3343,19 +3009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi8 Air) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi8 Air
   os_family: Android
   browser_family: Chrome
@@ -3363,19 +3027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi8 pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi8 Pro
   os_family: Android
   browser_family: Chrome
@@ -3383,19 +3045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; T1001X Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3A
+    brand: AllDocube
     model: M5X
   os_family: Android
   browser_family: Chrome
@@ -3403,19 +3063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE720T Build/PKQ1.190302.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: HI
+    brand: Hisense
     model: U30
   os_family: Android
   browser_family: Chrome
@@ -3423,19 +3081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ASUS_X002 Build/KTU84P; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE227T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F40
   os_family: Android
   browser_family: Chrome
@@ -3463,19 +3117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; Cool_9S Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool 9S
   os_family: Android
   browser_family: Chrome
@@ -3483,19 +3135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE316T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -3503,19 +3153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE216T Build/PKQ1.190118.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 5
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HLTE215T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F29
   os_family: Android
   browser_family: Chrome
@@ -3543,19 +3189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; HLTE310T Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H18
   os_family: Android
   browser_family: Chrome
@@ -3563,19 +3207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE226T Build/PPR1.180610.011;wv) AppleWebKit/537.36(KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 6
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE202N Build/PKQ1.190504.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -3603,19 +3243,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; HLTE510M Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.0.980 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.0.980"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H20
   os_family: Android
   browser_family: Unknown
@@ -3623,19 +3261,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-cn; HLTE500T Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H11
   os_family: Android
   browser_family: Unknown
@@ -3643,19 +3279,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; HLTE501N Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.0.1060 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.0.1060"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: V Plus
   os_family: Android
   browser_family: Unknown
@@ -3663,19 +3297,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; HLTE311T Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1072 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1072"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 4 Pro
   os_family: Android
   browser_family: Unknown
@@ -3683,19 +3315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HLTE203T Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A5 Pro CC
   os_family: Android
   browser_family: Chrome
@@ -3703,19 +3333,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; HLTE730T Build/PKQ1.190723.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.4.988 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.4.988"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A6L
   os_family: Android
   browser_family: Unknown
@@ -3723,19 +3351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; HLTE210T Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F28
   os_family: Android
   browser_family: Chrome
@@ -3743,19 +3369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2011A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.1.14.2
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.1.14.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: X50 Pro Plus
   os_family: Android
   browser_family: Unknown
@@ -3763,19 +3387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2024A; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/8.4.12.0
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "8.4.12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO 5
   os_family: Android
   browser_family: Unknown
@@ -3783,19 +3405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2020A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -3803,19 +3423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2012A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Z1x
   os_family: Android
   browser_family: Chrome
@@ -3823,19 +3441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2020CA Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -3843,19 +3459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; V2025A Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -3863,19 +3477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V1919A Build/PKQ1.181030.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: VV
+    brand: Vivo
     model: iQOO Z5x
   os_family: Android
   browser_family: Chrome
@@ -3883,19 +3495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MELROSE_2019 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0E
+    brand: Melrose
     model: 2019 Ultra Slim 3.4"
   os_family: Android
   browser_family: Chrome
@@ -3903,19 +3513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2121 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X7 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -3923,19 +3531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2142 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X3
   os_family: Android
   browser_family: Chrome
@@ -3943,19 +3549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; RMX2025 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: X50 5G
   os_family: Android
   browser_family: Chrome
@@ -3963,7 +3567,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; RMX2200 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36 HeyTapBrowser/40.7.2.9
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
@@ -3972,7 +3575,7 @@
     version: "40.7.2.9"
   device:
     type: smartphone
-    brand: RE
+    brand: Realme
     model: V3 5G
   os_family: Android
   browser_family: Unknown
@@ -3980,19 +3583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3LC Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.156 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.156"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9A
   os_family: Android
   browser_family: Chrome
@@ -4000,19 +3601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 1503-A01 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 36
+    brand: "360"
     model: N4
   os_family: Android
   browser_family: Chrome
@@ -4020,19 +3619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; XQ-AU52) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 EdgA/45.07.4.5057
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "45.07.4.5057"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 II
   os_family: Android
   browser_family: Internet Explorer
@@ -4040,19 +3637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 1831-A0 Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool Play C7
   os_family: Android
   browser_family: Chrome
@@ -4060,19 +3655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-TN00 Build/HONORTEL-TN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.156 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.156"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -4080,19 +3673,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; PDYM20 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/13.1.2.1092 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.2.1092"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: A72
   os_family: Android
   browser_family: Unknown
@@ -4100,19 +3691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PCLM50 Build/QKQ1.200216.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: K7
   os_family: Android
   browser_family: Chrome
@@ -4120,19 +3709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; PEAT00 Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -4140,19 +3727,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PEAM00 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -4160,19 +3745,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; PDNT00 Build/QKQ1.200216.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: OP
+    brand: OPPO
     model: Reno 4 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -4180,19 +3763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 8848 M5 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -4200,19 +3781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; 8848 M4 Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36 baidubrowser/7.11.4.204 (Baidu; P1 7.1.2)
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "7.11.4.204"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M4
   os_family: Android
   browser_family: Baidu
@@ -4220,19 +3799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 8848 M3 Build/1.6.1.59f311.20170329.user) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/35.0.1916.138 Mobile Safari/537.36 T7/7.5 baidubrowser/7.6.4.26 (Baidu; P1 6.0.1)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "7.6.4.26"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M3
   os_family: Android
   browser_family: Baidu
@@ -4240,19 +3817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 8848 M6 Build/QKQ1.200127.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.186"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 88
+    brand: "8848"
     model: M6
   os_family: Android
   browser_family: Chrome
@@ -4260,19 +3835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TNNH-AN00 Build/HONORTNNH-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4
   os_family: Android
   browser_family: Chrome
@@ -4280,19 +3853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZYVV1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3V
+    brand: VVETIME
     model: V1
   os_family: Android
   browser_family: Chrome
@@ -4300,19 +3871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; F103S Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: F103S
   os_family: Android
   browser_family: Chrome
@@ -4320,19 +3889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; GOME 2017X05A Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: C71
   os_family: Android
   browser_family: Chrome
@@ -4340,19 +3907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-41A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 II
   os_family: Android
   browser_family: Chrome
@@ -4360,19 +3925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; XIG01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36173
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: MI 10 Lite 5G
   os_family: Android
   browser_family: Chrome
@@ -4380,19 +3943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ASUS_I003D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 3
   os_family: Android
   browser_family: Chrome
@@ -4400,19 +3961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOG01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1 II
   os_family: Android
   browser_family: Chrome
@@ -4420,19 +3979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; 801FJ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows U 801FJ
   os_family: Android
   browser_family: Chrome
@@ -4440,19 +3997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-RM12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Lite
   os_family: Android
   browser_family: Chrome
@@ -4460,19 +4015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; 404SH) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos Xx
   os_family: Android
   browser_family: Chrome
@@ -4480,19 +4033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV47) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY Z Flip
   os_family: Android
   browser_family: Chrome
@@ -4500,19 +4051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCV48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SA
+    brand: Samsung
     model: GALAXY A41
   os_family: Android
   browser_family: Chrome
@@ -4520,19 +4069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SO-51A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 1 II
   os_family: Android
   browser_family: Chrome
@@ -4540,19 +4087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; KYV48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Gratina KYV48
   os_family: Android
   browser_family: Chrome
@@ -4560,19 +4105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SHV43-u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S2
   os_family: Android
   browser_family: Chrome
@@ -4580,19 +4123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; arrowsM04-PREMIUM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows M04 Premium
   os_family: Android
   browser_family: Chrome
@@ -4600,19 +4141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; KYT33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KY
+    brand: Kyocera
     model: Qua Tab QZ10
   os_family: Android
   browser_family: Chrome
@@ -4620,19 +4159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; F-51A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows 5G F-51A
   os_family: Android
   browser_family: Chrome
@@ -4640,19 +4177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 704HW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2 Lite
   os_family: Android
   browser_family: Chrome
@@ -4660,19 +4195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 608HW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.120 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.120"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova Lite
   os_family: Android
   browser_family: Chrome
@@ -4680,19 +4213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; LIO-N29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -4700,13 +4231,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; A001LG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
@@ -4720,19 +4249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SOV43) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.361
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SO
+    brand: Sony
     model: Xperia 10 II
   os_family: Android
   browser_family: Chrome
@@ -4740,19 +4267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; KYT32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KY
+    brand: Kyocera
     model: Qua Tab QZ8
   os_family: Android
   browser_family: Chrome
@@ -4760,19 +4285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; KYT31 Build/101.0.2120) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KY
+    brand: Kyocera
     model: Qua Tab 01
   os_family: Android
   browser_family: Chrome
@@ -4780,19 +4303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; KYV47) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Basio 4
   os_family: Android
   browser_family: Chrome
@@ -4800,19 +4321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KYV44_u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Qua Phone QZ
   os_family: Android
   browser_family: Chrome
@@ -4820,19 +4339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KYV40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Rafre
   os_family: Android
   browser_family: Chrome
@@ -4840,19 +4357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SCG06) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: phablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 20 Ultra 5G
   os_family: Android
   browser_family: Chrome
@@ -4860,19 +4375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 701HW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite
   os_family: Android
   browser_family: Chrome
@@ -4880,19 +4393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SH-RM11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: SH
+    brand: Sharp
     model: Aquos S3 Plus
   os_family: Android
   browser_family: Chrome
@@ -4900,19 +4411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/86.0.4240.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "86.0.4240.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9C
   os_family: Android
   browser_family: Chrome
@@ -4920,19 +4429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; M2006C3MNG Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: XI
+    brand: Xiaomi
     model: Redmi 9C NFC
   os_family: Android
   browser_family: Chrome
@@ -4940,19 +4447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MED-LX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6p
   os_family: Android
   browser_family: Chrome
@@ -4960,19 +4465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-N39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro Plus
   os_family: Android
   browser_family: Chrome
@@ -4980,19 +4483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-N04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro
   os_family: Android
   browser_family: Chrome
@@ -5000,19 +4501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-AN10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro Plus
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-2.yml
+++ b/Tests/fixtures/smartphone-2.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 4047A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U5 Plus
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5044S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U50
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 5044G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: U50
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; A577VL Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AL
+    brand: Alcatel
     model: Zip
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Azumi A35C_Lite Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AM
+    brand: Azumi Mobile
     model: A35C Lite
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; es-mx; Azumi A35CLITE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AM
+    brand: Azumi Mobile
     model: A35CLITE
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AZUMI A50c+ Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AM
+    brand: Azumi Mobile
     model: A50c+
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; es-mx; Azumi A50TQ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AM
+    brand: Azumi Mobile
     model: A50TQ
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0;  Azumi_IRO_A4_Q  Release/07.13.2016 Build/MRA58k) AppleWebKit/737.36 (KHTML, like Geck) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AM
+    brand: Azumi Mobile
     model: IRO A4 Q
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; A862W Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AO
+    brand: Amoi
     model: A862W
   os_family: Android
   browser_family: Android Browser
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_2_1 like Mac OS X) AppleWebKit/602.4.6 (KHTML, like Gecko) Mobile/14D27 (Ecosia ios@3.0.1.533)
   os:
     name: iOS
-    short_name: IOS
     version: "10.2.1"
     platform: ""
   client:
     type: browser
     name: Ecosia
-    short_name: EC
     version: "3.0.1.533"
     engine: WebKit
     engine_version: "602.4.6"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: QwantMobile/2.0 (iPhone; CPU iPhone OS 11_1_2 like Mac OS X) AppleWebKit/604.3.5 (KHTML, like Gecko) QwantiOS/2.0.0b1 Mobile/15B202 Safari/604.3.5
   os:
     name: iOS
-    short_name: IOS
     version: "11.1.2"
     platform: ""
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "2.0"
     engine: Gecko
     engine_version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Firefox
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 3_1_2 like Mac OS X; de-de) AppleWebKit/528.18 (KHTML, like Gecko) Version/4.0 Mobile/7D11 Safari/528.16
   os:
     name: iOS
-    short_name: IOS
     version: "3.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "4.0"
     engine: WebKit
     engine_version: "528.18"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_1 like Mac OS X; ru-ru) AppleWebKit/532.9 (KHTML, like Gecko) Mobile/8B117
   os:
     name: iOS
-    short_name: IOS
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "532.9"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_2_1 like Mac OS X; ar) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8C148
   os:
     name: iOS
-    short_name: IOS
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 4_3_3 like Mac OS X; ar) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8J2
   os:
     name: iOS
-    short_name: IOS
     version: "4.3.3"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 5_0_1 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8C148
   os:
     name: iOS
-    short_name: IOS
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 5_1 like Mac OS X) AppleWebKit/534.46 (KHTML, like Gecko) Version/5.1 Mobile/9B179 Safari/7534.48.3
   os:
     name: iOS
-    short_name: IOS
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "5.1"
     engine: WebKit
     engine_version: "534.46"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A405 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "6.0"
     engine: WebKit
     engine_version: "536.26"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -383,19 +345,17 @@
   user_agent: UCWEB/8.8 (iPhone; CPU OS_6; en-US)AppleWebKit/534.1 U3/3.0.0 Mobile
   os:
     name: iOS
-    short_name: IOS
     version: "6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8"
     engine: WebKit
     engine_version: "534.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "7.0"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Safari
@@ -423,7 +381,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_6 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11B651 MicroMessenger/5.2
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.6"
     platform: ""
   client:
@@ -432,7 +389,7 @@
     version: "5.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D201 MobileIron/1.3.0 Version/7.1.1 Safari/537.51.2
   os:
     name: iOS
-    short_name: IOS
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Iron Mobile
-    short_name: I3
     version: "1.3.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Chrome
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_1_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) OPiOS/8.0.1.80062 Mobile/11D201 Safari/9537.53
   os:
     name: iOS
-    short_name: IOS
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mini iOS
-    short_name: O1
     version: "8.0.1.80062"
     engine: WebKit
     engine_version: "537.51.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Opera
@@ -480,7 +433,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) Mobile/12F70 rabbit%2F1.0 baiduboxapp/0_0.1.9.6_enohpi_8022_2421/3.8_1C2%257enohPi/1099a/07EF65571537037D2F1065EB10EA39323F87539A9FRCMIPQKLP/1'
   os:
     name: iOS
-    short_name: IOS
     version: "8.3"
     platform: ""
   client:
@@ -489,7 +441,7 @@
     version: "0"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -497,19 +449,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 8_3 like Mac OS X) AppleWebKit/600.1.4 (KHTML, like Gecko) FxiOS/1.0 Mobile/12F69 Safari/600.1.4
   os:
     name: iOS
-    short_name: IOS
     version: "8.3"
     platform: ""
   client:
     type: browser
     name: Firefox Mobile iOS
-    short_name: F1
     version: "1.0"
     engine: WebKit
     engine_version: "600.1.4"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Firefox
@@ -517,7 +467,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13C75 search%2F1.0 baiduboxapp/0_0.0.0.7_enohpi_1002_5211/2.9_1C2%257enohPi/1099a/F320093B8EC9256C24B9649B246E288CF77E011E1OCRTTTGQQS/1'
   os:
     name: iOS
-    short_name: IOS
     version: "9.2"
     platform: ""
   client:
@@ -526,7 +475,7 @@
     version: "0"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Unknown
@@ -534,19 +483,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/603.1.30 (KHTML, like Gecko) Mobile/14E5260b Version/10.3 Safari/8536.25 Mobicip/1947694464
   os:
     name: iOS
-    short_name: IOS
     version: "10.3"
     platform: ""
   client:
     type: browser
     name: Mobicip
-    short_name: MO
     version: ""
     engine: Gecko
     engine_version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone
   os_family: iOS
   browser_family: Firefox
@@ -554,19 +501,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.2; 11)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 11
   os_family: iOS
   browser_family: Safari
@@ -574,19 +519,17 @@
   user_agent: Mozilla/5.0 (iPhone; U; CPU iPhone OS 435 like Mac OS X; ko-kr) AppleWebKit/533.17.9 (KHTML like Gecko) Mobile/8L1 NAVER(inapp; search; 301; 4.4.0; 3GS)
   os:
     name: iOS
-    short_name: IOS
     version: "435"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 3GS
   os_family: iOS
   browser_family: Safari
@@ -594,7 +537,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_6 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B500 [FBAN/FBIOS;FBAV/9.0.0.25.31;FBBV/2102024;FBDV/iPhone2,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/6.1.6;FBSS/1; FBCR/BouyguesTelecom;FBID/phone;FBLC/fr_FR;'
   os:
     name: iOS
-    short_name: IOS
     version: "6.1.6"
     platform: ""
   client:
@@ -603,7 +545,7 @@
     version: "9.0.0.25.31"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 3GS
   os_family: iOS
   browser_family: Unknown
@@ -611,7 +553,6 @@
   user_agent: iTunes-iPhone/4.3.3 (4; 16GB)
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -620,7 +561,7 @@
     version: "4.3.3"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4
   os_family: iOS
   browser_family: Unknown
@@ -628,7 +569,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11B554a [FBAN/FBIOS;FBAV/7.0.0.17.1;FBBV/1325030;FBDV/iPhone3,1;FBMD/iPhone;FBSN/iPhone OS;FBSV/7.0.4;FBSS/2; FBCR/Carrier;FBID/phone;FBLC/it_IT;FBOP/5'
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
@@ -637,7 +577,7 @@
     version: "7.0.0.17.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4
   os_family: iOS
   browser_family: Unknown
@@ -645,19 +585,17 @@
   user_agent: Mozilla/5.0 (iPhone 4; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/6.0 MQQBrowser/5.0.5 Mobile/11B554a Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0.5"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4
   os_family: iOS
   browser_family: Unknown
@@ -665,7 +603,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11B554a Weibo (iPhone3,2__weibo__4.2.5__iphone__os7.0.4)
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
@@ -674,7 +611,7 @@
     version: "4.2.5"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4
   os_family: iOS
   browser_family: Unknown
@@ -682,19 +619,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mobile/10B329 NAVER(inapp; search; 310; 4.6.0; 4S)
   os:
     name: iOS
-    short_name: IOS
     version: "6.1.3"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "536.26"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4S
   os_family: iOS
   browser_family: Safari
@@ -702,19 +637,17 @@
   user_agent: MQQBrowser/44 Mozilla/5.0 (iPhone 4S; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D167 Safari/7534.48.3
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "44"
     engine: WebKit
     engine_version: "537.51.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 4S
   os_family: iOS
   browser_family: Unknown
@@ -722,13 +655,12 @@
   user_agent: Apple-iPhone5C2/1104.201
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Unknown
@@ -736,19 +668,17 @@
   user_agent: UCWEB/2.0 (iOS; U; iPh OS 6_1; zh-CN; iPh5,2) U2/1.0.0 UCBrowser/9.5.1.408 U2/1.0.0 Mobile
   os:
     name: iOS
-    short_name: IOS
     version: "6.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.1.408"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Unknown
@@ -756,7 +686,6 @@
   user_agent: Instagram 5.0.2 (iPhone5,1; iPhone OS 7_0_4; en_US; en) AppleWebKit/420+
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
@@ -765,7 +694,7 @@
     version: "5.0.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Unknown
@@ -773,19 +702,17 @@
   user_agent: Mozilla/5.0 (iPhone 5ATT; CPU iPhone OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/6.0 MQQBrowser/5.0.5 Mobile/11B554a Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0.5"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Unknown
@@ -793,7 +720,6 @@
   user_agent: Mozilla/5.0 (iPhone5,2; iPhone; U; CPU OS 7_1 like Mac OS X; de_DE) com.google.GooglePlus/33839 (KHTML, like Gecko) Mobile/N42AP (gzip)
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
@@ -802,7 +728,7 @@
     version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Unknown
@@ -810,19 +736,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 71 like Mac OS X) AppleWebKit/537.51.2 (KHTML like Gecko) Mobile/11D167 NAVER(inapp; search; 370; 5.7.1; 5)
   os:
     name: iOS
-    short_name: IOS
     version: "71"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "537.51.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5
   os_family: iOS
   browser_family: Safari
@@ -830,19 +754,17 @@
   user_agent: Mozilla/5.0 (iPhone 5CGLOBAL; CPU iPhone OS 7_0_5 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/6.0 MQQBrowser/5.1.1 Mobile/11B601 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.5"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.1.1"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5C
   os_family: iOS
   browser_family: Unknown
@@ -850,7 +772,6 @@
   user_agent: Mozilla/5.0 (iPhone5,4; iPhone; U; CPU OS 7_0_6 like Mac OS X; de_DE) com.google.GooglePlus/29676 (KHTML, like Gecko) Mobile/N49AP (gzip)
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.6"
     platform: ""
   client:
@@ -859,7 +780,7 @@
     version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5C
   os_family: iOS
   browser_family: Unknown
@@ -867,13 +788,12 @@
   user_agent: Apple-iPhone6C2/1201.405
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -881,13 +801,12 @@
   user_agent: Apple-iPhone6C2/1202.440
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -895,7 +814,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 12_4_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E148 [FBAN/FBIOS;FBDV/iPhone6,2;FBMD/iPhone;FBSN/iOS;FBSV/12.4.3;FBSS/2;FBID/phone;FBLC/pt_PT;FBOP/5;FBCR/NOS]'
   os:
     name: iOS
-    short_name: IOS
     version: "12.4.3"
     platform: ""
   client:
@@ -904,7 +822,7 @@
     version: ""
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -912,7 +830,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 7_0_6 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Mobile/11B651 [FBAN/FBIOS;FBAV/7.0.0.17.1;FBBV/1325030;FBDV/iPhone6,2;FBMD/iPhone;FBSN/iPhone OS;FBSV/7.0.6;FBSS/2; FBCR/AIS;FBID/phone;FBLC/de_DE;FBOP/5]'
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.6"
     platform: ""
   client:
@@ -921,7 +838,7 @@
     version: "7.0.0.17.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -929,19 +846,17 @@
   user_agent: Mozilla/5.0 (iPhone 5SGSM; CPU iPhone OS 7_0_6 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/6.0 MQQBrowser/5.0.5 Mobile/11B651 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.6"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0.5"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -949,19 +864,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Mobile/11D167 iPhone6,1/N51AP Zite/2.6
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "537.51.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Safari
@@ -969,19 +882,17 @@
   user_agent: Mozilla/5.0 (iPhone 5SGLOBAL; CPU iPhone OS 7_1 like Mac OS X) AppleWebKit/537.51.2 (KHTML, like Gecko) Version/6.0 MQQBrowser/5.0.5 Mobile/11D167 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "7.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0.5"
     engine: WebKit
     engine_version: "537.51.2"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Unknown
@@ -989,19 +900,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_2 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13F69 NAVER(inapp; search; 580; 8.2.2; 5S)
   os:
     name: iOS
-    short_name: IOS
     version: "9.3.2"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "601.1.46"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 5S
   os_family: iOS
   browser_family: Safari
@@ -1009,19 +918,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_2 like Mac OS X) AppleWebKit/604.4.7 (KHTML, like Gecko) Mobile/15C202 NAVER(inapp; search; 580; 8.4.3; 6)
   os:
     name: iOS
-    short_name: IOS
     version: "11.2.2"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "604.4.7"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 6
   os_family: iOS
   browser_family: Safari
@@ -1029,19 +936,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/15E216; iPhone 6s/11.3 XING/7.17.0
   os:
     name: iOS
-    short_name: IOS
     version: "11.3"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 6s
   os_family: iOS
   browser_family: Safari
@@ -1049,19 +954,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 680; 10.12.2; 6S)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 6s
   os_family: iOS
   browser_family: Safari
@@ -1069,19 +972,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.2; 7)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 7
   os_family: iOS
   browser_family: Safari
@@ -1089,19 +990,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.2; 8)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone 8
   os_family: iOS
   browser_family: Safari
@@ -1109,19 +1008,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 11_2_6 like Mac OS X) AppleWebKit/604.5.6 (KHTML, like Gecko) Mobile/15D100 NAVER(inapp; search; 590; 8.8.5; SE)
   os:
     name: iOS
-    short_name: IOS
     version: "11.2.6"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "604.5.6"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone SE
   os_family: iOS
   browser_family: Safari
@@ -1129,7 +1026,6 @@
   user_agent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 9_3_3 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Mobile/13G34 [FBAN/FBIOS;FBAV/61.0.0.53.158;FBBV/35251526;FBRV/0;FBDV/iPhone8,4;FBMD/iPhone;FBSN/iPhone OS;FBSV/9.3.3;FBSS/2;FBCR/T-Mobile;FBID/phone;FBLC/en_US;FBOP/5] '
   os:
     name: iOS
-    short_name: IOS
     version: "9.3.3"
     platform: ""
   client:
@@ -1138,7 +1034,7 @@
     version: "61.0.0.53.158"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone SE
   os_family: iOS
   browser_family: Unknown
@@ -1146,7 +1042,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 12_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16B93 Instagram 74.0.0.17.99 (iPhone11,8; iOS 12_1; de_DE; de-DE; scale=2.00; gamut=wide; 828x1792; 134173980)
   os:
     name: iOS
-    short_name: IOS
     version: "12.1"
     platform: ""
   client:
@@ -1155,7 +1050,7 @@
     version: "74.0.0.17.99"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone XR
   os_family: iOS
   browser_family: Unknown
@@ -1163,19 +1058,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 700; 10.20.2; XR)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone XR
   os_family: iOS
   browser_family: Safari
@@ -1183,7 +1076,6 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 12_0_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Mobile/16A405 Instagram 68.0.0.10.99 (iPhone11,2; iOS 12_0_1; de_DE; de-DE; scale=3.00; gamut=wide; 1125x2436; 128202899)
   os:
     name: iOS
-    short_name: IOS
     version: "12.0.1"
     platform: ""
   client:
@@ -1192,7 +1084,7 @@
     version: "68.0.0.10.99"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone XS
   os_family: iOS
   browser_family: Unknown
@@ -1200,19 +1092,17 @@
   user_agent: Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/605.1 NAVER(inapp; search; 596; 10.20.2; XS)
   os:
     name: iOS
-    short_name: IOS
     version: "13.3.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "13.0"
     engine: WebKit
     engine_version: "605.1.15"
   device:
     type: smartphone
-    brand: AP
+    brand: Apple
     model: iPhone XS
   os_family: iOS
   browser_family: Safari
@@ -1220,19 +1110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Archos 40 Titanium Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 40 Titanium
   os_family: Android
   browser_family: Chrome
@@ -1240,19 +1128,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Archos 45 Platinum Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 45 Platinum
   os_family: Android
   browser_family: Android Browser
@@ -1260,19 +1146,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Archos 45 Titanium Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 45 Titanium
   os_family: Android
   browser_family: Chrome
@@ -1280,19 +1164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; Archos 50 Helium 4G Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Helium 4G
   os_family: Android
   browser_family: Chrome
@@ -1300,19 +1182,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Archos 50 Oxygen Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Oxygen
   os_family: Android
   browser_family: Chrome
@@ -1320,19 +1200,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; Archos 50 Platinum Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Platinum
   os_family: Android
   browser_family: Android Browser
@@ -1340,19 +1218,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-cn; YL-Archos 50 Power Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Power
   os_family: Android
   browser_family: Chrome
@@ -1360,19 +1236,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Archos 50 Titanium Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Titanium
   os_family: Android
   browser_family: Chrome
@@ -1380,19 +1254,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A50TI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 50 Titanium 4G
   os_family: Android
   browser_family: Chrome
@@ -1400,19 +1272,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Archos 53 Platinum Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 53 Platinum
   os_family: Android
   browser_family: Android Browser
@@ -1420,19 +1290,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Archos 53 Titanium Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 53 Titanium
   os_family: Android
   browser_family: Android Browser
@@ -1440,19 +1308,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Archos 55 Platinum Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.87.90 Mobile Safari/537.36 NokiaBrowser/1.0
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Nokia Browser
-    short_name: NB
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: 55 Platinum
   os_family: Android
   browser_family: Nokia Browser
@@ -1460,19 +1326,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Archos Oxygen 63) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AR
+    brand: Archos
     model: Oxygen 63
   os_family: Android
   browser_family: Chrome
@@ -1480,19 +1344,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/ 7.0; WpsLondonTest; Asus;Galaxy6)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: Galaxy6
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -1500,19 +1362,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ASUS_Z00YD Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.0.1326.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.10.0.1326.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: Live
   os_family: Android
   browser_family: Unknown
@@ -1520,19 +1380,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; PadFone Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: PadFone
   os_family: Android
   browser_family: Android Browser
@@ -1540,19 +1398,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; PadFone 2 Build/JRO03L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: PadFone 2
   os_family: Android
   browser_family: Chrome
@@ -1560,19 +1416,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; PadFone Infinity Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: PadFone Infinity
   os_family: Android
   browser_family: Chrome
@@ -1580,19 +1434,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ASUS_T00N Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: PadFone S
   os_family: Android
   browser_family: Chrome
@@ -1600,19 +1452,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PadFone T004 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: PadFone T004
   os_family: Android
   browser_family: Chrome
@@ -1620,19 +1470,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_Z01QD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone
   os_family: Android
   browser_family: Chrome
@@ -1640,19 +1488,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZS600KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.1.396.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.1.396.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone
   os_family: Android
   browser_family: Unknown
@@ -1660,19 +1506,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I001DA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1680,19 +1524,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I001D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1700,19 +1542,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I001DC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1720,19 +1560,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I001DE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1740,19 +1578,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I001DB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1760,19 +1596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZS660KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 2
   os_family: Android
   browser_family: Chrome
@@ -1780,19 +1614,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; ASUS_I003DD Build/QKQ1.200419.002) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Quark/4.3.0.142 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "4.3.0.142"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ROG Phone 3
   os_family: Android
   browser_family: Chrome
@@ -1800,19 +1632,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0; ASUS_Z008 Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Chrome
@@ -1820,19 +1650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Z00D Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Chrome
@@ -1840,19 +1668,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; ASUS_Z008D Build/LRX21V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/45.0.2454.95 Mobile Safari/537.36 NAVER(inapp; search; 390; 6.4.5)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "45.0.2454.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Chrome
@@ -1860,19 +1686,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0; zh-CN; ASUS_Z00ADA Build/LRX21V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Unknown
@@ -1880,19 +1704,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0; zh-CN; ASUS_Z00ADB Build/LRX21V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Unknown
@@ -1900,7 +1722,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; ASUS_Z00AD Build/LRX21V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36 MicroMessenger/6.2.2.54_rec1912d.563 NetType/Internet Language/zh_TW
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
@@ -1909,7 +1730,7 @@
     version: "6.2.2.54.rec1912d.563"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Unknown
@@ -1917,19 +1738,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; ASUS_Z00A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2
   os_family: Android
   browser_family: Chrome
@@ -1937,19 +1756,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; ASUS_Z00RD Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2 Laser
   os_family: Android
   browser_family: Chrome
@@ -1957,19 +1774,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z00ED Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2 Laser
   os_family: Android
   browser_family: Chrome
@@ -1977,19 +1792,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z00MD Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2 Laser
   os_family: Android
   browser_family: Chrome
@@ -1997,19 +1810,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z00TD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2 Laser
   os_family: Android
   browser_family: Chrome
@@ -2017,7 +1828,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z011D Build/MMB29P; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 Instagram 53.0.0.13.84 Android (23/6.0.1; 480dpi; 1080x1920; asus; ASUS_Z011D; ASUS_Z011; qcom; fr_FR; 116756948)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -2026,7 +1836,7 @@
     version: "53.0.0.13.84"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2 Laser
   os_family: Android
   browser_family: Unknown
@@ -2034,19 +1844,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; ASUS ZenFone 2E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 2E
   os_family: Android
   browser_family: Chrome
@@ -2054,19 +1862,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_Z012S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3
   os_family: Android
   browser_family: Chrome
@@ -2074,19 +1880,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZE520KL Build/OPR1.170623.026; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/20.0.2254.109835
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "20.0.2254.109835"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3
   os_family: Android
   browser_family: Opera
@@ -2094,7 +1898,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 8.0.0; ASUS_Z012D Build/OPR1.170623.026)'
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
@@ -2103,7 +1906,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3
   os_family: Android
   browser_family: Unknown
@@ -2111,7 +1914,6 @@
   user_agent: PodcastRepublic/18.0 (Linux; U; Android 8.0.0;ASUS_Z017D_1/OPR1.170623.026)
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
@@ -2120,7 +1922,7 @@
     version: "18.0"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3
   os_family: Android
   browser_family: Unknown
@@ -2128,19 +1930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z016D Build/MXB48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Deluxe
   os_family: Android
   browser_family: Chrome
@@ -2148,19 +1948,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_Z01FD Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Deluxe
   os_family: Android
   browser_family: Chrome
@@ -2168,19 +1966,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ZS550KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Deluxe
   os_family: Android
   browser_family: Chrome
@@ -2188,19 +1984,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z01BS Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Laser
   os_family: Android
   browser_family: Chrome
@@ -2208,19 +2002,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_Z01BD Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Laser
   os_family: Android
   browser_family: Chrome
@@ -2228,19 +2020,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZC551KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Laser
   os_family: Android
   browser_family: Chrome
@@ -2248,19 +2038,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X00DD Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Max
   os_family: Android
   browser_family: Chrome
@@ -2268,19 +2056,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; ZC553KL Build/OPM1.171019.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/35.3.2254.129226
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "35.3.2254.129226"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Max
   os_family: Android
   browser_family: Opera
@@ -2288,19 +2074,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X00DS Build/OPM1.171019.011; it-it) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36 Puffin/7.8.3.40913AP
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.3.40913"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Max
   os_family: Android
   browser_family: Unknown
@@ -2308,19 +2092,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_A001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Ultra
   os_family: Android
   browser_family: Chrome
@@ -2328,19 +2110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_Z01HD Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Zoom
   os_family: Android
   browser_family: Chrome
@@ -2348,19 +2128,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZE553KL Build/OPR1.170623.026; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/35.3.2254.129219
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "35.3.2254.129219"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 3 Zoom
   os_family: Android
   browser_family: Opera
@@ -2368,19 +2146,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; ASUS_T00I Build/JSS15Q) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Android Browser
@@ -2388,19 +2164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ASUS_T00Q Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Chrome
@@ -2408,19 +2182,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; ASUS_X00LD Build/NMF26F)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Android Browser
@@ -2428,19 +2200,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_Z01KS Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Chrome
@@ -2448,19 +2218,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZE554KL Build/OPR6.170623.013; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36 OPR/36.2.2254.130496
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "36.2.2254.130496"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Opera
@@ -2468,7 +2236,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/2.1.0 (Linux; U; Android 8.0.0; ASUS_Z01KDA Build/OPR6.170623.013)'
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
@@ -2477,7 +2244,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4
   os_family: Android
   browser_family: Unknown
@@ -2485,19 +2252,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_X00KD Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Chrome
@@ -2505,19 +2270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZC520KL Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Chrome
@@ -2525,19 +2288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X00HD Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3371.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3371.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Chrome
@@ -2545,19 +2306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X00ID Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Chrome
@@ -2565,19 +2324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X00IS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Chrome
@@ -2585,19 +2342,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; ZC554KL Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.2.1184 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.2.1184"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max
   os_family: Android
   browser_family: Unknown
@@ -2605,19 +2360,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_X015D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Max Plus
   os_family: Android
   browser_family: Chrome
@@ -2625,19 +2378,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_Z01GD Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Pro
   os_family: Android
   browser_family: Chrome
@@ -2645,19 +2396,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ZS551KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Pro
   os_family: Android
   browser_family: Chrome
@@ -2665,19 +2414,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X00LDA Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Selfie
   os_family: Android
   browser_family: Chrome
@@ -2685,19 +2432,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_Z01MD Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Selfie
   os_family: Android
   browser_family: Chrome
@@ -2705,19 +2450,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZD553KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Selfie
   os_family: Android
   browser_family: Chrome
@@ -2725,19 +2468,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZD552KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 4 Selfie Pro
   os_family: Android
   browser_family: Chrome
@@ -2745,19 +2486,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-; ASUS_T00F Build/JSS15Q) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5
   os_family: Android
   browser_family: Android Browser
@@ -2765,19 +2504,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ASUS_T00J Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100501012
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5
   os_family: Android
   browser_family: Chrome
@@ -2785,19 +2522,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_X00QD Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5
   os_family: Android
   browser_family: Chrome
@@ -2805,19 +2540,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_X00QSA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5
   os_family: Android
   browser_family: Chrome
@@ -2825,19 +2558,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZE620KL Build/OPR1.170623.032; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/35.1.2254.128344
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "35.1.2254.128344"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5
   os_family: Android
   browser_family: Opera
@@ -2845,7 +2576,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; ASUS_T00K Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/26.0.0.22.16;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2854,7 +2584,7 @@
     version: "26.0.0.22.16"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5 Lite
   os_family: Android
   browser_family: Unknown
@@ -2862,19 +2592,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X017D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5 Lite
   os_family: Android
   browser_family: Chrome
@@ -2882,19 +2610,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_X017DA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5 Lite
   os_family: Android
   browser_family: Chrome
@@ -2902,19 +2628,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZC600KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5 Lite
   os_family: Android
   browser_family: Chrome
@@ -2922,19 +2646,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ASUS_T00P Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 YaBrowser/14.12.2125.9740.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.12.2125.9740.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5 LTE
   os_family: Android
   browser_family: Unknown
@@ -2942,19 +2664,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_Z01RD Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5Z
   os_family: Android
   browser_family: Chrome
@@ -2962,19 +2682,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZS620KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 5Z
   os_family: Android
   browser_family: Chrome
@@ -2982,19 +2700,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-US; ASUS_T00G Build/JSS15Q) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.2.349 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.2.349"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 6
   os_family: Android
   browser_family: Unknown
@@ -3002,19 +2718,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; ASUS_Z002 Build/KVT49L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.1.512 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.1.512"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 6
   os_family: Android
   browser_family: Unknown
@@ -3022,19 +2736,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZS630KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 6
   os_family: Android
   browser_family: Chrome
@@ -3042,19 +2754,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I01WD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 6
   os_family: Android
   browser_family: Chrome
@@ -3062,19 +2772,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_I01WDX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.8 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.8"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone 6
   os_family: Android
   browser_family: Chrome
@@ -3082,19 +2790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_A002 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone AR
   os_family: Android
   browser_family: Chrome
@@ -3102,19 +2808,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_A002A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone AR
   os_family: Android
   browser_family: Chrome
@@ -3122,19 +2826,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; vi; ASUS_Z007 Build/KVT49L) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/10.1.2.571 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.2.571"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone C
   os_family: Android
   browser_family: Unknown
@@ -3142,7 +2844,6 @@
   user_agent: Deezer/5.4.23.14 (Android; 6.0.1; Mobile; fr) asus ASUS_X00AD
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -3151,7 +2852,7 @@
     version: "5.4.23.14"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Unknown
@@ -3159,19 +2860,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ASUS_Z00VD Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3179,19 +2878,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ASUS_Z00SD Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3199,19 +2896,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ASUS_L001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3219,19 +2914,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ASUS_X00BD Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3239,19 +2932,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Z00VD Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3259,19 +2950,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; ZB500KG Build/LMY47V) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.10.0.796 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.10.0.796"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Unknown
@@ -3279,19 +2968,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; ZB551KL Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Unknown
@@ -3299,19 +2986,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_X007D Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3319,19 +3004,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZB500KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3828.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3828.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go
   os_family: Android
   browser_family: Chrome
@@ -3339,19 +3022,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ASUS_X014D Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go Plus
   os_family: Android
   browser_family: Chrome
@@ -3359,19 +3040,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; G550KL Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Go TV
   os_family: Android
   browser_family: Chrome
@@ -3379,19 +3058,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; G553KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Lite L1
   os_family: Android
   browser_family: Chrome
@@ -3399,19 +3076,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ASUS_A007 Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live
   os_family: Android
   browser_family: Chrome
@@ -3419,19 +3094,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZB501KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live
   os_family: Android
   browser_family: Chrome
@@ -3439,19 +3112,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZB553KL Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live
   os_family: Android
   browser_family: Chrome
@@ -3459,19 +3130,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZA550KL Build/OPR1.170623.032; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 OPR/35.3.2254.129226
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "35.3.2254.129226"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live
   os_family: Android
   browser_family: Opera
@@ -3479,19 +3148,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X00RD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live L1
   os_family: Android
   browser_family: Chrome
@@ -3499,19 +3166,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; G552KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Live L1
   os_family: Android
   browser_family: Chrome
@@ -3519,19 +3184,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; ASUS_Z010D Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max
   os_family: Android
   browser_family: Chrome
@@ -3539,19 +3202,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ASUS_X00PD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max M1
   os_family: Android
   browser_family: Chrome
@@ -3559,19 +3220,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.0.0; ZB555KL Build/OPR1.170623.032; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36 OPR/28.0.2254.119224
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "28.0.2254.119224"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max M1
   os_family: Android
   browser_family: Opera
@@ -3579,19 +3238,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X01AD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max M2
   os_family: Android
   browser_family: Chrome
@@ -3599,19 +3256,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZB633KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max M2
   os_family: Android
   browser_family: Chrome
@@ -3619,19 +3274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASUS_X01BD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3871.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3871.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max M2
   os_family: Android
   browser_family: Chrome
@@ -3639,19 +3292,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_X018D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Plus M1
   os_family: Android
   browser_family: Chrome
@@ -3659,19 +3310,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; ZB602KL Build/OPM1; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/69.0.3497.91 Mobile Safari/537.36 OPR/37.0.2254.130605
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "37.0.2254.130605"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Pro
   os_family: Android
   browser_family: Opera
@@ -3679,19 +3328,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X00TD Build/OPM1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Pro M1
   os_family: Android
   browser_family: Chrome
@@ -3699,19 +3346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZB601KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Pro M1
   os_family: Android
   browser_family: Chrome
@@ -3719,19 +3364,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ASUS_X01BDA Build/OPM1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Pro M2
   os_family: Android
   browser_family: Chrome
@@ -3739,19 +3382,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ZB631KL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Max Pro M2
   os_family: Android
   browser_family: Chrome
@@ -3759,19 +3400,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; en-US; ASUS_X003 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus
   os_family: Android
   browser_family: Chrome
@@ -3779,19 +3418,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ASUS_X002 Build/KTU84P; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus
   os_family: Android
   browser_family: Chrome
@@ -3799,19 +3436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ASUS_X550 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -3819,19 +3454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_X00GD Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus 3S Max
   os_family: Android
   browser_family: Chrome
@@ -3839,19 +3472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ASUS_X005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Pegasus 5000
   os_family: Android
   browser_family: Chrome
@@ -3859,19 +3490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; ASUS_Z00UD Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Selfie
   os_family: Android
   browser_family: Chrome
@@ -3879,19 +3508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_A006) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone V
   os_family: Android
   browser_family: Chrome
@@ -3899,19 +3526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ASUS_A009 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone V Live
   os_family: Android
   browser_family: Chrome
@@ -3919,19 +3544,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; ASUS_Z00XS Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AU
+    brand: Asus
     model: ZenFone Zoom
   os_family: Android
   browser_family: Chrome
@@ -3939,19 +3562,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-us; AVVIO_765 AVVIO 765 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AV
+    brand: Avvio
     model: "765"
   os_family: Android
   browser_family: Android Browser
@@ -3959,19 +3580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Avvio774 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AV
+    brand: Avvio
     model: "774"
   os_family: Android
   browser_family: Chrome
@@ -3979,19 +3598,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-us; Avvio_775 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: AV
+    brand: Avvio
     model: "775"
   os_family: Android
   browser_family: Android Browser
@@ -3999,19 +3616,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; es-ES; Avvio_775) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: AV
+    brand: Avvio
     model: "775"
   os_family: Android
   browser_family: Unknown
@@ -4019,19 +3634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Avvio786 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AV
+    brand: Avvio
     model: "786"
   os_family: Android
   browser_family: Chrome
@@ -4039,19 +3652,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AW500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AW
+    brand: Aiwa
     model: AW500
   os_family: Android
   browser_family: Chrome
@@ -4059,19 +3670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AW790 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AW
+    brand: Aiwa
     model: AW790
   os_family: Android
   browser_family: Chrome
@@ -4079,19 +3688,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AWM533) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: AW
+    brand: Aiwa
     model: AWM533
   os_family: Android
   browser_family: Chrome
@@ -4099,19 +3706,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Bush 4 Android Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B1
+    brand: Bush
     model: 4 Android
   os_family: Android
   browser_family: Chrome
@@ -4119,7 +3724,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; BUSH 5 Android Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/54.0.0.23.62;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -4128,7 +3732,7 @@
     version: "54.0.0.23.62"
   device:
     type: smartphone
-    brand: B1
+    brand: Bush
     model: 5 Android
   os_family: Android
   browser_family: Unknown
@@ -4136,19 +3740,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A60) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: A60
   os_family: Android
   browser_family: Chrome
@@ -4156,19 +3758,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; A60Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: A60 Pro
   os_family: Android
   browser_family: Chrome
@@ -4176,19 +3776,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Blackview A8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: A8
   os_family: Android
   browser_family: Chrome
@@ -4196,19 +3794,17 @@
   user_agent: mozilla/5.0 (linux; android 9; a80pro) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.106 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: A80 Pro
   os_family: Android
   browser_family: Chrome
@@ -4216,19 +3812,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Alife P1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 YaBrowser/16.2.2.7988.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.2.2.7988.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: Alife P1
   os_family: Android
   browser_family: Unknown
@@ -4236,19 +3830,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Alife S1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: Alife S1
   os_family: Android
   browser_family: Chrome
@@ -4256,19 +3848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BV4000Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV4000 Pro
   os_family: Android
   browser_family: Chrome
@@ -4276,19 +3866,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; BV5500 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.8.1206 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.8.1206"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV5500
   os_family: Android
   browser_family: Unknown
@@ -4296,19 +3884,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BV5800 PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV5800 PRO
   os_family: Android
   browser_family: Chrome
@@ -4316,19 +3902,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; BV5900 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV5900
   os_family: Android
   browser_family: Unknown
@@ -4336,19 +3920,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BV6000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6000
   os_family: Android
   browser_family: Chrome
@@ -4356,19 +3938,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; BV6000 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.9.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.9.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6000
   os_family: Android
   browser_family: Unknown
@@ -4376,19 +3956,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BV6000 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.1.359.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.1.359.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6000
   os_family: Android
   browser_family: Unknown
@@ -4396,19 +3974,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BV6000S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6000S
   os_family: Android
   browser_family: Chrome
@@ -4416,19 +3992,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BV6800Pro Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV6800 Pro
   os_family: Android
   browser_family: Chrome
@@ -4436,19 +4010,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BV7000 PRO Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV7000 PRO
   os_family: Android
   browser_family: Chrome
@@ -4456,19 +4028,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BV8000Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV8000 Pro
   os_family: Android
   browser_family: Chrome
@@ -4476,19 +4046,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BV9000Pro-F Build/N4F26M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9000 Pro F
   os_family: Android
   browser_family: Chrome
@@ -4496,19 +4064,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BV9100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9100
   os_family: Android
   browser_family: Chrome
@@ -4516,19 +4082,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BV9500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9500
   os_family: Android
   browser_family: Chrome
@@ -4536,19 +4100,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; BV9600 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9600
   os_family: Android
   browser_family: Opera
@@ -4556,19 +4118,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BV9600Pro Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9600 Pro
   os_family: Android
   browser_family: Chrome
@@ -4576,19 +4136,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BV9700Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9700 Pro
   os_family: Android
   browser_family: Chrome
@@ -4596,19 +4154,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; en-US; BV9800 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.0.1288 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.0.1288"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9800
   os_family: Android
   browser_family: Unknown
@@ -4616,19 +4172,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BV9900) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: BV9900
   os_family: Android
   browser_family: Chrome
@@ -4636,19 +4190,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; DM550 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: DM550
   os_family: Android
   browser_family: Chrome
@@ -4656,19 +4208,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Blackview E7S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: E7S
   os_family: Android
   browser_family: Chrome
@@ -4676,19 +4226,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; omega_pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: Omega Pro
   os_family: Android
   browser_family: Chrome
@@ -4696,19 +4244,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; P10000_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B2
+    brand: Blackview
     model: P10000 Pro
   os_family: Android
   browser_family: Chrome
@@ -4716,19 +4262,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Bluboo Dual Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Dual
   os_family: Android
   browser_family: Chrome
@@ -4736,19 +4280,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Maya Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Maya
   os_family: Android
   browser_family: Chrome
@@ -4756,19 +4298,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Bluboo Mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Mini
   os_family: Android
   browser_family: Chrome
@@ -4776,19 +4316,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Picasso 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Picasso 4G
   os_family: Android
   browser_family: Chrome
@@ -4796,19 +4334,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BlubooS8 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: S8
   os_family: Android
   browser_family: Chrome
@@ -4816,19 +4352,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; XFire Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.7.5.658 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.5.658"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Xfire
   os_family: Android
   browser_family: Unknown
@@ -4836,19 +4370,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Xfire2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B3
+    brand: Bluboo
     model: Xfire 2
   os_family: Android
   browser_family: Chrome
@@ -4856,19 +4388,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; BO-FRSP4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B4
+    brand: bogo
     model: FRSP4
   os_family: Android
   browser_family: Chrome
@@ -4876,19 +4406,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; BO-LFSP4 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B4
+    brand: bogo
     model: LifeStyle 4DC
   os_family: Android
   browser_family: Chrome
@@ -4896,19 +4424,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BO-LFSPSL4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B4
+    brand: bogo
     model: LifeStyle 4SL
   os_family: Android
   browser_family: Chrome
@@ -4916,19 +4442,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BO-LFSPBS5 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B4
+    brand: bogo
     model: LifeStyle 5BS
   os_family: Android
   browser_family: Chrome
@@ -4936,19 +4460,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BO-LFSPSL6QCI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B4
+    brand: bogo
     model: LifeStyle 6QC
   os_family: Android
   browser_family: Chrome
@@ -4956,19 +4478,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Beeline E700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: E700
   os_family: Android
   browser_family: Chrome
@@ -4976,19 +4496,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Beeline Fast Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Fast
   os_family: Android
   browser_family: Android Browser
@@ -4996,19 +4514,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Beeline_Fast_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Fast 2
   os_family: Android
   browser_family: Chrome
@@ -5016,19 +4532,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 5.0; Beeline Pro 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.7.115.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.7.115.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Pro 2
   os_family: Android
   browser_family: Unknown
@@ -5036,19 +4550,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; Beeline_Pro_3 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Pro 3
   os_family: Android
   browser_family: Unknown
@@ -5056,19 +4568,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Beeline Pro 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Pro 4
   os_family: Android
   browser_family: Chrome
@@ -5076,19 +4586,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Beeline_Pro_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Pro 6
   os_family: Android
   browser_family: Chrome
@@ -5096,19 +4604,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Beeline Smart2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Smart 2
   os_family: Android
   browser_family: Chrome
@@ -5116,19 +4622,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Beeline Smart 3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Smart 3
   os_family: Android
   browser_family: Chrome
@@ -5136,19 +4640,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Beeline Smart 4 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Smart 4
   os_family: Android
   browser_family: Chrome
@@ -5156,19 +4658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Beeline Smart Dual) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B5
+    brand: Beeline
     model: Smart Dual
   os_family: Android
   browser_family: Chrome
@@ -5176,19 +4676,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; BIHEE A11 Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A11
   os_family: Android
   browser_family: Chrome
@@ -5196,19 +4694,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BIHEE A12 Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A12
   os_family: Android
   browser_family: Chrome
@@ -5216,19 +4712,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; ZBH-BIHEE A5 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A5
   os_family: Android
   browser_family: Android Browser
@@ -5236,19 +4730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BIHEE A6 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36 Mb2345Browser/7.5.1
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: 2345 Browser
-    short_name: 2B
     version: "7.5.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A6
   os_family: Android
   browser_family: Chrome
@@ -5256,19 +4748,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; BIHEE A7+ Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A7+
   os_family: Android
   browser_family: Android Browser
@@ -5276,19 +4766,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; BIHEE A8+ Build/MMB29M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.4.846 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.4.846"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: B8
+    brand: BIHEE
     model: A8+
   os_family: Android
   browser_family: Unknown
@@ -5296,19 +4784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLUEGOOD V6 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BD
+    brand: Bluegood
     model: V6
   os_family: Android
   browser_family: Chrome
@@ -5316,19 +4802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BMM541D Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B3
   os_family: Android
   browser_family: Chrome
@@ -5336,19 +4820,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BMM542D Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B3+
   os_family: Android
   browser_family: Chrome
@@ -5356,19 +4838,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BMM543D Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B4
   os_family: Android
   browser_family: Chrome
@@ -5376,19 +4856,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BMM543S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B4
   os_family: Android
   browser_family: Chrome
@@ -5396,19 +4874,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM441D Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B4 Mini
   os_family: Android
   browser_family: Chrome
@@ -5416,19 +4892,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM531B Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.103 YaBrowser/18.7.1.595.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.7.1.595.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B4 Mini (2019)
   os_family: Android
   browser_family: Unknown
@@ -5436,19 +4910,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM541B Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B4 Mini NFC
   os_family: Android
   browser_family: Chrome
@@ -5456,19 +4928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BMM531A Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B5
   os_family: Android
   browser_family: Chrome
@@ -5476,19 +4946,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM541A Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B5+
   os_family: Android
   browser_family: Chrome
@@ -5496,19 +4964,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM531D AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B6
   os_family: Android
   browser_family: Chrome
@@ -5516,19 +4982,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BMM442D AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.103 YaBrowser/19.4.0.535.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.4.0.535.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B7
   os_family: Android
   browser_family: Unknown
@@ -5536,19 +5000,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BMM443D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B7 Fox+
   os_family: Android
   browser_family: Chrome
@@ -5556,19 +5018,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 9; BMM541W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 YaBrowser/20.2.5.120.00 Mobile SA/1 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.5.120.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B7R Fox
   os_family: Android
   browser_family: Unknown
@@ -5576,19 +5036,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BMM441S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: B8 Fox
   os_family: Android
   browser_family: Chrome
@@ -5596,19 +5054,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BMM 431D Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: BMM 431D
   os_family: Android
   browser_family: Chrome
@@ -5616,19 +5072,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BMM_533D Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: BMM 533D
   os_family: Android
   browser_family: Chrome
@@ -5636,19 +5090,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BMM 541S AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: BMM 541S
   os_family: Android
   browser_family: Chrome
@@ -5656,19 +5108,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BMM-542S AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BF
+    brand: Black Fox
     model: BMM 542S
   os_family: Android
   browser_family: Chrome
@@ -5676,19 +5126,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BGH Joy 303) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy 303
   os_family: Android
   browser_family: Chrome
@@ -5696,19 +5144,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BGH Joy Smart A5C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart A5C
   os_family: Android
   browser_family: Chrome
@@ -5716,19 +5162,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BGH Joy Smart A6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart A6
   os_family: Android
   browser_family: Chrome
@@ -5736,19 +5180,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BGH Joy Smart A7G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart A7G
   os_family: Android
   browser_family: Chrome
@@ -5756,19 +5198,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BGH Joy Smart AXS II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart AXS II
   os_family: Android
   browser_family: Chrome
@@ -5776,19 +5216,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BGH Joy Smart AXS II D Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart AXS II D
   os_family: Android
   browser_family: Chrome
@@ -5796,19 +5234,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BGH Joy Smart AXS II D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy Smart AXS II D
   os_family: Android
   browser_family: Chrome
@@ -5816,19 +5252,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BGH Joy V6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy V6
   os_family: Android
   browser_family: Chrome
@@ -5836,19 +5270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BGH JOY X2 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy X2
   os_family: Android
   browser_family: Chrome
@@ -5856,19 +5288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BGH JOY X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy X2
   os_family: Android
   browser_family: Chrome
@@ -5876,19 +5306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BGH Joy X5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BG
+    brand: BGH
     model: Joy X5
   os_family: Android
   browser_family: Chrome
@@ -5896,19 +5324,17 @@
   user_agent: Bird-Doeasy E700_TD/S100 Linux/3.0.8 Android/4.0.3 Release/03.12.2013 Browser/AppleWebkit534.30 Mobile Safari/534.30;
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: Doeasy E700
   os_family: Android
   browser_family: Android Browser
@@ -5916,19 +5342,17 @@
   user_agent: Bird i600_TD/1.0 Linux/3.0.8 Android/4.0.3 Release/04.20.2013 AppleWebKit/534.30 Version/4.0 Mozilla/5.0 Mobile System/Android 4.0.3;
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: i600
   os_family: Android
   browser_family: Android Browser
@@ -5936,19 +5360,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Bird i7 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30Mopo/1830(4.0.12;1_skymobi_;bd87_89_td_emmc_bird_i7;Bird i7;480*854)'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: i7
   os_family: Android
   browser_family: Android Browser
@@ -5956,19 +5378,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; BIRD T900 Build/MocorDroid4.0.4) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.2.3.324 U3/0.8.0 Mobile Safari/534.31
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.3.324"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: T900
   os_family: Android
   browser_family: Unknown
@@ -5976,19 +5396,17 @@
   user_agent: Bird_T9108_TD/T9108_V1.00 Android/2.3.5 SC8810_CMCC/W12.06.10 Release/04.18.2012 Browser/AppleWebKit533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: T9108
   os_family: Android
   browser_family: Android Browser
@@ -5996,19 +5414,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; BIRD-V8 Build/AD35) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: V8
   os_family: Android
   browser_family: Android Browser
@@ -6016,19 +5432,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; BIRD_W5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BI
+    brand: Bird
     model: W5
   os_family: Android
   browser_family: Android Browser
@@ -6036,19 +5450,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1010 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1010
   os_family: Android
   browser_family: Chrome
@@ -6056,19 +5468,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1015 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1015
   os_family: Android
   browser_family: Chrome
@@ -6076,19 +5486,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1016 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1016
   os_family: Android
   browser_family: Chrome
@@ -6096,19 +5504,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BMOBILE AX1020 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1020
   os_family: Android
   browser_family: Chrome
@@ -6116,19 +5522,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AX1020 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1020
   os_family: Android
   browser_family: Chrome
@@ -6136,19 +5540,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AX1030 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1030
   os_family: Android
   browser_family: Chrome
@@ -6156,19 +5558,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1035 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1035
   os_family: Android
   browser_family: Chrome
@@ -6176,19 +5576,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1040 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1040
   os_family: Android
   browser_family: Chrome
@@ -6196,19 +5594,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1045 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1045
   os_family: Android
   browser_family: Chrome
@@ -6216,19 +5612,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; AX1050 Build/KTU84P); AppleWebkit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1050
   os_family: Android
   browser_family: Chrome
@@ -6236,19 +5630,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AX1055 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1055
   os_family: Android
   browser_family: Chrome
@@ -6256,19 +5648,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; AX1060 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1060
   os_family: Android
   browser_family: Chrome
@@ -6276,19 +5666,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AX1065 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1065
   os_family: Android
   browser_family: Chrome
@@ -6296,19 +5684,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1065E Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1065E
   os_family: Android
   browser_family: Chrome
@@ -6316,19 +5702,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1070 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1070
   os_family: Android
   browser_family: Chrome
@@ -6336,19 +5720,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1070e Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1070e
   os_family: Android
   browser_family: Chrome
@@ -6356,19 +5738,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1071 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1071
   os_family: Android
   browser_family: Chrome
@@ -6376,19 +5756,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1072 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1072
   os_family: Android
   browser_family: Chrome
@@ -6396,19 +5774,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1073 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1073
   os_family: Android
   browser_family: Chrome
@@ -6416,19 +5792,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1073+ Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1073+
   os_family: Android
   browser_family: Chrome
@@ -6436,19 +5810,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1074 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1074
   os_family: Android
   browser_family: Chrome
@@ -6456,19 +5828,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; AX1075 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1075
   os_family: Android
   browser_family: Chrome
@@ -6476,19 +5846,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; AX1075 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1075
   os_family: Android
   browser_family: Chrome
@@ -6496,19 +5864,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX1085 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1085
   os_family: Android
   browser_family: Chrome
@@ -6516,19 +5882,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX1091 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX1091
   os_family: Android
   browser_family: Chrome
@@ -6536,19 +5900,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; AX-340 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX340
   os_family: Android
   browser_family: Android Browser
@@ -6556,19 +5918,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; AX510 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX510
   os_family: Android
   browser_family: Android Browser
@@ -6576,19 +5936,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AX512 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX512
   os_family: Android
   browser_family: Chrome
@@ -6596,19 +5954,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 2.3.6; AX515 Build/GRK39F) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "14.0.1025.52315"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX515
   os_family: Android
   browser_family: Opera
@@ -6616,19 +5972,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; AX520 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX520
   os_family: Android
   browser_family: Android Browser
@@ -6636,19 +5990,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AX524 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX524
   os_family: Android
   browser_family: Chrome
@@ -6656,19 +6008,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; AX525 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX525
   os_family: Android
   browser_family: Android Browser
@@ -6676,19 +6026,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; AX530 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX530
   os_family: Android
   browser_family: Android Browser
@@ -6696,19 +6044,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AX535 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX535
   os_family: Android
   browser_family: Chrome
@@ -6716,19 +6062,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; AX540 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX540
   os_family: Android
   browser_family: Android Browser
@@ -6736,19 +6080,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX570 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX570
   os_family: Android
   browser_family: Chrome
@@ -6756,19 +6098,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX600 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX600
   os_family: Android
   browser_family: Chrome
@@ -6776,19 +6116,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX605 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX605
   os_family: Android
   browser_family: Chrome
@@ -6796,19 +6134,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; AX610 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX610
   os_family: Android
   browser_family: Android Browser
@@ -6816,19 +6152,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-mx; Bmobile_AX610) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX610
   os_family: Android
   browser_family: Android Browser
@@ -6836,19 +6170,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Bmobile_AX620 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36 OPR/30.0.1856.93524
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "30.0.1856.93524"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX620
   os_family: Android
   browser_family: Opera
@@ -6856,19 +6188,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; AX650 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX650
   os_family: Android
   browser_family: Android Browser
@@ -6876,19 +6206,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX660 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX660
   os_family: Android
   browser_family: Chrome
@@ -6896,19 +6224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX670 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX670
   os_family: Android
   browser_family: Chrome
@@ -6916,19 +6242,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX675 Build/AX675) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX675
   os_family: Android
   browser_family: Chrome
@@ -6936,19 +6260,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Bmobile_AX680 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX680
   os_family: Android
   browser_family: Chrome
@@ -6956,19 +6278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX680+ Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX680+
   os_family: Android
   browser_family: Chrome
@@ -6976,19 +6296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX681 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX681
   os_family: Android
   browser_family: Chrome
@@ -6996,19 +6314,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX683 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX683
   os_family: Android
   browser_family: Chrome
@@ -7016,19 +6332,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX685 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX685
   os_family: Android
   browser_family: Chrome
@@ -7036,19 +6350,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; AX690 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX690
   os_family: Android
   browser_family: Android Browser
@@ -7056,19 +6368,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX7OO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX700
   os_family: Android
   browser_family: Chrome
@@ -7076,19 +6386,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX705 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX705
   os_family: Android
   browser_family: Chrome
@@ -7096,19 +6404,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX710 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX710
   os_family: Android
   browser_family: Chrome
@@ -7116,19 +6422,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; AX745 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX745
   os_family: Android
   browser_family: Android Browser
@@ -7136,19 +6440,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Bmobile_AX810 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX810
   os_family: Android
   browser_family: Chrome
@@ -7156,19 +6458,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX820 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX820
   os_family: Android
   browser_family: Chrome
@@ -7176,19 +6476,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX821 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX821
   os_family: Android
   browser_family: Chrome
@@ -7196,19 +6494,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX823 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX823
   os_family: Android
   browser_family: Chrome
@@ -7216,19 +6512,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX920 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX920
   os_family: Android
   browser_family: Chrome
@@ -7236,19 +6530,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AX921 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX921
   os_family: Android
   browser_family: Chrome
@@ -7256,19 +6548,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AX922 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: AX922
   os_family: Android
   browser_family: Chrome
@@ -7276,19 +6566,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-mx; Bmobile_T35AC) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BM
+    brand: Bmobile
     model: T35AC
   os_family: Android
   browser_family: Android Browser
@@ -7296,19 +6584,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Blaupunkt SL 01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BP
+    brand: Blaupunkt
     model: SL 01
   os_family: Android
   browser_family: Chrome
@@ -7316,19 +6602,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Blaupunkt SL 02 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BP
+    brand: Blaupunkt
     model: SL 02
   os_family: Android
   browser_family: Chrome
@@ -7336,19 +6620,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Blaupunkt SL 04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BP
+    brand: Blaupunkt
     model: SL 04
   os_family: Android
   browser_family: Chrome
@@ -7356,19 +6638,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Blaupunkt SM 01 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BP
+    brand: Blaupunkt
     model: SM 01
   os_family: Android
   browser_family: Chrome
@@ -7376,19 +6656,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 501 SZ Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: 501 SZ
   os_family: Android
   browser_family: Chrome
@@ -7396,19 +6674,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Brondi 620 SZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: 620 SZ
   os_family: Android
   browser_family: Chrome
@@ -7416,19 +6692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Brondi_730_4G_HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: 730 4G HD
   os_family: Android
   browser_family: Chrome
@@ -7436,19 +6710,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; CENTURION Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: CENTURION
   os_family: Android
   browser_family: Android Browser
@@ -7456,19 +6728,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CENTURION 3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: CENTURION 3
   os_family: Android
   browser_family: Chrome
@@ -7476,19 +6746,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; GLADIATOR Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLADIATOR
   os_family: Android
   browser_family: Android Browser
@@ -7496,19 +6764,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; GLADIATOR-2 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLADIATOR 2
   os_family: Android
   browser_family: Chrome
@@ -7516,19 +6782,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; GLADIATOR 3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLADIATOR 3
   os_family: Android
   browser_family: Android Browser
@@ -7536,19 +6800,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GLADIATOR_4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLADIATOR 4
   os_family: Android
   browser_family: Chrome
@@ -7556,19 +6818,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1 JELLY BEAN; it-it; Glory Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLORY
   os_family: Android
   browser_family: Android Browser
@@ -7576,19 +6836,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; Glory 2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLORY 2
   os_family: Android
   browser_family: Android Browser
@@ -7596,19 +6854,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; Glory3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLORY 3
   os_family: Android
   browser_family: Android Browser
@@ -7616,19 +6872,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GLORY 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: GLORY 4
   os_family: Android
   browser_family: Chrome
@@ -7636,19 +6890,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; LUXURY Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: LUXURY
   os_family: Android
   browser_family: Android Browser
@@ -7656,19 +6908,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; LUXURY 3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: LUXURY 3
   os_family: Android
   browser_family: Android Browser
@@ -7676,19 +6926,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; LUXURY 4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: LUXURY 4
   os_family: Android
   browser_family: Android Browser
@@ -7696,19 +6944,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LUXURY 5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: LUXURY 5
   os_family: Android
   browser_family: Chrome
@@ -7716,19 +6962,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; SENSUELLE Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: SENSUELLE
   os_family: Android
   browser_family: Android Browser
@@ -7736,19 +6980,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; VICTORY Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: VICTORY
   os_family: Android
   browser_family: Android Browser
@@ -7756,19 +6998,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Victory 2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: VICTORY 2
   os_family: Android
   browser_family: Android Browser
@@ -7776,19 +7016,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Victory 3 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BR
+    brand: Brondi
     model: VICTORY 3
   os_family: Android
   browser_family: Chrome
@@ -7796,19 +7034,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8407 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8407
   os_family: Android
   browser_family: Chrome
@@ -7816,19 +7052,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8408 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8408
   os_family: Android
   browser_family: Chrome
@@ -7836,19 +7070,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BITEL B8409 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8409
   os_family: Android
   browser_family: Chrome
@@ -7856,19 +7088,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8410 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8410
   os_family: Android
   browser_family: Chrome
@@ -7876,19 +7106,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Bitel_B8411 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8411
   os_family: Android
   browser_family: Chrome
@@ -7896,19 +7124,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Bitel-B8413 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8413
   os_family: Android
   browser_family: Chrome
@@ -7916,19 +7142,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B8414 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8414
   os_family: Android
   browser_family: Chrome
@@ -7936,19 +7160,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B8415 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8415
   os_family: Android
   browser_family: Chrome
@@ -7956,19 +7178,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B8416 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8416
   os_family: Android
   browser_family: Chrome
@@ -7976,19 +7196,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8502 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8502
   os_family: Android
   browser_family: Chrome
@@ -7996,19 +7214,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8503 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8503
   os_family: Android
   browser_family: Chrome
@@ -8016,19 +7232,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B8504) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8504
   os_family: Android
   browser_family: Chrome
@@ -8036,19 +7250,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; B8506 Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8506
   os_family: Android
   browser_family: Chrome
@@ -8056,19 +7268,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; B8601 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8601
   os_family: Android
   browser_family: Chrome
@@ -8076,19 +7286,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; B8604 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8604
   os_family: Android
   browser_family: Chrome
@@ -8096,19 +7304,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B8606) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B8606
   os_family: Android
   browser_family: Chrome
@@ -8116,19 +7322,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B9401 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9401
   os_family: Android
   browser_family: Chrome
@@ -8136,19 +7340,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B9501 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9501
   os_family: Android
   browser_family: Chrome
@@ -8156,19 +7358,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B9502 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9502
   os_family: Android
   browser_family: Chrome
@@ -8176,19 +7376,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B9503 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9503
   os_family: Android
   browser_family: Chrome
@@ -8196,19 +7394,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B9504 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9504
   os_family: Android
   browser_family: Chrome
@@ -8216,19 +7412,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B9505 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BT
+    brand: Bitel
     model: B9505
   os_family: Android
   browser_family: Chrome
@@ -8236,19 +7430,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BLU ADVANCE 4.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Advance 4.0
   os_family: Android
   browser_family: Chrome
@@ -8256,19 +7448,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BLU ADVANCE 4.0 L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Advance 4.0 L
   os_family: Android
   browser_family: Chrome
@@ -8276,19 +7466,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Advance 4.0M Build/A090; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Advance 4.0M
   os_family: Android
   browser_family: Chrome
@@ -8296,19 +7484,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Advance 5.0 HD Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Advance 5.0 HD
   os_family: Android
   browser_family: Chrome
@@ -8316,19 +7502,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Advance A4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Advance A4
   os_family: Android
   browser_family: Chrome
@@ -8336,19 +7520,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; BLU DASH 3.5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 3.5
   os_family: Android
   browser_family: Android Browser
@@ -8356,19 +7538,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; BLU DASH 3.5 VIVA Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 3.5 VIVA
   os_family: Android
   browser_family: Android Browser
@@ -8376,19 +7556,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; BLU DASH 4.0 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 4.0
   os_family: Android
   browser_family: Android Browser
@@ -8396,19 +7574,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; BLU DASH 4.5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 4.5
   os_family: Android
   browser_family: Android Browser
@@ -8416,19 +7592,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; BLU DASH 5.0 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 5.0
   os_family: Android
   browser_family: Android Browser
@@ -8436,19 +7610,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BLU DASH 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 5.0
   os_family: Android
   browser_family: Chrome
@@ -8456,19 +7628,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; DASH 5.0+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash 5.0+
   os_family: Android
   browser_family: Chrome
@@ -8476,19 +7646,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; es-es; BLU DASH JR Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash JR
   os_family: Android
   browser_family: Android Browser
@@ -8496,19 +7664,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; DASH JR K Build/BLUZAW268) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash JR K
   os_family: Android
   browser_family: Chrome
@@ -8516,19 +7682,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BLU DASH L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash L
   os_family: Android
   browser_family: Chrome
@@ -8536,19 +7700,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Dash L2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash L2
   os_family: Android
   browser_family: Chrome
@@ -8556,19 +7718,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Dash L3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash L3
   os_family: Android
   browser_family: Chrome
@@ -8576,19 +7736,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU DASH M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash M
   os_family: Android
   browser_family: Chrome
@@ -8596,19 +7754,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; BLU DASH MUSIC 4.0 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash MUSIC 4.0
   os_family: Android
   browser_family: Android Browser
@@ -8616,19 +7772,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU DASH X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash X
   os_family: Android
   browser_family: Chrome
@@ -8636,19 +7790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; DASH_X_PLUS_LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash X PLUS LTE
   os_family: Android
   browser_family: Chrome
@@ -8656,19 +7808,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Dash X2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash X2
   os_family: Android
   browser_family: Chrome
@@ -8676,19 +7826,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLU DASH X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash X2
   os_family: Android
   browser_family: Chrome
@@ -8696,19 +7844,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Dash X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash X2
   os_family: Android
   browser_family: Chrome
@@ -8716,19 +7862,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Dash XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Dash XL
   os_family: Android
   browser_family: Chrome
@@ -8736,19 +7880,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLU ENERGY DIAMOND) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Energy Diamond
   os_family: Android
   browser_family: Chrome
@@ -8756,19 +7898,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; BLU ENERGY X PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Energy X Plus
   os_family: Android
   browser_family: Chrome
@@ -8776,19 +7916,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLU ENERGY X PLUS 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Energy X Plus 2
   os_family: Android
   browser_family: Chrome
@@ -8796,19 +7934,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ENERGY XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Energy XL
   os_family: Android
   browser_family: Chrome
@@ -8816,19 +7952,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLU GRAND 5.5 HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Grand 5.5 HD
   os_family: Android
   browser_family: Chrome
@@ -8836,19 +7970,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLU Grand X LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Grand X LTE
   os_family: Android
   browser_family: Chrome
@@ -8856,19 +7988,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Grand XL LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Grand XL LTE
   os_family: Android
   browser_family: Chrome
@@ -8876,19 +8006,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; BLU Life One Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Life One
   os_family: Android
   browser_family: Chrome
@@ -8896,19 +8024,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BLU LIFE ONE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Life One
   os_family: Android
   browser_family: Chrome
@@ -8916,19 +8042,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Life One X2 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Life One X2
   os_family: Android
   browser_family: Chrome
@@ -8936,19 +8060,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; BLU Life View Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Life View
   os_family: Android
   browser_family: Chrome
@@ -8956,19 +8078,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; BLU LIFE XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Life XL
   os_family: Android
   browser_family: Chrome
@@ -8976,19 +8096,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; BLU Magic Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Magic
   os_family: Android
   browser_family: Unknown
@@ -8996,19 +8114,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU_NEO_ENERGY_MINI Build/N130) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: NEO ENERGY MINI
   os_family: Android
   browser_family: Chrome
@@ -9016,19 +8132,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU NEO X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Neo X
   os_family: Android
   browser_family: Chrome
@@ -9036,19 +8150,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU NEO X PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Neo X Plus
   os_family: Android
   browser_family: Chrome
@@ -9056,19 +8168,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU NEO XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Neo XL
   os_family: Android
   browser_family: Chrome
@@ -9076,19 +8186,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PURE XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Pure XL
   os_family: Android
   browser_family: Chrome
@@ -9096,19 +8204,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us;BLU Quattro 4.5 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Quattro 4.5
   os_family: Android
   browser_family: Android Browser
@@ -9116,19 +8222,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLU R1 HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: R1 HD
   os_family: Android
   browser_family: Chrome
@@ -9136,19 +8240,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; R1 PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: R1 Plus
   os_family: Android
   browser_family: Chrome
@@ -9156,19 +8258,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; BLU STUDIO 5.0 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: STUDIO 5.0
   os_family: Android
   browser_family: Android Browser
@@ -9176,19 +8276,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BLU STUDIO 5.0 C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio 5.0 C
   os_family: Android
   browser_family: Chrome
@@ -9196,19 +8294,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; BLU STUDIO 5.0 II Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: STUDIO 5.0 II
   os_family: Android
   browser_family: Android Browser
@@ -9216,19 +8312,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; STUDIO 5.0K Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio 5.0 K
   os_family: Android
   browser_family: Android Browser
@@ -9236,19 +8330,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; BLU STUDIO 5.3 II Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: STUDIO 5.3 II
   os_family: Android
   browser_family: Chrome
@@ -9256,19 +8348,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; STUDIO 5.5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio 5.5
   os_family: Android
   browser_family: Android Browser
@@ -9276,19 +8366,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; BLU STUDIO C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio C
   os_family: Android
   browser_family: Chrome
@@ -9296,19 +8384,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Studio C HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio C HD
   os_family: Android
   browser_family: Chrome
@@ -9316,19 +8402,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Studio J1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio J1
   os_family: Android
   browser_family: Chrome
@@ -9336,19 +8420,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Studio J2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio J2
   os_family: Android
   browser_family: Chrome
@@ -9356,19 +8438,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Studio J5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio J5
   os_family: Android
   browser_family: Chrome
@@ -9376,19 +8456,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Studio J8 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio J8
   os_family: Android
   browser_family: Chrome
@@ -9396,19 +8474,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; STUDIO M HD Build/S110L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio M HD
   os_family: Android
   browser_family: Chrome
@@ -9416,19 +8492,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Studio M5 Plus Build/D710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio M5 Plus
   os_family: Android
   browser_family: Chrome
@@ -9436,19 +8510,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Studio Mega) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio Mega
   os_family: Android
   browser_family: Chrome
@@ -9456,19 +8528,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU STUDIO ONE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio One
   os_family: Android
   browser_family: Chrome
@@ -9476,19 +8546,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; STUDIO SELFIE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio Selfie
   os_family: Android
   browser_family: Chrome
@@ -9496,19 +8564,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BLU STUDIO SELFIE 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio Selfie 2
   os_family: Android
   browser_family: Chrome
@@ -9516,19 +8582,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; BLU STUDIO SELFIE LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio Selfie LTE
   os_family: Android
   browser_family: Chrome
@@ -9536,19 +8600,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Studio View XL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio View XL
   os_family: Android
   browser_family: Chrome
@@ -9556,19 +8618,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BLU STUDIO X8 HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio X
   os_family: Android
   browser_family: Chrome
@@ -9576,19 +8636,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BLU STUDIO X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Studio X
   os_family: Android
   browser_family: Chrome
@@ -9596,19 +8654,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; BLU_STUDIO_XL Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: STUDIO XL
   os_family: Android
   browser_family: Chrome
@@ -9616,19 +8672,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Tank Xtreme 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Tank Xtreme 5.0
   os_family: Android
   browser_family: Chrome
@@ -9636,19 +8690,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tank Xtreme Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Tank Xtreme Pro
   os_family: Android
   browser_family: Chrome
@@ -9656,19 +8708,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; BLU VIVO 4.65 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: VIVO 4.65
   os_family: Android
   browser_family: Android Browser
@@ -9676,19 +8726,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BLU VIVO AIR LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BU
+    brand: Blu
     model: Vivo Air LTE
   os_family: Android
   browser_family: Chrome
@@ -9696,19 +8744,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A501 BRIGHT Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A501 Bright
   os_family: Android
   browser_family: Chrome
@@ -9716,19 +8762,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; A503 Joy Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 UCBrowser/12.10.0.1178 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1178"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A503 Joy
   os_family: Android
   browser_family: Unknown
@@ -9736,19 +8780,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; A504 Trace Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.2.1289 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.2.1289"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A504 Trace
   os_family: Android
   browser_family: Unknown
@@ -9756,19 +8798,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; A505 JOY Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.5.0.1109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.5.0.1109"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A505 Joy Plus
   os_family: Android
   browser_family: Unknown
@@ -9776,19 +8816,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A509_Jeans) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A509 Jeans
   os_family: Android
   browser_family: Chrome
@@ -9796,19 +8834,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A510_Jeans_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A510 Jeans 4G
   os_family: Android
   browser_family: Chrome
@@ -9816,19 +8852,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A512 Harmony Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/82.0.4077.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "82.0.4077.2"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A512 Harmony Pro
   os_family: Android
   browser_family: Chrome
@@ -9836,19 +8870,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; Atlas A551 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1143"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A551 Atlas
   os_family: Android
   browser_family: Unknown
@@ -9856,19 +8888,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; A552 JOY Max Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A552 Joy Max
   os_family: Android
   browser_family: Unknown
@@ -9876,19 +8906,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BRAVIS A554) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: A554 Grand
   os_family: Android
   browser_family: Chrome
@@ -9896,19 +8924,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BRAVIS BIZ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Biz
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-3.yml
+++ b/Tests/fixtures/smartphone-3.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; bravis_A506) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Crystal
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BRAVIS DELTA Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Delta
   os_family: Android
   browser_family: Android Browser
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; bravis_A553 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Discovery
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B501 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Easy
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; N1_550_Cruiser) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 OPR/55.1.2719.50626
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "55.1.2719.50626"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: N1-550 Cruiser
   os_family: Android
   browser_family: Opera
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BRAVIS OMEGA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Omega
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BRAVIS POWER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Power
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BRAVIS S500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 OPR/55.1.2719.50626
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "55.1.2719.50626"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: S500 Diamond
   os_family: Android
   browser_family: Opera
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; N1-570 Space) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Space
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; BRAVIS TAU Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.5.1146 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.5.1146"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Tau
   os_family: Android
   browser_family: Unknown
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BRAVIS X500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Trace Pro
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BRAVIS_TREND Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BV
+    brand: Bravis
     model: Trend
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: sprd-BOWAY-I5/1.0 Linux/2.6.35.7 Android/2.3.5 Release/10.13.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: I5
   os_family: Android
   browser_family: Android Browser
@@ -263,7 +237,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; i6 Build/BOWAYBOWAY_i6) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.0 (Baidu; P1 4.0.3)
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
@@ -272,7 +245,7 @@
     version: "6.0"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: i6
   os_family: Android
   browser_family: Unknown
@@ -280,19 +253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; BOWAY I7 Build/BOWAYA75P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.2.585 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.2.585"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: I7
   os_family: Android
   browser_family: Unknown
@@ -300,19 +271,17 @@
   user_agent: MQQBrowser/3.0/Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; BOWAY_U3 Build/alpsBOWAY-) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "3.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: U3
   os_family: Android
   browser_family: Unknown
@@ -320,7 +289,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; BOWAY_U7 Build/KTU84P) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.66_r1062275.542 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -329,7 +297,7 @@
     version: "6.1.0.66.r1062275.542"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: U7
   os_family: Android
   browser_family: Unknown
@@ -337,19 +305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; V100 Build/BOWAYV100) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: V100
   os_family: Android
   browser_family: Unknown
@@ -357,19 +323,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; BOWAY_V95Pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BW
+    brand: Boway
     model: V95Pro
   os_family: Android
   browser_family: Unknown
@@ -377,19 +341,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5500L Build/MDA89D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Advance
   os_family: Android
   browser_family: Chrome
@@ -397,19 +359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS_5505 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 YandexSearch/9.50 YandexSearchWebView/9.50
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Amsterdam
   os_family: Android
   browser_family: Chrome
@@ -417,19 +377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; bq Aquaris Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris
   os_family: Android
   browser_family: Android Browser
@@ -437,19 +395,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; bq Aquaris 4 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris 4
   os_family: Android
   browser_family: Android Browser
@@ -457,19 +413,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; es-es; bq Aquaris 5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris 5
   os_family: Android
   browser_family: Android Browser
@@ -477,19 +431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; bq Aquaris 5 HD Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris 5 HD
   os_family: Android
   browser_family: Chrome
@@ -497,19 +449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; bq Aquaris 5.7 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris 5.7
   os_family: Android
   browser_family: Chrome
@@ -517,19 +467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Aquaris_A4.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris A4.5
   os_family: Android
   browser_family: Chrome
@@ -537,19 +485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Aquaris C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris C
   os_family: Android
   browser_family: Chrome
@@ -557,19 +503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E4
   os_family: Android
   browser_family: Chrome
@@ -577,19 +521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E4.5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E4.5
   os_family: Android
   browser_family: Chrome
@@ -597,19 +539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E4.5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E4.5
   os_family: Android
   browser_family: Chrome
@@ -617,19 +557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Aquaris E5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E5
   os_family: Android
   browser_family: Chrome
@@ -637,19 +575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E5 FHD Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E5 FHD
   os_family: Android
   browser_family: Chrome
@@ -657,19 +593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E6
   os_family: Android
   browser_family: Chrome
@@ -677,19 +611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Aquaris E6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris E6
   os_family: Android
   browser_family: Chrome
@@ -697,19 +629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Aquaris M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris M
   os_family: Android
   browser_family: Chrome
@@ -717,19 +647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Aquaris M10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris M10
   os_family: Android
   browser_family: Chrome
@@ -737,19 +665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Aquaris M5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris M5
   os_family: Android
   browser_family: Chrome
@@ -757,19 +683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Aquaris U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris U
   os_family: Android
   browser_family: Chrome
@@ -777,19 +701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Aquaris U Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris U Lite
   os_family: Android
   browser_family: Chrome
@@ -797,19 +719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Aquaris U Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris U Plus
   os_family: Android
   browser_family: Chrome
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Aquaris U2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris U2
   os_family: Android
   browser_family: Chrome
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Aquaris U2 Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris U2 Lite
   os_family: Android
   browser_family: Chrome
@@ -857,19 +773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Aquaris V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris V
   os_family: Android
   browser_family: Chrome
@@ -877,19 +791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Aquaris V Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris V Plus
   os_family: Android
   browser_family: Chrome
@@ -897,19 +809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Aquaris X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris X
   os_family: Android
   browser_family: Chrome
@@ -917,19 +827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Aquaris X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris X
   os_family: Android
   browser_family: Chrome
@@ -937,19 +845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Aquaris X Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris X Pro
   os_family: Android
   browser_family: Chrome
@@ -957,19 +863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Aquaris X5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris X5
   os_family: Android
   browser_family: Chrome
@@ -977,19 +881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Aquaris X5 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aquaris X5 Plus
   os_family: Android
   browser_family: Chrome
@@ -997,19 +899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4010 Build/BQS4010-2015.07.10-HSS0721P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aspen
   os_family: Android
   browser_family: Chrome
@@ -1017,19 +917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-3510 Build/BQS3510-2015.07.03) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aspen Mini
   os_family: Android
   browser_family: Chrome
@@ -1037,19 +935,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-6000L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.169 YaBrowser/19.6.0.612.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.0.612.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aurora
   os_family: Android
   browser_family: Unknown
@@ -1057,19 +953,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-6200L AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Aurora
   os_family: Android
   browser_family: Chrome
@@ -1077,19 +971,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5206L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.169 YaBrowser/19.6.1.396.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.1.396.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Balance
   os_family: Android
   browser_family: Unknown
@@ -1097,19 +989,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-5071 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Belief
   os_family: Android
   browser_family: Chrome
@@ -1117,19 +1007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; BQS-4800 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Blade
   os_family: Android
   browser_family: Chrome
@@ -1137,19 +1025,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5511L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 YandexSearch/6.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Bliss
   os_family: Android
   browser_family: Chrome
@@ -1157,19 +1043,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; BQS-3503 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Bombay
   os_family: Android
   browser_family: Android Browser
@@ -1177,19 +1061,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-5022 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/65.0.3325.181 YaBrowser/18.4.0.649.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.4.0.649.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Bond
   os_family: Android
   browser_family: Unknown
@@ -1197,19 +1079,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-5022 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Bond
   os_family: Android
   browser_family: Chrome
@@ -1217,19 +1097,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5008L AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Brave
   os_family: Android
   browser_family: Chrome
@@ -1237,19 +1115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4501 Bristol Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Bristol
   os_family: Android
   browser_family: Android Browser
@@ -1257,19 +1133,17 @@
   user_agent: Dalvik/0.0.0 (Linux; U; Android 0.0.0; BQS-5065 Build/ABCDEF)
   os:
     name: Android
-    short_name: AND
     version: "0.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Choice
   os_family: Android
   browser_family: Android Browser
@@ -1277,19 +1151,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5340 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 YandexSearch/6.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Choice
   os_family: Android
   browser_family: Chrome
@@ -1297,19 +1169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-5002 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Colombo
   os_family: Android
   browser_family: Chrome
@@ -1317,19 +1187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; BQS-5003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Colombo II
   os_family: Android
   browser_family: Chrome
@@ -1337,19 +1205,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5001L AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.103 YaBrowser/19.4.3.352.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.4.3.352.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Contact
   os_family: Android
   browser_family: Unknown
@@ -1357,19 +1223,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-4001G AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Cool
   os_family: Android
   browser_family: Chrome
@@ -1377,19 +1241,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-5054 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Crystal
   os_family: Android
   browser_family: Chrome
@@ -1397,19 +1259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4570 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.2.2517.139816
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.2.2517.139816"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Drive
   os_family: Android
   browser_family: Opera
@@ -1417,19 +1277,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4503; Android/4.4.2; Release/07.22.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Dubai
   os_family: Android
   browser_family: Android Browser
@@ -1437,19 +1295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4004 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Dusseldorf
   os_family: Android
   browser_family: Unknown
@@ -1457,19 +1313,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-5032 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/62.0.3202.94 YaBrowser/17.11.1.628.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.11.1.628.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Element
   os_family: Android
   browser_family: Unknown
@@ -1477,19 +1331,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-5515 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36 OPR/51.3.2461.138727
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "51.3.2461.138727"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fast
   os_family: Android
   browser_family: Opera
@@ -1497,19 +1349,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0; en-US; BQS-5045 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.6.1200 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.6.1200"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fast
   os_family: Android
   browser_family: Unknown
@@ -1517,19 +1367,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5515L AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.103 YaBrowser/19.4.5.141.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.4.5.141.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fast
   os_family: Android
   browser_family: Unknown
@@ -1537,19 +1385,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5519L AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.103 YaBrowser/19.4.5.141.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.4.5.141.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fast Plus
   os_family: Android
   browser_family: Unknown
@@ -1557,19 +1403,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5015L Build/O21019 AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: First
   os_family: Android
   browser_family: Chrome
@@ -1577,19 +1421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4510 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Florence
   os_family: Android
   browser_family: Android Browser
@@ -1597,19 +1439,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-4526 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox
   os_family: Android
   browser_family: Chrome
@@ -1617,19 +1457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-4526) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox
   os_family: Android
   browser_family: Chrome
@@ -1637,19 +1475,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5004G AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.169 YaBrowser/19.6.1.396.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.1.396.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox
   os_family: Android
   browser_family: Unknown
@@ -1657,19 +1493,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-4501G Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/72.0.3626.105 Mobile Safari/537.36 YandexSearch/8.00 YandexSearchBrowser/8.00
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox Easy
   os_family: Android
   browser_family: Chrome
@@ -1677,19 +1511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-4500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox LTE
   os_family: Android
   browser_family: Chrome
@@ -1697,19 +1529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-4583 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox Power
   os_family: Android
   browser_family: Chrome
@@ -1717,19 +1547,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-4585 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox View
   os_family: Android
   browser_family: Chrome
@@ -1737,19 +1565,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5011G Build/O21019 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fox View
   os_family: Android
   browser_family: Chrome
@@ -1757,19 +1583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5030 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fresh
   os_family: Android
   browser_family: Chrome
@@ -1777,19 +1601,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5056 Build/NRD90M; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.81 Mobile Safari/537.36 Puffin/7.8.1.40497AP
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.1.40497"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fresh
   os_family: Android
   browser_family: Unknown
@@ -1797,19 +1619,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5002G Build/OPM2.171019.012 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Fun
   os_family: Android
   browser_family: Chrome
@@ -1817,19 +1637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4560 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 YaBrowser/15.10.2454.3908.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.10.2454.3908.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Golf
   os_family: Android
   browser_family: Unknown
@@ -1837,19 +1655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5502 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Hammer
   os_family: Android
   browser_family: Chrome
@@ -1857,19 +1673,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-US; BQS-5025 Build/MMB29M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.6.1200 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.6.1200"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: High Way
   os_family: Android
   browser_family: Unknown
@@ -1877,19 +1691,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-8068L Build/OPM2.171019.012 AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Hornet Plus Pro
   os_family: Android
   browser_family: Chrome
@@ -1897,19 +1709,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5005L Build/MDA89D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Intense
   os_family: Android
   browser_family: Chrome
@@ -1917,19 +1727,17 @@
   user_agent: mozilla/5.0 (linux; android 9; bq-5530l) applewebkit/537.36 (khtml, like gecko) chrome/74.0.3729.136 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Intense
   os_family: Android
   browser_family: Chrome
@@ -1937,19 +1745,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5007L Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Iron
   os_family: Android
   browser_family: Chrome
@@ -1957,19 +1763,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5507L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Iron Max
   os_family: Android
   browser_family: Chrome
@@ -1977,19 +1781,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5591 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 YandexSearch/6.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Jeans
   os_family: Android
   browser_family: Chrome
@@ -1997,19 +1799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-5518G Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36 YaApp_Android/9.60 YaSearchBrowser/9.60
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Jeans
   os_family: Android
   browser_family: Chrome
@@ -2017,19 +1817,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-6050 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.2.730.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.2.730.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Jumbo
   os_family: Android
   browser_family: Unknown
@@ -2037,19 +1835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-5501 Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Kawasaki
   os_family: Android
   browser_family: Chrome
@@ -2057,19 +1853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4502 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Kingston
   os_family: Android
   browser_family: Chrome
@@ -2077,19 +1871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5006 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Los Angeles
   os_family: Android
   browser_family: Chrome
@@ -2097,19 +1889,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0; BQS-5070 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/40.1.2254.138129
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "40.1.2254.138129"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Magic
   os_family: Android
   browser_family: Opera
@@ -2117,19 +1907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-6040L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Magic
   os_family: Android
   browser_family: Chrome
@@ -2137,19 +1925,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; BQ-5730L Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 OPR/47.0.2254.146543
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "47.0.2254.146543"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Magic C
   os_family: Android
   browser_family: Opera
@@ -2157,19 +1943,17 @@
   user_agent: mozilla/5.0 (linux; android 9; bq-6042l) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.101 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Magic E
   os_family: Android
   browser_family: Chrome
@@ -2177,19 +1961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-5731L Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 YaBrowser/18.10.2.113.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.10.2.113.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Magic S
   os_family: Android
   browser_family: Unknown
@@ -2197,19 +1979,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0; en-US; BQS-5520 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.5.0.1015 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.5.0.1015"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Mercury
   os_family: Android
   browser_family: Unknown
@@ -2217,19 +1997,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-6016L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.169 YaBrowser/19.6.4.48.00 alpha Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.4.48.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Mercury
   os_family: Android
   browser_family: Unknown
@@ -2237,19 +2015,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.3; ru-ru; BQS-5001 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Milan
   os_family: Android
   browser_family: Android Browser
@@ -2257,19 +2033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5011 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Monte Carlo
   os_family: Android
   browser_family: Chrome
@@ -2277,19 +2051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4707 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Montreal
   os_family: Android
   browser_family: Chrome
@@ -2297,19 +2069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; BQS-4515 Build/Android) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Moscow
   os_family: Android
   browser_family: Chrome
@@ -2317,19 +2087,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; BQ-5508L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.169 YaBrowser/19.6.1.396.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.1.396.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Next LTE
   os_family: Android
   browser_family: Unknown
@@ -2337,19 +2105,17 @@
   user_agent: ozilla/5.0 Linux; Android 8.1.0; BQ-5707G AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.103 YaBrowser/19.4.1.454.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.4.1.454.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Next Music
   os_family: Android
   browser_family: Unknown
@@ -2357,19 +2123,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-5503 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Nice 2
   os_family: Android
   browser_family: Chrome
@@ -2377,19 +2141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4009 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Orleans
   os_family: Android
   browser_family: Chrome
@@ -2397,19 +2159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4001 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Oxford
   os_family: Android
   browser_family: Chrome
@@ -2417,19 +2177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0.99; BQS-5004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0.99"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Paris
   os_family: Android
   browser_family: Chrome
@@ -2437,19 +2195,17 @@
   user_agent: mozilla/5.0 (linux; android 7.0; bqru-5525 build/nrd90m) applewebkit/537.36 (khtml, like gecko) chrome/59.0.3071.125 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Practic
   os_family: Android
   browser_family: Chrome
@@ -2457,19 +2213,17 @@
   user_agent: 'user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-6010G AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Practic
   os_family: Android
   browser_family: Chrome
@@ -2477,19 +2231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Prague
   os_family: Android
   browser_family: Chrome
@@ -2497,19 +2249,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5012L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36 YandexSearch/8.40 YandexSearchBrowser/8.40
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Rich
   os_family: Android
   browser_family: Chrome
@@ -2517,19 +2267,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.4.2;  zh-cn; BQS-4550; Android/4.4.2; Release/12.19.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Richmond
   os_family: Android
   browser_family: Android Browser
@@ -2537,19 +2285,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; ru-ru; BQS-4505 Build/MocorDroid2.3.5_Trout) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Santiago
   os_family: Android
   browser_family: Android Browser
@@ -2557,7 +2303,6 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-5052 Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 Line/7.1.3/IAB
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -2566,7 +2311,7 @@
     version: "7.1.3"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Sense
   os_family: Android
   browser_family: Unknown
@@ -2574,19 +2319,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-5082 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Sense 2
   os_family: Android
   browser_family: Chrome
@@ -2594,19 +2337,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4005 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Seoul
   os_family: Android
   browser_family: Android Browser
@@ -2614,19 +2355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4008 Build/MocorDroid) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: MocorDroid
-    short_name: MCD
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Shanghai
   os_family: Android
   browser_family: Chrome
@@ -2634,19 +2373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5033 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Shark
   os_family: Android
   browser_family: Chrome
@@ -2654,19 +2391,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-4077 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Shark Mini
   os_family: Android
   browser_family: Chrome
@@ -2674,19 +2409,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; en-US; BQ-5003L Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Shark Pro
   os_family: Android
   browser_family: Unknown
@@ -2694,19 +2427,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-5541L Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Shark Rush
   os_family: Android
   browser_family: Chrome
@@ -2714,19 +2445,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; BQ-5520L Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.3.1202 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.3.1202"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Silk
   os_family: Android
   browser_family: Unknown
@@ -2734,19 +2463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4516 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Singapore
   os_family: Android
   browser_family: Chrome
@@ -2754,19 +2481,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0; en-US; BQS-5060 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.5.1185 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.5.1185"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Slim
   os_family: Android
   browser_family: Unknown
@@ -2774,19 +2499,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5701L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Slim
   os_family: Android
   browser_family: Chrome
@@ -2794,19 +2517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5060 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Slim
   os_family: Android
   browser_family: Chrome
@@ -2814,19 +2535,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-5201 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Space
   os_family: Android
   browser_family: Chrome
@@ -2834,19 +2553,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5201 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Space
   os_family: Android
   browser_family: Chrome
@@ -2854,19 +2571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5202 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Space Lite
   os_family: Android
   browser_family: Chrome
@@ -2874,19 +2589,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; BQ-5700L Build/N2G47H; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Space X
   os_family: Android
   browser_family: Chrome
@@ -2894,19 +2607,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; BQ-5010G Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/42.0.2254.139276
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "42.0.2254.139276"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Spot
   os_family: Android
   browser_family: Opera
@@ -2914,19 +2625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru_5590 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Spring
   os_family: Android
   browser_family: Chrome
@@ -2934,19 +2643,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; en-US; BQ-5702 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.2.1164 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.2.1164"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Spring
   os_family: Android
   browser_family: Unknown
@@ -2954,19 +2661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BQS-5020 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike
   os_family: Android
   browser_family: Chrome
@@ -2974,19 +2679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQ-5211 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 YandexSearch/7.50 YandexSearchBrowser/7.50
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike
   os_family: Android
   browser_family: Chrome
@@ -2994,19 +2697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5057 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike 2
   os_family: Android
   browser_family: Chrome
@@ -3014,19 +2715,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5512L Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Forward
   os_family: Android
   browser_family: Chrome
@@ -3034,19 +2733,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; BQ-5528L Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko Chrome/62.0.3202.94 YaBrowser/17.11.1.632.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.11.1.632.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Forward
   os_family: Android
   browser_family: Unknown
@@ -3054,19 +2751,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQ-5044 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike LTE
   os_family: Android
   browser_family: Chrome
@@ -3074,19 +2769,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5209L Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.106 YaBrowser/18.9.2.31.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.9.2.31.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike LTE
   os_family: Android
   browser_family: Unknown
@@ -3094,19 +2787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-4072 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Mini
   os_family: Android
   browser_family: Chrome
@@ -3114,19 +2805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQ5059 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power
   os_family: Android
   browser_family: Chrome
@@ -3134,19 +2823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5059 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power
   os_family: Android
   browser_family: Chrome
@@ -3154,19 +2841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQ-5059 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power
   os_family: Android
   browser_family: Chrome
@@ -3174,19 +2859,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5514G Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power
   os_family: Android
   browser_family: Chrome
@@ -3194,19 +2877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BQru-5037 Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power 4G
   os_family: Android
   browser_family: Chrome
@@ -3214,19 +2895,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5514L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power 4G
   os_family: Android
   browser_family: Chrome
@@ -3234,19 +2913,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5058 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power Easy
   os_family: Android
   browser_family: Chrome
@@ -3254,19 +2931,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5594 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power Max
   os_family: Android
   browser_family: Chrome
@@ -3274,19 +2949,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; BQ-6035L Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.136 Mobile Safari/537.36 OPR/46.0.2254.145391
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "46.0.2254.145391"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power Max
   os_family: Android
   browser_family: Opera
@@ -3294,19 +2967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5510 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power Max 4G
   os_family: Android
   browser_family: Chrome
@@ -3314,19 +2985,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; BQ-5535L Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.121 Mobile Safari/537.36 OPR/47.1.2254.147528
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "47.1.2254.147528"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Power Plus
   os_family: Android
   browser_family: Opera
@@ -3334,19 +3003,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BQS-5050 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Selfie
   os_family: Android
   browser_family: Chrome
@@ -3354,19 +3021,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5204 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.0.412.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.0.412.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Selfie
   os_family: Android
   browser_family: Unknown
@@ -3374,19 +3039,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5504 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike Selfie Max
   os_family: Android
   browser_family: Chrome
@@ -3394,19 +3057,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-5301 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Strike View
   os_family: Android
   browser_family: Chrome
@@ -3414,19 +3075,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; BQS-5005 Build/BQS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Sydney
   os_family: Android
   browser_family: Unknown
@@ -3434,19 +3093,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5009 Build/BQS5009-2015.12.11-HSS0721T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Sydney
   os_family: Android
   browser_family: Chrome
@@ -3454,19 +3111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-5000 Tokyo Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Tokyo
   os_family: Android
   browser_family: Android Browser
@@ -3474,19 +3129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5000 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Tokyo
   os_family: Android
   browser_family: Chrome
@@ -3494,19 +3147,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; BQ-5009L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Trend
   os_family: Android
   browser_family: Opera
@@ -3514,19 +3165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4555 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Turbo
   os_family: Android
   browser_family: Chrome
@@ -3534,19 +3183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-5055 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Turbo Plus
   os_family: Android
   browser_family: Chrome
@@ -3554,19 +3201,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5516L Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.169 Mobile Safari/537.36 YandexSearch/8.50 YandexSearchBrowser/8.50
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.169"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Twin
   os_family: Android
   browser_family: Chrome
@@ -3574,19 +3219,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-5517L Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Twin Pro
   os_family: Android
   browser_family: Chrome
@@ -3594,19 +3237,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.0.0; BQru-6015L Build/OPR1.170623.032
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Universe
   os_family: Android
   browser_family: Android Browser
@@ -3614,19 +3255,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; BQ-6015L Build/OPR1.170623.032; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Universe
   os_family: Android
   browser_family: Chrome
@@ -3634,19 +3273,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; BQ-4026 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 YandexSearch/7.15
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Up!
   os_family: Android
   browser_family: Chrome
@@ -3654,19 +3291,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-4028 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Up!
   os_family: Android
   browser_family: Chrome
@@ -3674,19 +3309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4007 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Valencia
   os_family: Android
   browser_family: Chrome
@@ -3694,19 +3327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.3; BQS-5500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.3"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Vancouver
   os_family: Android
   browser_family: Unknown
@@ -3714,19 +3345,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; BQ-5302G Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.3.1204 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.3.1204"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Velvet 2
   os_family: Android
   browser_family: Unknown
@@ -3734,19 +3363,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; BQ-5300G Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.67 UCBrowser/12.10.6.1200 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.6.1200"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Velvet View
   os_family: Android
   browser_family: Unknown
@@ -3754,19 +3381,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4701 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Venice
   os_family: Android
   browser_family: Android Browser
@@ -3774,19 +3399,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; BQS-4003 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Verona
   os_family: Android
   browser_family: Android Browser
@@ -3794,19 +3417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BQS-4525 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Vienna
   os_family: Android
   browser_family: Unknown
@@ -3814,19 +3435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-5203 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Vision
   os_family: Android
   browser_family: Chrome
@@ -3834,19 +3453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BQS-5515 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Wide
   os_family: Android
   browser_family: Chrome
@@ -3854,19 +3471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQS-4702 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BX
+    brand: bq
     model: Оsaka
   os_family: Android
   browser_family: Chrome
@@ -3874,19 +3489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BEZKAM BK-RAM2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: BZ
+    brand: Bezkam
     model: BK-RAM2
   os_family: Android
   browser_family: Chrome
@@ -3894,19 +3507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hind 5.1 Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: Hind 5.1
   os_family: Android
   browser_family: Chrome
@@ -3914,19 +3525,17 @@
   user_agent: Mozilla/5.0 (Linux;U;Android 7.0;en-US;X417_Amaze Build/NRD90M) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/11.0.0.1016 Mobile
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.0.1016"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X417 Amaze
   os_family: Android
   browser_family: Unknown
@@ -3934,7 +3543,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; X418 Zest Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/176.0.0.42.87;]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -3943,7 +3551,7 @@
     version: "176.0.0.42.87"
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X418 Zest
   os_family: Android
   browser_family: Unknown
@@ -3951,19 +3559,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; X421 Nova Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36 OPR/33.0.2254.125672
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "33.0.2254.125672"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X421 Nova
   os_family: Android
   browser_family: Opera
@@ -3971,19 +3577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X422 Exotic Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X422 Exotic
   os_family: Android
   browser_family: Chrome
@@ -3991,19 +3595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X425 Shavit Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X425 Shavit
   os_family: Android
   browser_family: Chrome
@@ -4011,19 +3613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X428 Astute Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C0
+    brand: Clout
     model: X428 Astute
   os_family: Android
   browser_family: Chrome
@@ -4031,19 +3631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Action-X3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Action-X3
   os_family: Android
   browser_family: Chrome
@@ -4051,19 +3649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Core-X3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Core-X3
   os_family: Android
   browser_family: Chrome
@@ -4071,19 +3667,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Crosscall ELEMENT Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: ELEMENT
   os_family: Android
   browser_family: Android Browser
@@ -4091,19 +3685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Odyssey S1 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: ODYSSEY S1
   os_family: Android
   browser_family: Chrome
@@ -4111,19 +3703,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; fr-fr; ODYSSEY_Plus Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: ODYSSEY+
   os_family: Android
   browser_family: Android Browser
@@ -4131,19 +3721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Trekker-M1 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Trekker-M1
   os_family: Android
   browser_family: Chrome
@@ -4151,19 +3739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TREKKER-M1 CORE Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Trekker-M1 CORE
   os_family: Android
   browser_family: Chrome
@@ -4171,19 +3757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Trekker-S1 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Trekker-S1
   os_family: Android
   browser_family: Chrome
@@ -4191,19 +3775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Trekker-X1 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Trekker-X1
   os_family: Android
   browser_family: Chrome
@@ -4211,19 +3793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Trekker-X4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: Trekker-X4
   os_family: Android
   browser_family: Chrome
@@ -4231,19 +3811,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; CROSSCALL WILD Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C1
+    brand: Crosscall
     model: WILD
   os_family: Android
   browser_family: Android Browser
@@ -4251,19 +3829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 1501_M02 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 wkbrowser 4.1.55 3085
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: 1501 M02
   os_family: Android
   browser_family: Chrome
@@ -4271,19 +3847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; 9930i Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: 9930i
   os_family: Android
   browser_family: Chrome
@@ -4291,19 +3865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A1303 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 WapAppInfo:AndroidNew
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: A1303
   os_family: Android
   browser_family: Chrome
@@ -4311,19 +3883,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-CN; M651CY Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.1.5.871 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.1.5.871"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: A3
   os_family: Android
   browser_family: Unknown
@@ -4331,19 +3901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A309W Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: A309W
   os_family: Android
   browser_family: Chrome
@@ -4351,19 +3919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M812C Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C3
+    brand: China Mobile
     model: M812C
   os_family: Android
   browser_family: Chrome
@@ -4371,19 +3937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Cyrus_CS25 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C4
+    brand: Cyrus
     model: CS25
   os_family: Android
   browser_family: Chrome
@@ -4391,19 +3955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Cyrus_CS30 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C4
+    brand: Cyrus
     model: CS30
   os_family: Android
   browser_family: Chrome
@@ -4411,19 +3973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN607 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A100
   os_family: Android
   browser_family: Chrome
@@ -4431,19 +3991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN609 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A100 Lite
   os_family: Android
   browser_family: Chrome
@@ -4451,19 +4009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN606 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A55
   os_family: Android
   browser_family: Chrome
@@ -4471,19 +4027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN613 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 ACHEETAHI/1
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A55 Plus
   os_family: Android
   browser_family: Chrome
@@ -4491,19 +4045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN608 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A55 Slim
   os_family: Android
   browser_family: Chrome
@@ -4511,19 +4063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN611 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A8
   os_family: Android
   browser_family: Chrome
@@ -4531,19 +4081,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 6.0; en-US; PGN612) U2/1.0.0 UCBrowser/10.9.8.1006 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.8.1006"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A8 Plus
   os_family: Android
   browser_family: Unknown
@@ -4551,19 +4099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-507 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A9
   os_family: Android
   browser_family: Chrome
@@ -4571,19 +4117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; PGN511 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure A9 Plus
   os_family: Android
   browser_family: Chrome
@@ -4591,19 +4135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Allure M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure M1
   os_family: Android
   browser_family: Chrome
@@ -4611,19 +4153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Allure M3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Allure M3
   os_family: Android
   browser_family: Chrome
@@ -4631,19 +4171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PKT-301 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -4651,19 +4189,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; PGN-403 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C4+ Noir
   os_family: Android
   browser_family: Android Browser
@@ -4671,19 +4207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-504 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C5
   os_family: Android
   browser_family: Chrome
@@ -4691,19 +4225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; PGN-509 Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C6 Pro
   os_family: Android
   browser_family: Chrome
@@ -4711,19 +4243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-508 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C6+
   os_family: Android
   browser_family: Chrome
@@ -4731,19 +4261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-506 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.50 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.50"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C7
   os_family: Android
   browser_family: Chrome
@@ -4751,19 +4279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-404 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C7 Mini
   os_family: Android
   browser_family: Chrome
@@ -4771,19 +4297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; PHS-601 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C8
   os_family: Android
   browser_family: Chrome
@@ -4791,19 +4315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PGN-505 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: C8S
   os_family: Android
   browser_family: Chrome
@@ -4811,19 +4333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN513 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G4
   os_family: Android
   browser_family: Chrome
@@ -4831,19 +4351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN521 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G4 Plus
   os_family: Android
   browser_family: Chrome
@@ -4851,19 +4369,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; PHQ519 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G4S
   os_family: Android
   browser_family: Android Browser
@@ -4871,19 +4387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PHQ520 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G5
   os_family: Android
   browser_family: Chrome
@@ -4891,19 +4405,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; PHQ525 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G6
   os_family: Android
   browser_family: Android Browser
@@ -4911,19 +4423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHQ526 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe G6 Pro
   os_family: Android
   browser_family: Chrome
@@ -4931,19 +4441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Griffe T2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T2
   os_family: Android
   browser_family: Chrome
@@ -4951,19 +4459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Griffe T5 Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T5
   os_family: Android
   browser_family: Chrome
@@ -4971,19 +4477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Griffe T6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T6
   os_family: Android
   browser_family: Chrome
@@ -4991,19 +4495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Griffe T7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T7
   os_family: Android
   browser_family: Chrome
@@ -5011,19 +4513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Griffe T8 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T8 Plus
   os_family: Android
   browser_family: Chrome
@@ -5031,19 +4531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Griffe T9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Griffe T9
   os_family: Android
   browser_family: Chrome
@@ -5051,19 +4549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN522 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: P6 Plus
   os_family: Android
   browser_family: Chrome
@@ -5071,19 +4567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN523 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: P7 Plus
   os_family: Android
   browser_family: Chrome
@@ -5091,19 +4585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Plume H1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume H1
   os_family: Android
   browser_family: Chrome
@@ -5111,19 +4603,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; Plume L1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 OPR/35.0.2254.127755
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "35.0.2254.127755"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume L1
   os_family: Android
   browser_family: Opera
@@ -5131,19 +4621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Plume L2 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume L2 Pro
   os_family: Android
   browser_family: Chrome
@@ -5151,19 +4639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Plume L3 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume L3 Plus
   os_family: Android
   browser_family: Chrome
@@ -5171,19 +4657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN409 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P4
   os_family: Android
   browser_family: Chrome
@@ -5191,19 +4675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGN527 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P4 Plus
   os_family: Android
   browser_family: Chrome
@@ -5211,19 +4693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN515 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P4 Pro
   os_family: Android
   browser_family: Chrome
@@ -5231,19 +4711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; PGN516 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P5
   os_family: Android
   browser_family: Chrome
@@ -5251,19 +4729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN518 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P6
   os_family: Android
   browser_family: Chrome
@@ -5271,19 +4747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN517 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P6
   os_family: Android
   browser_family: Chrome
@@ -5291,19 +4765,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; ar-SA; PGN528 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.2.960 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.2.960"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P6 Pro Lte
   os_family: Android
   browser_family: Unknown
@@ -5311,19 +4783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; PGN514 Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P7
   os_family: Android
   browser_family: Chrome
@@ -5331,19 +4801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PGN605 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P8
   os_family: Android
   browser_family: Chrome
@@ -5351,19 +4819,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; ar-SA; PGN610 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.0.950 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.0.950"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P8 Lite
   os_family: Android
   browser_family: Unknown
@@ -5371,19 +4837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Plume P8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C5
+    brand: Condor
     model: Plume P8 Pro
   os_family: Android
   browser_family: Chrome
@@ -5391,19 +4855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; COMIO P1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C6
+    brand: Comio
     model: P1
   os_family: Android
   browser_family: Chrome
@@ -5411,19 +4873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; COMIO S1 Lite Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C6
+    brand: Comio
     model: S1 Lite
   os_family: Android
   browser_family: Chrome
@@ -5431,19 +4891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TeslaEvo5.0 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Evo 5.0
   os_family: Android
   browser_family: Chrome
@@ -5451,19 +4909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Tesla SMARTPHONE 3 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 3
   os_family: Android
   browser_family: Chrome
@@ -5471,19 +4927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Tesla_SP3.1_Lite Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 3.1 Lite
   os_family: Android
   browser_family: Chrome
@@ -5491,19 +4945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Tesla SP3.2 Lite Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 3.2 Lite
   os_family: Android
   browser_family: Chrome
@@ -5511,19 +4963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla_SP3.3 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 3.3
   os_family: Android
   browser_family: Chrome
@@ -5531,19 +4981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla_SP3.3 Lite Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 3.3 Lite
   os_family: Android
   browser_family: Chrome
@@ -5551,19 +4999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tesla Smartphone 6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 6
   os_family: Android
   browser_family: Chrome
@@ -5571,19 +5017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Smartphone_6.1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 6.1
   os_family: Android
   browser_family: Chrome
@@ -5591,19 +5035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP6.2 Build/GQ3030AH2_Smartphone6.2_20170307) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 6.2
   os_family: Android
   browser_family: Chrome
@@ -5611,19 +5053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP6.2_Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 6.2 Lite
   os_family: Android
   browser_family: Chrome
@@ -5631,19 +5071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla_SP6.3 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 6.3
   os_family: Android
   browser_family: Chrome
@@ -5651,19 +5089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tesla_SP9 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 9
   os_family: Android
   browser_family: Chrome
@@ -5671,19 +5107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla_SP9.1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 9.1
   os_family: Android
   browser_family: Chrome
@@ -5691,19 +5125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla_SP9.1L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C7
+    brand: ComTrade Tesla
     model: Smartphone 9.1 Lite
   os_family: Android
   browser_family: Chrome
@@ -5711,19 +5143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Flyfix 6 C-713 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C8
+    brand: Concord
     model: Flyfix 6
   os_family: Android
   browser_family: Chrome
@@ -5731,19 +5161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Concord M10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C8
+    brand: Concord
     model: M10
   os_family: Android
   browser_family: Chrome
@@ -5751,19 +5179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CAGI-OMEGA Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: C9
+    brand: CAGI
     model: Omega
   os_family: Android
   browser_family: Chrome
@@ -5771,19 +5197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; B15Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CA
+    brand: Cat
     model: B15Q
   os_family: Android
   browser_family: Chrome
@@ -5791,19 +5215,17 @@
   user_agent: Mozilla/5.0 (Mobile; CAT B35; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.5.1
   os:
     name: KaiOS
-    short_name: KOS
     version: "2.5.1"
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "48.0"
     engine: Gecko
     engine_version: "48.0"
   device:
     type: smartphone
-    brand: CA
+    brand: Cat
     model: B35
   os_family: Firefox OS
   browser_family: Firefox
@@ -5811,19 +5233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CUBOT A5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -5831,19 +5251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; CUBOT C11 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: C11
   os_family: Android
   browser_family: Android Browser
@@ -5851,19 +5269,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; CUBOT_C6W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: C6W
   os_family: Android
   browser_family: Chrome
@@ -5871,19 +5287,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; CUBOT C9+ Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: C9+
   os_family: Android
   browser_family: Android Browser
@@ -5891,19 +5305,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT CHEETAH 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Cheetah 2
   os_family: Android
   browser_family: Chrome
@@ -5911,19 +5323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CUBOT DINOSAUR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Dinosaur
   os_family: Android
   browser_family: Chrome
@@ -5931,19 +5341,17 @@
   user_agent: mozilla/5.0 (linux; android 6.0; cubot echo) applewebkit/537.36 (khtml, like gecko) chrome/70.0.3538.80 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Echo
   os_family: Android
   browser_family: Chrome
@@ -5951,19 +5359,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; CUBOT GT72E Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: GT72E
   os_family: Android
   browser_family: Android Browser
@@ -5971,19 +5377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; CUBOT GT72E Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: GT72E
   os_family: Android
   browser_family: Android Browser
@@ -5991,19 +5395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; CUBOT GT99 Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: GT99
   os_family: Android
   browser_family: Chrome
@@ -6011,19 +5413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT H3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: H3
   os_family: Android
   browser_family: Chrome
@@ -6031,19 +5431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CUBOT_J3 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: J3
   os_family: Android
   browser_family: Chrome
@@ -6051,19 +5449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT KING KONG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: King Kong
   os_family: Android
   browser_family: Chrome
@@ -6071,19 +5467,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; KING_KONG_3 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36 OPR/28.0.2254.119224
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "28.0.2254.119224"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: King Kong 3
   os_family: Android
   browser_family: Opera
@@ -6091,19 +5485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KINGKONG_MINI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: King Kong Mini
   os_family: Android
   browser_family: Chrome
@@ -6111,19 +5503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT MAGIC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Magic
   os_family: Android
   browser_family: Chrome
@@ -6131,19 +5521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CUBOT_MANITO Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Manito
   os_family: Android
   browser_family: Chrome
@@ -6151,19 +5539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CUBOT MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Max
   os_family: Android
   browser_family: Chrome
@@ -6171,19 +5557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT NOTE Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Note Plus
   os_family: Android
   browser_family: Chrome
@@ -6191,19 +5575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CUBOT_NOTE_S Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Note S
   os_family: Android
   browser_family: Chrome
@@ -6211,19 +5593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; CUBOT NOTE_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Note S
   os_family: Android
   browser_family: Chrome
@@ -6231,19 +5611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CUBOT_NOVA Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6251,19 +5629,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; CUBOT ONE Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100501044
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: ONE
   os_family: Android
   browser_family: Chrome
@@ -6271,19 +5647,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; CUBOT ONE-S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: ONE-S
   os_family: Android
   browser_family: Android Browser
@@ -6291,19 +5665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; CUBOT_P20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: P20
   os_family: Android
   browser_family: Chrome
@@ -6311,19 +5683,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; CUBOT_P7 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: P7
   os_family: Android
   browser_family: Chrome
@@ -6331,19 +5701,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; CUBOT P9 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: P9
   os_family: Android
   browser_family: Android Browser
@@ -6351,19 +5719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CUBOT_POWER Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Power
   os_family: Android
   browser_family: Chrome
@@ -6371,19 +5737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; QUEST LITE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Quest Lite
   os_family: Android
   browser_family: Chrome
@@ -6391,19 +5755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CUBOT R11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: R11
   os_family: Android
   browser_family: Chrome
@@ -6411,19 +5773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT R9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: R9
   os_family: Android
   browser_family: Chrome
@@ -6431,19 +5791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CUBOT RAINBOW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Rainbow
   os_family: Android
   browser_family: Chrome
@@ -6451,19 +5809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RAINBOW 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: Rainbow 2
   os_family: Android
   browser_family: Chrome
@@ -6471,19 +5827,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; S222 Build/CUBOT) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: S222
   os_family: Android
   browser_family: Android Browser
@@ -6491,19 +5845,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; S308 Build/CUBOT) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: S308
   os_family: Android
   browser_family: Android Browser
@@ -6511,19 +5863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUBOT X18) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: X18
   os_family: Android
   browser_family: Chrome
@@ -6531,19 +5881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; CUBOT_X18_Plus Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: X18 Plus
   os_family: Android
   browser_family: Chrome
@@ -6551,19 +5899,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; CUBOT X6 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: X6
   os_family: Android
   browser_family: Android Browser
@@ -6571,19 +5917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CUBOT X6 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: X6
   os_family: Android
   browser_family: Chrome
@@ -6591,19 +5935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Cubot X9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.42 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.42"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CB
+    brand: CUBOT
     model: X9
   os_family: Android
   browser_family: Chrome
@@ -6611,19 +5953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; hu-hu; ConCorde SmartPhone 4300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CC
+    brand: ConCorde
     model: SmartPhone 4300
   os_family: Android
   browser_family: Android Browser
@@ -6631,19 +5971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Thrill Access) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CD
+    brand: Cloudfone
     model: Thrill Access
   os_family: Android
   browser_family: Chrome
@@ -6651,19 +5989,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Thrill Boost) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CD
+    brand: Cloudfone
     model: Thrill Boost
   os_family: Android
   browser_family: Chrome
@@ -6671,19 +6007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Thrill Boost 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CD
+    brand: Cloudfone
     model: Thrill Boost 2
   os_family: Android
   browser_family: Chrome
@@ -6691,19 +6025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Thrill Boost 3 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CD
+    brand: Cloudfone
     model: Thrill Boost 3
   os_family: Android
   browser_family: Chrome
@@ -6711,19 +6043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Thrill Snap) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CD
+    brand: Cloudfone
     model: Thrill Snap
   os_family: Android
   browser_family: Chrome
@@ -6731,19 +6061,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; Celkon_A_63) U2/1.0.0 UCBrowser/9.1.1.420 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A 63
   os_family: GNU/Linux
   browser_family: Opera
@@ -6751,19 +6079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A.R 40 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A.R 40
   os_family: Android
   browser_family: Android Browser
@@ -6771,19 +6097,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Celkon_A10) U2/1.0.0 UCBrowser/9.1.1.420 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.1.420"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A10
   os_family: Android
   browser_family: Unknown
@@ -6791,19 +6115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Celkon A119Q Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A119Q
   os_family: Android
   browser_family: Android Browser
@@ -6811,19 +6133,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A125 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A125
   os_family: Android
   browser_family: Android Browser
@@ -6831,19 +6151,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Celkon A15 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A15
   os_family: Android
   browser_family: Android Browser
@@ -6851,19 +6169,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2; Celkon A66) Linux/3.0.8 Release/09.23.2013  AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A66
   os_family: Android
   browser_family: Android Browser
@@ -6871,19 +6187,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.6; en-US; Celkon*A86 Build/Celkon_A86) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/8.7.0.315 Mobile'
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A86
   os_family: Android
   browser_family: Unknown
@@ -6891,19 +6205,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; CELKON A9 Dual Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A9 Dual
   os_family: Android
   browser_family: Unknown
@@ -6911,19 +6223,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; CELKON A9+ Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: A9+
   os_family: Android
   browser_family: Android Browser
@@ -6933,13 +6243,12 @@
   client:
     type: browser
     name: SEMC-Browser
-    short_name: SC
     version: "4.0.3"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: CE
+    brand: Celkon
     model: C64
   os_family: Unknown
   browser_family: Unknown
@@ -6947,19 +6256,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Cherry Mobile Amber W380 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Amber W380
   os_family: Android
   browser_family: Android Browser
@@ -6967,19 +6274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FLARE 4 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare 4
   os_family: Android
   browser_family: Chrome
@@ -6987,19 +6292,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FlareA1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare A1
   os_family: Android
   browser_family: Chrome
@@ -7007,19 +6310,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Flare_A2_Lite Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare A2 Lite
   os_family: Android
   browser_family: Chrome
@@ -7027,19 +6328,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare A3 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare A3
   os_family: Android
   browser_family: Chrome
@@ -7047,19 +6346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare_HD_MAX Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare HD Max
   os_family: Android
   browser_family: Chrome
@@ -7067,19 +6364,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare_J1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J1
   os_family: Android
   browser_family: Chrome
@@ -7087,19 +6382,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare_J1_mini Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J1 Mini
   os_family: Android
   browser_family: Chrome
@@ -7107,19 +6400,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare J2 Mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J2 Mini
   os_family: Android
   browser_family: Chrome
@@ -7127,19 +6418,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare J2S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J2s
   os_family: Android
   browser_family: Chrome
@@ -7147,19 +6436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FlareJ3 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J3
   os_family: Android
   browser_family: Chrome
@@ -7167,19 +6454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare_J3_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J3 Lite
   os_family: Android
   browser_family: Chrome
@@ -7187,19 +6472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare J5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare J5
   os_family: Android
   browser_family: Chrome
@@ -7207,19 +6490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FLARE LITE Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare Lite
   os_family: Android
   browser_family: Chrome
@@ -7227,19 +6508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare P1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare P1
   os_family: Android
   browser_family: Chrome
@@ -7247,19 +6526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare_P1_Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare P1 Lite
   os_family: Android
   browser_family: Chrome
@@ -7267,19 +6544,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Flare_P3 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare P3
   os_family: Android
   browser_family: Chrome
@@ -7287,19 +6562,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare S Play Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S Play
   os_family: Android
   browser_family: Chrome
@@ -7307,19 +6580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare_S4 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S4
   os_family: Android
   browser_family: Chrome
@@ -7327,19 +6598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare S4 lite Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S4 Lite
   os_family: Android
   browser_family: Chrome
@@ -7347,19 +6616,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare S4 Max Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S4 Max
   os_family: Android
   browser_family: Chrome
@@ -7367,19 +6634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare S4 Max LTE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S4 Max LTE
   os_family: Android
   browser_family: Chrome
@@ -7387,19 +6652,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FlareS5LiteDTV Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S5 Lite DTV
   os_family: Android
   browser_family: Chrome
@@ -7407,19 +6670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Flare_S5_mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S5 Mini
   os_family: Android
   browser_family: Chrome
@@ -7427,19 +6688,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare S6 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S6
   os_family: Android
   browser_family: Chrome
@@ -7447,19 +6706,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare_S6_Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S6 Lite
   os_family: Android
   browser_family: Chrome
@@ -7467,19 +6724,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Flare_S6_Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S6 Plus
   os_family: Android
   browser_family: Chrome
@@ -7487,19 +6742,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FLARE S6 POWER Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S6 Power
   os_family: Android
   browser_family: Chrome
@@ -7507,19 +6760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Flare S8 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare S8
   os_family: Android
   browser_family: Chrome
@@ -7527,19 +6778,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Flare_X_V2 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare X V2
   os_family: Android
   browser_family: Android Browser
@@ -7547,19 +6796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Flare X2 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare X2
   os_family: Android
   browser_family: Chrome
@@ -7567,19 +6814,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Flare XL Plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare XL Plus
   os_family: Android
   browser_family: Chrome
@@ -7587,19 +6832,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Flare2X Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Flare2X
   os_family: Android
   browser_family: Chrome
@@ -7607,19 +6850,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; th-th; Cherry Life Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Life
   os_family: Android
   browser_family: Android Browser
@@ -7627,19 +6868,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; OMEGA HD 4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Omega HD 4
   os_family: Android
   browser_family: Chrome
@@ -7647,7 +6886,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Cherry Razor Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.1.24.941712.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -7656,7 +6894,7 @@
     version: "3.1.24.941712"
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Razor
   os_family: Android
   browser_family: Unknown
@@ -7664,19 +6902,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; CHERRY SNAP Build/MocorDroid2.3.5_Trout) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: SNAP
   os_family: Android
   browser_family: Android Browser
@@ -7684,19 +6920,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; Cherry Sonic  Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CH
+    brand: Cherry Mobile
     model: Sonic
   os_family: Android
   browser_family: Android Browser
@@ -7704,19 +6938,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; YL-Coolpad_5210S Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 5210S
   os_family: Android
   browser_family: Android Browser
@@ -7724,19 +6956,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; 5860S Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 5860S
   os_family: Android
   browser_family: Android Browser
@@ -7744,19 +6974,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Coolpad 5890 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/4.1 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "4.1"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "5890"
   os_family: Android
   browser_family: Unknown
@@ -7764,19 +6992,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Coolpad 5950 Build/JZO54K) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/4.5.20.0 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.5.20.0"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "5950"
   os_family: Android
   browser_family: Baidu
@@ -7784,19 +7010,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; YL-Coolpad_7230-B Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 7230-B
   os_family: Android
   browser_family: Android Browser
@@ -7804,19 +7028,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; YL-Coolpad_7260/2.3.002.111110.7260; 480*800; CTC/2.0) CoolpadWebkit/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "7260"
   os_family: Android
   browser_family: Android Browser
@@ -7824,19 +7046,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Coolpad 7295+ Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 7295+
   os_family: Android
   browser_family: Unknown
@@ -7844,7 +7064,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Coolpad 7295A Build/4.1.003.130605.7295A; 480*854; CUCC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.1.2)'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -7853,7 +7072,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 7295A
   os_family: Android
   browser_family: Unknown
@@ -7861,19 +7080,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Coolpad 7296 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "7296"
   os_family: Android
   browser_family: Unknown
@@ -7881,19 +7098,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; Coolpad-8076_TD/1.0 Android/2.3.5 Release/03.11.2012 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "8076"
   os_family: Android
   browser_family: Android Browser
@@ -7901,19 +7116,17 @@
   user_agent: CoolPad8190_CMCC_TD/1.0 Linux/3.0.8 Android/4.0 Release/10.15.2012 Browser/AppleWebkit534.3
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.3"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "8190"
   os_family: Android
   browser_family: Android Browser
@@ -7921,7 +7134,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; 8190Q Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -7930,7 +7142,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8190Q
   os_family: Android
   browser_family: Unknown
@@ -7938,19 +7150,17 @@
   user_agent: Coolpad8198T_CMCC_TD/1.0 Linux/3.4.5 Android/4.2.1 Release/06.30.2013 Browser/1.0 Profile/MIDP-1.0 Configuration/CLDC-1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8198T
   os_family: Android
   browser_family: Android Browser
@@ -7958,19 +7168,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; 8295 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: "8295"
   os_family: Android
   browser_family: Unknown
@@ -7978,19 +7186,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; Coolpad8295M Build/JOP40D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.3.413 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.3.413"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8295M
   os_family: Android
   browser_family: Unknown
@@ -7998,19 +7204,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 8676-A01 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.97"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8676-A01
   os_family: Android
   browser_family: Chrome
@@ -8018,19 +7222,17 @@
   user_agent: Coolpad8720Q_CMCC_TD/1.0 Linux/3.4.5 Android/4.2 Release/3.29.2013 Browser/AppleWebkit533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8720Q
   os_family: Android
   browser_family: Android Browser
@@ -8038,19 +7240,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; Coolpad8720Q Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: 8720Q
   os_family: Android
   browser_family: Unknown
@@ -8058,19 +7258,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; C106-7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool 1
   os_family: Android
   browser_family: Chrome
@@ -8078,19 +7276,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; ORL-C0 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1072 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1072"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool 9
   os_family: Android
   browser_family: Unknown
@@ -8098,19 +7294,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; Cool_9S Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool 9S
   os_family: Android
   browser_family: Chrome
@@ -8118,19 +7312,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; VCR-I0 Build/VCRSIN00X1000DPX1709300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool Play 6
   os_family: Android
   browser_family: Chrome
@@ -8138,19 +7330,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; ru-ru; VCR-A0 Build/VCRSCN00X1000MPX1705029) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36 Hawk/QuickBrowser/2.4.28.115670
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool Play 6
   os_family: Android
   browser_family: Chrome
@@ -8158,19 +7348,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 1831-A0 Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Cool Play C7
   os_family: Android
   browser_family: Chrome
@@ -8178,19 +7366,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us;Coolpad Flo Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Flo
   os_family: Android
   browser_family: Android Browser
@@ -8198,19 +7384,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; cp3705A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Legacy
   os_family: Android
   browser_family: Chrome
@@ -8218,19 +7402,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; cp3705AS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Legacy
   os_family: Android
   browser_family: Chrome
@@ -8238,19 +7420,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; cp3648A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Legacy S
   os_family: Android
   browser_family: Chrome
@@ -8258,19 +7438,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MTS-T0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: N2M
   os_family: Android
   browser_family: Chrome
@@ -8278,19 +7456,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CP8676_I02 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Note 3
   os_family: Android
   browser_family: Chrome
@@ -8298,19 +7474,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CP8298_I00 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Note 3 Lite
   os_family: Android
   browser_family: Chrome
@@ -8318,19 +7492,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CP8676_I03 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CO
+    brand: Coolpad
     model: Note 3 Plus
   os_family: Android
   browser_family: Chrome
@@ -8338,19 +7510,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; C771 Build/C771M120) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 (Mobile; afma-sdk-a-v4.1.0)
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: CS
+    brand: Casio
     model: "G'zOne Commando"
   os_family: Android
   browser_family: Android Browser
@@ -8358,19 +7528,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; C811 4G Build/C811M050) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CS
+    brand: Casio
     model: "G'zOne Commando 4G LTE"
   os_family: Android
   browser_family: Chrome
@@ -8378,19 +7546,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Venus 1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CX
+    brand: Crescent
     model: Venus 1
   os_family: Android
   browser_family: Chrome
@@ -8398,19 +7564,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0;U;Adr 4.4.2;en-US;Venus_4) U2/1.0.0 UCBrowser/10.7.8.806 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.8.806"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: CX
+    brand: Crescent
     model: Venus 4
   os_family: Android
   browser_family: Unknown
@@ -8418,19 +7582,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; WING 5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CX
+    brand: Crescent
     model: Wing 5
   os_family: Android
   browser_family: Chrome
@@ -8438,19 +7600,17 @@
   user_agent: Mozilla/5.0 (Linux;Android 4.4.2;WING9 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: CX
+    brand: Crescent
     model: Wing 9
   os_family: Android
   browser_family: Chrome
@@ -8458,19 +7618,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Doopro P3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D0
+    brand: Doopro
     model: P3
   os_family: Android
   browser_family: Chrome
@@ -8478,19 +7636,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Datsun_D5001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D1
+    brand: Datsun
     model: D5001
   os_family: Android
   browser_family: Chrome
@@ -8498,19 +7654,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DATSUN_D5500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D1
+    brand: Datsun
     model: D5500
   os_family: Android
   browser_family: Chrome
@@ -8518,19 +7672,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CITI ATL 4G CS5029ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: CITI ATL 4G
   os_family: Android
   browser_family: Chrome
@@ -8538,7 +7690,6 @@
   user_agent: AndroidDownloadManager/5.1 (Linux; U; Android 5.1; CITI Z530 3G Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -8547,7 +7698,7 @@
     version: "5.1"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: CITI Z530 3G
   os_family: Android
   browser_family: Unknown
@@ -8555,19 +7706,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; HIT Q401 3G HT4039PG Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1153 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1153"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: HIT Q401 3G
   os_family: Android
   browser_family: Unknown
@@ -8575,19 +7724,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; HIT Q500 3G HT5035PG Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: HIT Q500 3G
   os_family: Android
   browser_family: Unknown
@@ -8595,19 +7742,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-US; iDx5 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.3
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: iDx5
   os_family: Android
   browser_family: Unknown
@@ -8615,19 +7760,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; iDxD5 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: iDxD5
   os_family: Android
   browser_family: Android Browser
@@ -8635,19 +7778,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; iDxQ5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: iDxQ5
   os_family: Android
   browser_family: Android Browser
@@ -8655,19 +7796,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Digma Linx 4.5 PT452E Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx 4.5
   os_family: Android
   browser_family: Chrome
@@ -8675,19 +7814,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; LINX 6.0 PS604M Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx 6.0
   os_family: Android
   browser_family: Android Browser
@@ -8695,19 +7832,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Linx A400 3G LT4001PG Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx A400 3G
   os_family: Android
   browser_family: Chrome
@@ -8715,19 +7850,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; LINX A420 3G LS4019PG Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.13.4.1214 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.4.1214"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx A420 3G
   os_family: Android
   browser_family: Unknown
@@ -8735,19 +7868,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; LINX A450 3G LT4028PG Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.12.8.1206 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.8.1206"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx A450 3G
   os_family: Android
   browser_family: Unknown
@@ -8755,19 +7886,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LINX A452 3G LT4030PG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx A452 3G
   os_family: Android
   browser_family: Chrome
@@ -8775,19 +7904,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LINX A453 3G LT4038PG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx A453 3G
   os_family: Android
   browser_family: Chrome
@@ -8795,19 +7922,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LINX ALFA 3G LT4047MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Alfa 3G
   os_family: Android
   browser_family: Chrome
@@ -8815,19 +7940,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Linx Argo 3G LT4054MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Argo 3G
   os_family: Android
   browser_family: Chrome
@@ -8835,19 +7958,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LINX ATOM 3G LT4049PG Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Atom 3G
   os_family: Android
   browser_family: Chrome
@@ -8855,19 +7976,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LINX B510 3G LT5037MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx B510 3G
   os_family: Android
   browser_family: Chrome
@@ -8875,19 +7994,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Linx Base 4G LT5052ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Base 4G
   os_family: Android
   browser_family: Chrome
@@ -8895,19 +8012,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Linx C500 3G LT5001PG Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx C500 3G
   os_family: Android
   browser_family: Chrome
@@ -8915,19 +8030,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LINX JOY 3G LT5048MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Joy 3G
   os_family: Android
   browser_family: Chrome
@@ -8935,19 +8048,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Linx Pay 4G LS5053ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Pay 4G
   os_family: Android
   browser_family: Chrome
@@ -8955,19 +8066,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Linx PS474S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx PS474S
   os_family: Android
   browser_family: Android Browser
@@ -8975,19 +8084,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LINX RAGE 4G LS5040PL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Rage 4G
   os_family: Android
   browser_family: Chrome
@@ -8995,19 +8102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LINX TRIX 4G LS5041PL Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx Trix 4G
   os_family: Android
   browser_family: Chrome
@@ -9015,19 +8120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Linx X1 3G LS4050MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx X1 3G
   os_family: Android
   browser_family: Chrome
@@ -9035,19 +8138,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Linx X1 PRO 3G LS4051MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: Linx X1 Pro 3G
   os_family: Android
   browser_family: Chrome
@@ -9055,19 +8156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VOX S502 4G VS5013ML Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D2
+    brand: Digma
     model: VOX S502 4G
   os_family: Android
   browser_family: Chrome
@@ -9075,19 +8174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; DIGICEL DL810 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D3
+    brand: Digicel
     model: DL810
   os_family: Android
   browser_family: Chrome
@@ -9095,19 +8192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Digi C1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D4
+    brand: Digi
     model: C1
   os_family: Android
   browser_family: Chrome
@@ -9115,19 +8210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Digi_K1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D4
+    brand: Digi
     model: K1
   os_family: Android
   browser_family: Chrome
@@ -9135,19 +8228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Digi R1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D4
+    brand: Digi
     model: R1
   os_family: Android
   browser_family: Chrome
@@ -9155,19 +8246,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; DW-PS3G5 Build/3G5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D7
+    brand: Datawind
     model: Pocket Surfer 3G5
   os_family: Android
   browser_family: Android Browser
@@ -9175,19 +8264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Droxio B45 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: D8
+    brand: Droxio
     model: B45
   os_family: Android
   browser_family: Chrome
@@ -9195,19 +8282,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; DROXIO C40 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: D8
+    brand: Droxio
     model: C40
   os_family: Android
   browser_family: Android Browser
@@ -9215,19 +8300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Konnect402) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DA
+    brand: Danew
     model: Konnect 402
   os_family: Android
   browser_family: Chrome
@@ -9235,19 +8318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Konnect_504 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DA
+    brand: Danew
     model: Konnect 504
   os_family: Android
   browser_family: Chrome
@@ -9255,19 +8336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Konnect_601) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DA
+    brand: Danew
     model: Konnect 601
   os_family: Android
   browser_family: Chrome
@@ -9275,19 +8354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Konnect602) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DA
+    brand: Danew
     model: Konnect 602
   os_family: Android
   browser_family: Chrome
@@ -9295,19 +8372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Konnect_607) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DA
+    brand: Danew
     model: Konnect 607
   os_family: Android
   browser_family: Chrome
@@ -9315,19 +8390,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; Dialog K35 Build/RheaTK) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DG
+    brand: Dialog
     model: K35
   os_family: Android
   browser_family: Android Browser
@@ -9335,19 +8408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update-1; en-us; Dell_Aero Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari.530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: DL
+    brand: Dell
     model: Aero
   os_family: Android
   browser_family: Android Browser
@@ -9355,19 +8426,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; Dell Venue Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DL
+    brand: Dell
     model: Venue
   os_family: Android
   browser_family: Android Browser
@@ -9375,19 +8444,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; DELL; Venue Pro)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: DL
+    brand: Dell
     model: Venue Pro
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9395,19 +8462,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-; XCD35 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: DL
+    brand: Dell
     model: XCD35
   os_family: Android
   browser_family: Android Browser
@@ -9415,19 +8480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; DNS_S4003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DN
+    brand: DNS
     model: S4003
   os_family: Android
   browser_family: Chrome
@@ -9435,19 +8498,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; DNS S4502) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DN
+    brand: DNS
     model: S4502
   os_family: Android
   browser_family: Chrome
@@ -9455,19 +8516,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; S4505M Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.138 Mobile Safari/537.36 OPR/22.0.1485.78487
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "22.0.1485.78487"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DN
+    brand: DNS
     model: S4505M
   os_family: Android
   browser_family: Opera
@@ -9475,19 +8534,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SD01M Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DN
+    brand: DNS
     model: SD01M
   os_family: Android
   browser_family: Opera
@@ -9495,19 +8552,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; DOOGEE-BIGBOY-DG600    Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BIGBOY DG600
   os_family: Android
   browser_family: Android Browser
@@ -9515,19 +8570,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BL12000 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL12000
   os_family: Android
   browser_family: Chrome
@@ -9535,19 +8588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BL12000 PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL12000 Pro
   os_family: Android
   browser_family: Chrome
@@ -9555,7 +8606,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; BL5000 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 [Pinterest/Android]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -9564,7 +8614,7 @@
     version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL5000
   os_family: Android
   browser_family: Unknown
@@ -9572,19 +8622,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BL5500_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL5500 Lite
   os_family: Android
   browser_family: Chrome
@@ -9592,19 +8640,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BL7000 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL7000
   os_family: Android
   browser_family: Chrome
@@ -9612,19 +8658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BL9000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: BL9000
   os_family: Android
   browser_family: Chrome
@@ -9632,19 +8676,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Discovery DG500 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Discovery DG500
   os_family: Android
   browser_family: Chrome
@@ -9652,19 +8694,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; Discovery2-DG500C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Discovery2 DG500C
   os_family: Android
   browser_family: Android Browser
@@ -9672,19 +8712,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Hitman_DG850) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Hitman DG580
   os_family: Android
   browser_family: Chrome
@@ -9692,19 +8730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KISSME-DG580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Kissme DG580
   os_family: Android
   browser_family: Chrome
@@ -9712,19 +8748,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0; en-US; LEO_DG280 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.0.1288 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.0.1288"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Leo DG280
   os_family: Android
   browser_family: Unknown
@@ -9732,19 +8766,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ro-ro; MINT-DG330 Build/MINT-DG330) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: MINT DG330
   os_family: Android
   browser_family: Android Browser
@@ -9752,19 +8784,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; DOOGEE-TITANS-DG150    Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: TITANS DG150
   os_family: Android
   browser_family: Android Browser
@@ -9772,19 +8802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Titans2_DG700 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Titans2 DG700
   os_family: Android
   browser_family: Chrome
@@ -9792,19 +8820,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.9; fr-fr; TURBO DG2014 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: TURBO DG2014
   os_family: Android
   browser_family: Android Browser
@@ -9812,19 +8838,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Y100_Plus Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Valencia2 Y100 Plus
   os_family: Android
   browser_family: Android Browser
@@ -9832,19 +8856,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Valencia2_Y100_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Valencia2 Y100 Plus
   os_family: Android
   browser_family: Chrome
@@ -9852,19 +8874,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Valencia2_Y100pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Valencia2 Y100 Pro
   os_family: Android
   browser_family: Chrome
@@ -9872,19 +8892,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; VOYAGER DG300 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: VOYAGER DG300
   os_family: Android
   browser_family: Android Browser
@@ -9892,19 +8910,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VOYAGER2 DG310 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: VOYAGER2 DG310
   os_family: Android
   browser_family: Chrome
@@ -9912,19 +8928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X5max Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: X5max
   os_family: Android
   browser_family: Chrome
@@ -9932,19 +8946,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X5max_PRO Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: X5max PRO
   os_family: Android
   browser_family: Chrome
@@ -9952,19 +8964,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X9 Mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: X9 Mini
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Y9Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DO
+    brand: Doogee
     model: Y9 Plus
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Doro 8030/8031/8028 Build/EU_RET_03.14.02; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DR
+    brand: Doro
     model: "8030"
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: DESAY TL1263_TD/Linux/3.4.39 Android/4.3 Release/08.15.2013 Browser/AppleWebkit534.30 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TL1263
   os_family: Android
   browser_family: Android Browser
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; DESAY TL1266 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.2.559 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.2.559"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TL1266
   os_family: Android
   browser_family: Unknown
@@ -83,19 +75,17 @@
   user_agent: DESAY TS1008/1.0 Release/07.12.2013 Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TS1008
   os_family: Android
   browser_family: Android Browser
@@ -103,19 +93,17 @@
   user_agent: DESAYTS518_TD/1.0 Linux/2.6.35 Android/2.3.5 Release/01.04.2013 Browser/AppleWebKit533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TS518
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; DESAY TS808 Build/MocorDroid2.3.5) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.1 Mobile Safari/537.36
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TS808
   os_family: Android
   browser_family: Unknown
@@ -143,19 +129,17 @@
   user_agent: DESAY_TS908_CMCC_TD/1.0 Android/2.3.7 (LinuxOS 2.6.35.7) Release/04.13.2012 Browser/WAP2.0
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: DS
+    brand: Desay
     model: TS908 CMCC
   os_family: Android
   browser_family: Android Browser
@@ -163,7 +147,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; DATANG S11 Build/V11_DATANG_2__D0_GT818X_nM-V1127B1842-usr) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/cmwap Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
@@ -172,7 +155,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: DT
+    brand: Datang
     model: S11
   os_family: Android
   browser_family: Unknown
@@ -180,7 +163,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; DATANG S18 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/5.0 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -189,7 +171,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: DT
+    brand: Datang
     model: S18
   os_family: Android
   browser_family: Unknown
@@ -197,19 +179,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; Datang-DATANG-S18i/1.0 Android/2.3.5 Release/05.02.2013 Browser/AppleWebKit533.1 Build/MocorDroid2.3.5) AppleWebKit533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DT
+    brand: Datang
     model: S18i
   os_family: Android
   browser_family: Android Browser
@@ -217,19 +197,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; DATANG S62L Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.1.576 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.1.576"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DT
+    brand: Datang
     model: S62L
   os_family: Android
   browser_family: Unknown
@@ -237,19 +215,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; DOOV_D2 Build/DOOV) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: D2
   os_family: Android
   browser_family: Android Browser
@@ -257,19 +233,17 @@
   user_agent: DOOV-DOOV_D300/1.0 Linux/2.6.35.7 Android/2.3.5 Release/02.18.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: D300
   os_family: Android
   browser_family: Android Browser
@@ -277,19 +251,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2;  zh-cn; DOOV D350; Android/4.1.2; Release/01.20.2014)  AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: D350
   os_family: Android
   browser_family: Android Browser
@@ -297,7 +269,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; DOOV D8 Build/JOP40D) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.2.1)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
@@ -306,7 +277,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: D8
   os_family: Android
   browser_family: Unknown
@@ -314,19 +285,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; DOOV S1 Build/DOOVS1) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025442 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: S1
   os_family: Android
   browser_family: Unknown
@@ -334,19 +303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; DOOV S2y Build/DOOVS2y) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/4.2 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "4.2"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: S2y
   os_family: Android
   browser_family: Unknown
@@ -354,19 +321,17 @@
   user_agent: DOOV T60/1.0 Android/4.3 Release/JLS36C Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: DV
+    brand: Doov
     model: T60
   os_family: Android
   browser_family: Android Browser
@@ -374,19 +339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DeWalt MD501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DW
+    brand: DeWalt
     model: MD501
   os_family: Android
   browser_family: Chrome
@@ -394,19 +357,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; AL140 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: AL140
   os_family: Android
   browser_family: Opera
@@ -414,19 +375,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; AL240 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/43.3.2254.141404
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.3.2254.141404"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: AL240
   os_family: Android
   browser_family: Opera
@@ -434,19 +393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; B340) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: B340
   os_family: Android
   browser_family: Chrome
@@ -454,19 +411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; B450) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: B450
   os_family: Android
   browser_family: Chrome
@@ -474,19 +429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BL150 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BL150
   os_family: Android
   browser_family: Chrome
@@ -494,19 +447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BL250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BL250
   os_family: Android
   browser_family: Chrome
@@ -514,19 +465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BS150) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS150
   os_family: Android
   browser_family: Chrome
@@ -534,19 +483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BS155 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS155
   os_family: Android
   browser_family: Chrome
@@ -554,19 +501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BS160) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS160
   os_family: Android
   browser_family: Chrome
@@ -574,19 +519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BS250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS250
   os_family: Android
   browser_family: Chrome
@@ -594,19 +537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BS550 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS550
   os_family: Android
   browser_family: Chrome
@@ -614,19 +555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BS650 Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: BS650
   os_family: Android
   browser_family: Chrome
@@ -634,19 +573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ixion_ES255 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Mobile Safari/537.36 OPR/37.0.2192.105088
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "37.0.2192.105088"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion ES255
   os_family: Android
   browser_family: Opera
@@ -654,19 +591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ixion ES350 Build/DEXP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 YaBrowser/17.3.0.373.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.3.0.373.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion ES350
   os_family: Android
   browser_family: Unknown
@@ -674,19 +609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ixion ES950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion ES950
   os_family: Android
   browser_family: Chrome
@@ -694,19 +627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ixion M340) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion M340
   os_family: Android
   browser_family: Chrome
@@ -714,19 +645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ixion ML250) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.4.349.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.4.349.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion ML250
   os_family: Android
   browser_family: Unknown
@@ -734,19 +663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ML450) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion ML450
   os_family: Android
   browser_family: Chrome
@@ -754,19 +681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion MS550
   os_family: Android
   browser_family: Chrome
@@ -774,19 +699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS650) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Ixion MS650
   os_family: Android
   browser_family: Chrome
@@ -794,19 +717,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-RU; SENIOR Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.8.6.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.8.6.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: DX
+    brand: DEXP
     model: Senior
   os_family: Android
   browser_family: Unknown
@@ -814,19 +735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HEYOU1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: HEYou 1
   os_family: Android
   browser_family: Chrome
@@ -834,19 +753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HEYOU3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: HEYou 3
   os_family: Android
   browser_family: Chrome
@@ -854,19 +771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HEYOU5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: HEYou 5
   os_family: Android
   browser_family: Chrome
@@ -874,19 +789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Wooze_I5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: Wooze I5
   os_family: Android
   browser_family: Chrome
@@ -894,19 +807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Wooze_I55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: Wooze I55
   os_family: Android
   browser_family: Chrome
@@ -914,19 +825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wooze_L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: Wooze L
   os_family: Android
   browser_family: Chrome
@@ -934,19 +843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wooze_XL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E2
+    brand: Essentielb
     model: Wooze XL
   os_family: Android
   browser_family: Chrome
@@ -954,19 +861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; M4MAGIC Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: M4 Magic
   os_family: Android
   browser_family: Chrome
@@ -974,19 +879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Evolio_M5Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: M5 Pro
   os_family: Android
   browser_family: Chrome
@@ -994,19 +897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Evolio_M6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: M6
   os_family: Android
   browser_family: Chrome
@@ -1014,19 +915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Evolio S4 Cobalt Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: S4 Cobalt
   os_family: Android
   browser_family: Chrome
@@ -1034,19 +933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Evolio_S5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: S5
   os_family: Android
   browser_family: Chrome
@@ -1054,19 +951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Evolio_S5 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: S5
   os_family: Android
   browser_family: Chrome
@@ -1074,19 +969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; Evolio X10 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E3
+    brand: Evolio
     model: X10
   os_family: Android
   browser_family: Chrome
@@ -1094,19 +987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ECHO_DUNE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: DUNE
   os_family: Android
   browser_family: Chrome
@@ -1114,19 +1005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ECHO_HOLI Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: HOLI
   os_family: Android
   browser_family: Chrome
@@ -1134,19 +1023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ECHO_HORIZON_LITE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: HORIZON Lite
   os_family: Android
   browser_family: Chrome
@@ -1154,19 +1041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HORIZON_M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: HORIZON M
   os_family: Android
   browser_family: Chrome
@@ -1174,19 +1059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ECHO JAVA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: JAVA
   os_family: Android
   browser_family: Chrome
@@ -1194,19 +1077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ECHO_MAX Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: MAX
   os_family: Android
   browser_family: Chrome
@@ -1214,19 +1095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ECHO MOSS Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: MOSS
   os_family: Android
   browser_family: Chrome
@@ -1234,19 +1113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ECHO_NOTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: NOTE
   os_family: Android
   browser_family: Chrome
@@ -1254,19 +1131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Echo POWER Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: POWER
   os_family: Android
   browser_family: Chrome
@@ -1274,19 +1149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ECHO SMART Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: SMART
   os_family: Android
   browser_family: Chrome
@@ -1294,19 +1167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ECHO_SMART_4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E4
+    brand: Echo Mobiles
     model: SMART 4G
   os_family: Android
   browser_family: Chrome
@@ -1314,19 +1185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Rock X9+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E5
+    brand: Extrem
     model: Rock X9+
   os_family: Android
   browser_family: Chrome
@@ -1334,19 +1203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hawk_from_EE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E6
+    brand: EE
     model: Hawk
   os_family: Android
   browser_family: Chrome
@@ -1354,19 +1221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ERGO A500 Best Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A500 Best
   os_family: Android
   browser_family: Chrome
@@ -1374,19 +1239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ERGO_A500_Best Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A500 Best
   os_family: Android
   browser_family: Chrome
@@ -1394,19 +1257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A502_Aurum Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A502 Aurum
   os_family: Android
   browser_family: Chrome
@@ -1414,19 +1275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A503 Optima Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A503 Optima
   os_family: Android
   browser_family: Chrome
@@ -1434,19 +1293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A503-Optima Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A503 Optima
   os_family: Android
   browser_family: Chrome
@@ -1454,19 +1311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ERGO_A550_Maxx) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A550 Maxx
   os_family: Android
   browser_family: Chrome
@@ -1474,19 +1329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ERGO A550 Maxx Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A550 Maxx
   os_family: Android
   browser_family: Chrome
@@ -1494,19 +1347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A551 Sky 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A551 Sky 4G
   os_family: Android
   browser_family: Chrome
@@ -1514,19 +1365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A555 Universe Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A555 Universe
   os_family: Android
   browser_family: Chrome
@@ -1534,19 +1383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ERGO_A556 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: A556
   os_family: Android
   browser_family: Chrome
@@ -1554,19 +1401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ERGO B500 First Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: B500 First
   os_family: Android
   browser_family: Chrome
@@ -1574,19 +1419,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; B502 Basic AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: B502 Basic
   os_family: Android
   browser_family: Chrome
@@ -1594,19 +1437,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; B504_Unit Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: B504 Unit
   os_family: Android
   browser_family: Chrome
@@ -1614,19 +1455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; B505_Unit_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: B505 Unit 4G
   os_family: Android
   browser_family: Chrome
@@ -1634,19 +1473,17 @@
   user_agent: mozilla/5.0 (linux; android 8.1.0; b506_intro) applewebkit/537.36 (khtml, like gecko) chrome/70.0.3538.110 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: B506 Intro
   os_family: Android
   browser_family: Chrome
@@ -1654,19 +1491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ERGO F500 Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: F500
   os_family: Android
   browser_family: Chrome
@@ -1674,19 +1509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ERGO F501 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: F501
   os_family: Android
   browser_family: Chrome
@@ -1694,19 +1527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; F501_Magic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: F501 Magic
   os_family: Android
   browser_family: Chrome
@@ -1714,19 +1545,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Ergo F502 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1155"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: F502 Platinum
   os_family: Android
   browser_family: Unknown
@@ -1734,19 +1563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Force F500 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: Force F500
   os_family: Android
   browser_family: Chrome
@@ -1754,19 +1581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Prime B400 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 YaBrowser/17.10.2.135.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.10.2.135.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: Prime B400
   os_family: Android
   browser_family: Unknown
@@ -1774,19 +1599,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; V540_Level) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.3.91.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.3.91.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: V540 Level
   os_family: Android
   browser_family: Unknown
@@ -1794,19 +1617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; V550_Vision) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: V550 Vision
   os_family: Android
   browser_family: Chrome
@@ -1814,19 +1635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; V551 Aura Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1163"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: V551 Aura
   os_family: Android
   browser_family: Unknown
@@ -1834,19 +1653,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; V551 Aura) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 YaBrowser/20.2.4.153.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.4.153.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: V551 Aura
   os_family: Android
   browser_family: Unknown
@@ -1854,19 +1671,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; V570_BIG_BEN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 YaBrowser/19.12.1.121.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.12.1.121.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E7
+    brand: Ergo
     model: V570 Big Ben
   os_family: Android
   browser_family: Unknown
@@ -1874,19 +1689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; E-tel_i250 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E8
+    brand: E-tel
     model: i250
   os_family: Android
   browser_family: Chrome
@@ -1894,19 +1707,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; EVERCOSS A65 Build/MOB31E)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A65
   os_family: Android
   browser_family: Android Browser
@@ -1914,19 +1725,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; EVERCOSS_A74A Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A74A
   os_family: Android
   browser_family: Android Browser
@@ -1934,19 +1743,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; A75A* Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A75A Star
   os_family: Android
   browser_family: Chrome
@@ -1954,19 +1761,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; EVERCOSS A7B Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A7B
   os_family: Android
   browser_family: Android Browser
@@ -1974,19 +1779,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; EVERCOSS A7L Build/Android4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A7L
   os_family: Android
   browser_family: Android Browser
@@ -1994,19 +1797,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 6.0; EVERCOSS A7R Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A7R
   os_family: Android
   browser_family: Android Browser
@@ -2014,19 +1815,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; EVERCOSS A7Z Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: A7Z
   os_family: Android
   browser_family: Android Browser
@@ -2034,19 +1833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M50 STAR Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: M50 Star
   os_family: Android
   browser_family: Chrome
@@ -2054,19 +1851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; U50A_PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: E9
+    brand: Evercoss
     model: U50A Plus
   os_family: Android
   browser_family: Chrome
@@ -2074,19 +1869,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; EBEST S10 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: S10
   os_family: Android
   browser_family: Unknown
@@ -2094,7 +1887,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; T3482 Build/EBESTT3482) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.51_rdf8da56.600 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2103,7 +1895,7 @@
     version: "6.2.4.51.rdf8da56.600"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: T3482
   os_family: Android
   browser_family: Unknown
@@ -2111,19 +1903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; EBEST T7 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser-CMCC/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: T7
   os_family: Android
   browser_family: Unknown
@@ -2131,19 +1921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; EBEST_U1 Build/EBEST_U1EBEST_U1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.2.585 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.2.585"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: U1
   os_family: Android
   browser_family: Unknown
@@ -2151,7 +1939,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; EBEST_U1 Build/EBEST_U1EBEST_U1) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -2160,7 +1947,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: U1
   os_family: Android
   browser_family: Unknown
@@ -2168,19 +1955,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; EBEST W70 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EA
+    brand: EBEST
     model: W70
   os_family: Android
   browser_family: Android Browser
@@ -2188,19 +1973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Eclipse_G400M Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EB
+    brand: E-Boda
     model: Eclipse G400M
   os_family: Android
   browser_family: Chrome
@@ -2208,19 +1991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Eclipse_G500 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EB
+    brand: E-Boda
     model: Eclipse G500
   os_family: Android
   browser_family: Chrome
@@ -2228,19 +2009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Energy400) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy 400
   os_family: Android
   browser_family: Chrome
@@ -2248,19 +2027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Energy 400 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy 400 LTE
   os_family: Android
   browser_family: Chrome
@@ -2268,19 +2045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Energy 400S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy 400S
   os_family: Android
   browser_family: Chrome
@@ -2288,19 +2063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ENERGY_500_LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy 500 LTE
   os_family: Android
   browser_family: Chrome
@@ -2308,19 +2081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ENERGY E520 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy E520 LTE
   os_family: Android
   browser_family: Chrome
@@ -2328,19 +2099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Energy S500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy S500
   os_family: Android
   browser_family: Chrome
@@ -2348,19 +2117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ENERGY S600) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Energy S600
   os_family: Android
   browser_family: Chrome
@@ -2368,19 +2135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PowerMaxP490) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: ED
+    brand: Energizer
     model: Power Max P490
   os_family: Android
   browser_family: Chrome
@@ -2388,19 +2153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PH-1 Build/OPM1.180104.234) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EE
+    brand: Essential
     model: PH-1
   os_family: Android
   browser_family: Chrome
@@ -2408,19 +2171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; EKO Omega Q47 Build/EKO_OMEGA_Q47_OM_V1.0_20170921) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EK
+    brand: EKO
     model: Omega Q47
   os_family: Android
   browser_family: Chrome
@@ -2428,19 +2189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; EKO Omega Q50 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EK
+    brand: EKO
     model: Omega Q50
   os_family: Android
   browser_family: Chrome
@@ -2448,19 +2207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; EKO OMEGA Q57 Build/EKO_OMEGA_Q57_OM_V1.0_20171023) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EK
+    brand: EKO
     model: OMEGA Q57
   os_family: Android
   browser_family: Chrome
@@ -2468,19 +2225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone G6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: G6
   os_family: Android
   browser_family: Chrome
@@ -2488,19 +2243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone-P10C Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P10C
   os_family: Android
   browser_family: Chrome
@@ -2508,19 +2261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone P2000 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P2000
   os_family: Android
   browser_family: Chrome
@@ -2528,19 +2279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone-P2000 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100501090
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P2000
   os_family: Android
   browser_family: Chrome
@@ -2548,19 +2297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone P3000S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P3000S
   os_family: Android
   browser_family: Chrome
@@ -2568,19 +2315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Elephone_P3000S-64bit Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P3000S-64bit
   os_family: Android
   browser_family: Chrome
@@ -2588,19 +2333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Elephone P5000 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P5000
   os_family: Android
   browser_family: Chrome
@@ -2608,19 +2351,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2; en-us; P6000 Build/F6) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000
   os_family: Android
   browser_family: Android Browser
@@ -2628,19 +2369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Elephone P6000 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000
   os_family: Android
   browser_family: Chrome
@@ -2648,19 +2387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Elephone P6000 02 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000 02
   os_family: Android
   browser_family: Chrome
@@ -2668,19 +2405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Elephone P6000 02 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000 02
   os_family: Android
   browser_family: Chrome
@@ -2688,19 +2423,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2; en-us; P6000Plus Build/F10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000 Plus
   os_family: Android
   browser_family: Android Browser
@@ -2708,19 +2441,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; P6000+ Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000 Plus
   os_family: Android
   browser_family: Android Browser
@@ -2728,19 +2459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P6000 Pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P6000 Pro
   os_family: Android
   browser_family: Chrome
@@ -2748,19 +2477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Elephone P8000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: P8000
   os_family: Android
   browser_family: Chrome
@@ -2768,19 +2495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Elephone S2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: S2
   os_family: Android
   browser_family: Chrome
@@ -2788,19 +2513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elephone Trunk) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EL
+    brand: Elephone
     model: Trunk
   os_family: Android
   browser_family: Chrome
@@ -2808,19 +2531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; S5LS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EM
+    brand: Eks Mobility
     model: S5LS
   os_family: Android
   browser_family: Chrome
@@ -2828,19 +2549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4UPlus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EM
+    brand: Eks Mobility
     model: X4U Plus
   os_family: Android
   browser_family: Chrome
@@ -2848,19 +2567,17 @@
   user_agent: ETON-D510_TD/1.0 Linux/2.6.35.7 Android/2.3.5 Release/01.01.2012 Browser/AppleWebKit533.1 Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: D510
   os_family: Android
   browser_family: Android Browser
@@ -2868,7 +2585,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; ETON I12 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.49_r8d971a2.600 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2877,7 +2593,7 @@
     version: "6.2.4.49.r8d971a2.600"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: I12
   os_family: Android
   browser_family: Unknown
@@ -2885,7 +2601,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; ETON I6 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -2894,7 +2609,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: I6
   os_family: Android
   browser_family: Unknown
@@ -2902,19 +2617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; ETON I95 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: I95
   os_family: Android
   browser_family: Unknown
@@ -2922,7 +2635,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; ETON P1 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -2931,7 +2643,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: P1
   os_family: Android
   browser_family: Unknown
@@ -2939,7 +2651,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; ETON P3 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -2948,7 +2659,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: P3
   os_family: Android
   browser_family: Unknown
@@ -2956,19 +2667,17 @@
   user_agent: ETON-T730D_TD/1.0 Linux/2.6.35.7 Android/2.3.5 Release/01.01.2012 Browser/AppleWebKit533.1 Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: T730D
   os_family: Android
   browser_family: Android Browser
@@ -2976,19 +2685,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.3; ETON T860) Linux/3.0.8-svn5727 Release/10.31.2013  AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: T860
   os_family: Android
   browser_family: Android Browser
@@ -2996,7 +2703,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; ETON T890 Build/JDQ39) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 T5/1.0 baiduboxapp/4.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -3005,7 +2711,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: EN
+    brand: Eton
     model: T890
   os_family: Android
   browser_family: Unknown
@@ -3013,19 +2719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVOLVEO StrongPhone G2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone G2
   os_family: Android
   browser_family: Chrome
@@ -3033,19 +2737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; EVOLVEO StrongPhone G4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone G4
   os_family: Android
   browser_family: Chrome
@@ -3053,19 +2755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVOLVEO StrongPhone G4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone G4
   os_family: Android
   browser_family: Chrome
@@ -3073,19 +2773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVOLVEO StrongPhone G8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone G8
   os_family: Android
   browser_family: Chrome
@@ -3093,19 +2791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; EVOLVEO_StrongPhone_Q7_LTE Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone Q7 LTE
   os_family: Android
   browser_family: Chrome
@@ -3113,19 +2809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; EVOLVEO_StrongPhone_Q8_LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: StrongPhone Q8 LTE
   os_family: Android
   browser_family: Chrome
@@ -3133,19 +2827,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.2.1; EVOLVEO_XtraPhone_4.5_Q4 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36 '
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EO
+    brand: Evolveo
     model: XtraPhone 4.5 Q4
   os_family: Android
   browser_family: Chrome
@@ -3153,19 +2845,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; EasyPhone EP5 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EP
+    brand: Easypix
     model: EasyPhone EP5
   os_family: Android
   browser_family: Android Browser
@@ -3173,19 +2863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Onyx-1S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EU
+    brand: Eurostar
     model: Onyx 1S
   os_family: Android
   browser_family: Chrome
@@ -3193,19 +2881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Onyx-3S Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EU
+    brand: Eurostar
     model: Onyx 3S
   os_family: Android
   browser_family: Chrome
@@ -3213,19 +2899,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; EverClassic Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverClassic
   os_family: Android
   browser_family: Android Browser
@@ -3233,19 +2917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; EverGlory Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverGlory
   os_family: Android
   browser_family: Chrome
@@ -3253,19 +2935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; EverGlory Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverGlory
   os_family: Android
   browser_family: Chrome
@@ -3273,19 +2953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; EverMagic Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverMagic
   os_family: Android
   browser_family: Android Browser
@@ -3293,19 +2971,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; EverMellow D45 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverMellow D45
   os_family: Android
   browser_family: Android Browser
@@ -3313,19 +2989,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; EverMellow D50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverMellow D50
   os_family: Android
   browser_family: Android Browser
@@ -3333,19 +3007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; EverMiracle Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverMiracle
   os_family: Android
   browser_family: Chrome
@@ -3353,19 +3025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; EverMiracle Nano Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverMiracle Nano
   os_family: Android
   browser_family: Chrome
@@ -3373,19 +3043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; EverShine Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverShine
   os_family: Android
   browser_family: Chrome
@@ -3393,19 +3061,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ar-eg; EverSmart Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverSmart
   os_family: Android
   browser_family: Android Browser
@@ -3413,19 +3079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ar-eg; EverStar Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverStar
   os_family: Android
   browser_family: Android Browser
@@ -3433,19 +3097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; EverTrendy Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverTrendy
   os_family: Android
   browser_family: Android Browser
@@ -3453,19 +3115,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; EverTrendy Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: EV
+    brand: Evertek
     model: EverTrendy
   os_family: Android
   browser_family: Android Browser
@@ -3473,19 +3133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SENWA S605 Build/MocorDroid) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: MocorDroid
-    short_name: MCD
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: City
   os_family: Android
   browser_family: Chrome
@@ -3493,19 +3151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; S5018) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: Inizio
   os_family: Android
   browser_family: Chrome
@@ -3513,19 +3169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S471 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: Jazz
   os_family: Android
   browser_family: Chrome
@@ -3533,19 +3187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S905TL Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: Odin
   os_family: Android
   browser_family: Chrome
@@ -3553,19 +3205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S615 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: S615
   os_family: Android
   browser_family: Chrome
@@ -3573,19 +3223,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; S-715 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 bdbrowser_i18n/4.1.0.3
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.1.0.3"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: S715
   os_family: Android
   browser_family: Baidu
@@ -3593,19 +3241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S725 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: S725
   os_family: Android
   browser_family: Chrome
@@ -3613,19 +3259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S915 Build/KOT49H) AppleWebKit/534.31 (KHTML, like Gecko) Version/3.0 Chrome/30.0.0.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: S915
   os_family: Android
   browser_family: Chrome
@@ -3633,19 +3277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V705B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EW
+    brand: Senwa
     model: V705B
   os_family: Android
   browser_family: Chrome
@@ -3653,19 +3295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Atlant Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EX
+    brand: Explay
     model: Atlant
   os_family: Android
   browser_family: Chrome
@@ -3673,19 +3313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RioPlay Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: EX
+    brand: Explay
     model: Rio Play
   os_family: Android
   browser_family: Chrome
@@ -3693,19 +3331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower C1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.97 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.97"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C1
   os_family: Android
   browser_family: Chrome
@@ -3713,19 +3349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower C2 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2531.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2531.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -3733,19 +3367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower C3 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C3
   os_family: Android
   browser_family: Chrome
@@ -3753,19 +3385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower C4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 YaBrowser/16.2.1.7529.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.2.1.7529.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C4
   os_family: Android
   browser_family: Unknown
@@ -3773,19 +3403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower C5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C5
   os_family: Android
   browser_family: Chrome
@@ -3793,19 +3421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; FinePower_C6 Build/MOB30Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.154 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.154"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: C6
   os_family: Android
   browser_family: Chrome
@@ -3813,19 +3439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower D1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: D1
   os_family: Android
   browser_family: Chrome
@@ -3833,19 +3457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FinePower D3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F1
+    brand: FinePower
     model: D3
   os_family: Android
   browser_family: Chrome
@@ -3853,19 +3475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FORME A37 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F2
+    brand: FORME
     model: A37
   os_family: Android
   browser_family: Chrome
@@ -3873,19 +3493,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; FORME_F520) U2/1.0.0 UCBrowser/9.3.0.440 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.0.440"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: F2
+    brand: FORME
     model: Forever
   os_family: Android
   browser_family: Unknown
@@ -3893,19 +3511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Forme R7S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F2
+    brand: FORME
     model: R7S
   os_family: Android
   browser_family: Chrome
@@ -3913,19 +3529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AURII_F8_Premium) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII F8 Premium
   os_family: Android
   browser_family: Chrome
@@ -3933,19 +3547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AURII_FORCE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII Force
   os_family: Android
   browser_family: Chrome
@@ -3953,19 +3565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AURII_FUSION Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII Fusion
   os_family: Android
   browser_family: Chrome
@@ -3973,19 +3583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AURII Passion) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII Passion
   os_family: Android
   browser_family: Chrome
@@ -3993,19 +3601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AURII Secret Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII Secret Lite
   os_family: Android
   browser_family: Chrome
@@ -4013,19 +3619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AURII Virtuoso Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII Virtuoso
   os_family: Android
   browser_family: Chrome
@@ -4033,19 +3637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AURII_XCITE Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F3
+    brand: FireFly Mobile
     model: AURII xCite
   os_family: Android
   browser_family: Chrome
@@ -4053,19 +3655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Royale_X2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F7
+    brand: Fero
     model: Royale X2
   os_family: Android
   browser_family: Chrome
@@ -4073,19 +3673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Fero_Y1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: F7
+    brand: Fero
     model: Y1
   os_family: Android
   browser_family: Chrome
@@ -4093,19 +3691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; FP1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FA
+    brand: Fairphone
     model: FP1
   os_family: Android
   browser_family: Chrome
@@ -4113,19 +3709,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; FP1U Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FA
+    brand: Fairphone
     model: FP1U
   os_family: Android
   browser_family: Android Browser
@@ -4133,19 +3727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; FP2 Build/FP2-gms-18.04.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FA
+    brand: Fairphone
     model: FP2
   os_family: Android
   browser_family: Chrome
@@ -4153,19 +3745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Fondi-D66) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36 MxBrowser/4.5.5.2000
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.5.5.2000"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FD
+    brand: Fondi
     model: D66
   os_family: Android
   browser_family: Unknown
@@ -4173,19 +3763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T602B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FD
+    brand: Fondi
     model: T602B
   os_family: Android
   browser_family: Chrome
@@ -4193,19 +3781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T702 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FD
+    brand: Fondi
     model: T702
   os_family: Android
   browser_family: Chrome
@@ -4213,19 +3799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ATRIUM II F55L2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Atrium II
   os_family: Android
   browser_family: Chrome
@@ -4233,19 +3817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; EPIC F50G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Epic F50G
   os_family: Android
   browser_family: Chrome
@@ -4253,19 +3835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; F55L Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: F55L
   os_family: Android
   browser_family: Chrome
@@ -4273,19 +3853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Gravity X55L Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Gravity X55L
   os_family: Android
   browser_family: Chrome
@@ -4293,19 +3871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Orion M50L Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Orion M50L
   os_family: Android
   browser_family: Chrome
@@ -4313,19 +3889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ULTRA M50G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Prime
   os_family: Android
   browser_family: Chrome
@@ -4333,19 +3907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRIO F40LT Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Trio F40LT
   os_family: Android
   browser_family: Chrome
@@ -4353,19 +3925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; M405B Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Virtue II
   os_family: Android
   browser_family: Chrome
@@ -4373,19 +3943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; M405B_8GB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Virtue II 8GB
   os_family: Android
   browser_family: Chrome
@@ -4393,19 +3961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIRTUE3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FI
+    brand: FiGO
     model: Virtue III
   os_family: Android
   browser_family: Chrome
@@ -4413,19 +3979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; IQ448 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Mobile Safari/537.36 OPR/19.0.1340.69721
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "19.0.1340.69721"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Chic
   os_family: Android
   browser_family: Opera
@@ -4433,19 +3997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; FS502 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.2.8.945 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.2.8.945"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 1
   os_family: Android
   browser_family: Unknown
@@ -4453,19 +4015,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS517 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 Fly/1.0.1.0 AlohaBrowser/1.3.3.0
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "1.3.3.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 11
   os_family: Android
   browser_family: Unknown
@@ -4473,19 +4033,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS516 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 12
   os_family: Android
   browser_family: Chrome
@@ -4493,19 +4051,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS518 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 13
   os_family: Android
   browser_family: Chrome
@@ -4513,19 +4069,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS522 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 14
   os_family: Android
   browser_family: Chrome
@@ -4533,19 +4087,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS523 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 16
   os_family: Android
   browser_family: Chrome
@@ -4553,19 +4105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS504 Build/LMY47I; ru-ru) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Mobile Safari/537.36 Puffin/6.1.0.15920AP
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "6.1.0.15920"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 2
   os_family: Android
   browser_family: Unknown
@@ -4573,19 +4123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS506 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 3
   os_family: Android
   browser_family: Chrome
@@ -4593,19 +4141,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS507 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 4
   os_family: Android
   browser_family: Chrome
@@ -4613,19 +4159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FS508 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 6
   os_family: Android
   browser_family: Chrome
@@ -4633,19 +4177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FS511 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 YaBrowser/16.6.0.8810.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.6.0.8810.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 7
   os_family: Android
   browser_family: Unknown
@@ -4653,19 +4195,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS514 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 8
   os_family: Android
   browser_family: Chrome
@@ -4673,19 +4213,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS553 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cirrus 9
   os_family: Android
   browser_family: Chrome
@@ -4693,19 +4231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; IQ4412 Quad Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Coral
   os_family: Android
   browser_family: Chrome
@@ -4713,19 +4249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; FS403 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0 Mobile Safari/537
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Cumulus 1
   os_family: Android
   browser_family: Chrome
@@ -4733,19 +4267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; IQ444 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Diamond 2
   os_family: Android
   browser_family: Chrome
@@ -4753,19 +4285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; IQ444 Quattro Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Diamond 2
   os_family: Android
   browser_family: Chrome
@@ -4773,19 +4303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; IQ237 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Dynamic
   os_family: Android
   browser_family: Android Browser
@@ -4793,19 +4321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IQ452 Quad Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Ego Vision 1
   os_family: Android
   browser_family: Chrome
@@ -4813,19 +4339,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru; IQ440) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.0.347 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.347"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Energy
   os_family: Android
   browser_family: Unknown
@@ -4833,19 +4357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; IQ4411 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36 OPR/27.0.1698.89115
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "27.0.1698.89115"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Energy 2
   os_family: Android
   browser_family: Opera
@@ -4853,19 +4375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IQ4403 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Energy 3
   os_family: Android
   browser_family: Chrome
@@ -4873,19 +4393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ4401) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Energy 2
   os_family: Android
   browser_family: Chrome
@@ -4893,19 +4411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IQ447 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 YaBrowser/14.10.2062.12160.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.10.2062.12160.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Life 1
   os_family: Android
   browser_family: Unknown
@@ -4913,19 +4429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IQ456 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36 OPR/24.0.1565.82529
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "24.0.1565.82529"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Life 2
   os_family: Android
   browser_family: Opera
@@ -4933,19 +4447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ4409 Quad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Life 4
   os_family: Android
   browser_family: Chrome
@@ -4953,19 +4465,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru; IQ432 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 1
   os_family: Android
   browser_family: Unknown
@@ -4973,19 +4483,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2;; xx-xx; Fly IQ436 Build/JZO57K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 3
   os_family: Android
   browser_family: Android Browser
@@ -4993,19 +4501,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; en-US; IQ4490) U2/1.0.0 UCBrowser/8.8.0.332 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.0.332"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 4
   os_family: Android
   browser_family: Unknown
@@ -5013,19 +4519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IQ434 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 5
   os_family: Android
   browser_family: Chrome
@@ -5035,13 +4539,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.4.3.532"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 6
   os_family: Unknown
   browser_family: Unknown
@@ -5049,19 +4552,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ436i Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Nano 9
   os_family: Android
   browser_family: Chrome
@@ -5069,19 +4570,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; ru-; IQ4415 Quad Build/KOT49H) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 bdbrowser_i18n/4.6.0.7
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "4.6.0.7"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Era Style 3
   os_family: Android
   browser_family: Baidu
@@ -5089,19 +4588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ4413_Quad Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Evo Chic 3
   os_family: Android
   browser_family: Chrome
@@ -5109,19 +4606,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ4504 Quad Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 YaBrowser/15.4.2272.3842.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.4.2272.3842.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Evo Energy 5
   os_family: Android
   browser_family: Unknown
@@ -5129,19 +4624,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; IQ454 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.582 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.582"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Evo Tech 1
   os_family: Android
   browser_family: Unknown
@@ -5149,19 +4642,17 @@
   user_agent: Android 4.4.2;AppleWebKit/534.30;Build/KOT49H;IQ4414 Quad Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Evo Tech 3
   os_family: Android
   browser_family: Android Browser
@@ -5169,19 +4660,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru; IQ430 Build/JRO03C) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/9.2.0.419 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.419"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Evoke
   os_family: Android
   browser_family: Unknown
@@ -5189,19 +4678,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; IQ270 Firebird Build/GRJ22; LeWa_IQ270_ROM_12.12.14) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Firebird
   os_family: Android
   browser_family: Android Browser
@@ -5209,19 +4696,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; IQ270 Build/ICSv2.04) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Firebird
   os_family: Android
   browser_family: Android Browser
@@ -5229,19 +4714,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Fly_IQ445 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Genius
   os_family: Android
   browser_family: Android Browser
@@ -5249,19 +4732,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; IQ431 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Glory
   os_family: Android
   browser_family: Android Browser
@@ -5269,19 +4750,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Fly_IQ450 Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.172 YaBrowser/1.20.1364.172 Mobile Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "1.20.1364.172"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Horizon
   os_family: Android
   browser_family: Unknown
@@ -5289,19 +4768,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; IQ450_Quattro Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.45 Mobile Safari/537.36 OPR/15.0.1162.59192
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "15.0.1162.59192"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Horizon 2
   os_family: Android
   browser_family: Opera
@@ -5309,19 +4786,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; FLY IQ256 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Maxthon/4.1.4.2000
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.1.4.2000"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: IQ256
   os_family: Android
   browser_family: Unknown
@@ -5329,19 +4804,17 @@
   user_agent: Android 4.1.2;AppleWebKit/533.1;Build/MocorDroid2.3.5;IQ238 Build/MocorDroid2.3.5
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Jazz
   os_family: Android
   browser_family: Android Browser
@@ -5349,19 +4822,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS524 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Knockout
   os_family: Android
   browser_family: Chrome
@@ -5369,19 +4840,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-RU; Life Ace Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.9.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.9.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Life Ace
   os_family: Android
   browser_family: Unknown
@@ -5389,19 +4858,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-ru; Life Compact 4G Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36 Hawk/QuickBrowser/2.4.30.115711
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Life Compact 4G
   os_family: Android
   browser_family: Chrome
@@ -5409,19 +4876,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-RU; Life Jet Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.1.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.1.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Life Jet
   os_family: Android
   browser_family: Unknown
@@ -5429,19 +4894,17 @@
   user_agent: ozilla/5.0 (Linux; U; Android 8.1.0; ru-ru; Life Sky Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 Hawk/QuickBrowser/2.4.33.115728
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Life Sky
   os_family: Android
   browser_family: Chrome
@@ -5449,19 +4912,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru; IQ446 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Magic
   os_family: Android
   browser_family: Unknown
@@ -5469,19 +4930,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; IQ446 Magic Build/JOP40D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Magic
   os_family: Android
   browser_family: Chrome
@@ -5489,19 +4948,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; IQ275 Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Marathon
   os_family: Android
   browser_family: Android Browser
@@ -5509,19 +4966,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS528 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Memory Plus
   os_family: Android
   browser_family: Chrome
@@ -5529,19 +4984,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Fly_IQ442 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Miracle
   os_family: Android
   browser_family: Chrome
@@ -5549,19 +5002,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; IQ442 Quad Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.57"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Miracle 2
   os_family: Android
   browser_family: Chrome
@@ -5569,19 +5020,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FS451 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 1
   os_family: Android
   browser_family: Chrome
@@ -5589,19 +5038,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS512 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 10
   os_family: Android
   browser_family: Chrome
@@ -5609,19 +5056,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS455 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 11
   os_family: Android
   browser_family: Chrome
@@ -5629,19 +5074,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS510 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 12
   os_family: Android
   browser_family: Chrome
@@ -5649,19 +5092,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS456 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 14
   os_family: Android
   browser_family: Chrome
@@ -5669,19 +5110,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS457 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 15
   os_family: Android
   browser_family: Chrome
@@ -5689,19 +5128,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS459 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 16
   os_family: Android
   browser_family: Chrome
@@ -5709,19 +5146,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS527 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 17
   os_family: Android
   browser_family: Chrome
@@ -5729,19 +5164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FS452 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 2
   os_family: Android
   browser_family: Chrome
@@ -5749,19 +5182,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FS501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 3
   os_family: Android
   browser_family: Chrome
@@ -5769,19 +5200,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FS551 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 YaBrowser/17.3.2.414.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.3.2.414.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 4
   os_family: Android
   browser_family: Unknown
@@ -5789,19 +5218,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS505 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 7
   os_family: Android
   browser_family: Chrome
@@ -5809,19 +5236,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FS454 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.137 YaBrowser/17.4.0.491.00 (alpha) Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.4.0.491.00 alpha"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 8
   os_family: Android
   browser_family: Unknown
@@ -5829,19 +5254,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FS509 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Nimbus 9
   os_family: Android
   browser_family: Chrome
@@ -5849,19 +5272,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; IQ4410 Quad Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Phoenix
   os_family: Android
   browser_family: Chrome
@@ -5869,19 +5290,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-RU; Photo Pro Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163 UCTurbo/1.7.1.900 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.7.1.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Photo Pro
   os_family: Android
   browser_family: Unknown
@@ -5889,19 +5308,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS521 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Power Plus 1
   os_family: Android
   browser_family: Chrome
@@ -5909,19 +5326,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS526 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Power Plus 2
   os_family: Android
   browser_family: Chrome
@@ -5929,19 +5344,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Power Plus 5000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Power Plus 5000
   os_family: Android
   browser_family: Chrome
@@ -5949,19 +5362,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS554 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Power Plus FHD
   os_family: Android
   browser_family: Chrome
@@ -5969,19 +5380,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS530 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Power Plus XXL
   os_family: Android
   browser_family: Chrome
@@ -5989,19 +5398,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 2.3.6; IQ255 Build/GRK39F) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Mobile Safari/537.22 OPR/14.0.1025.52315
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "14.0.1025.52315"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Pride
   os_family: Android
   browser_family: Opera
@@ -6009,19 +5416,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; IQ449 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Pronto
   os_family: Android
   browser_family: Android Browser
@@ -6029,19 +5434,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Fly IQ441; Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Radiance
   os_family: Android
   browser_family: Android Browser
@@ -6049,19 +5452,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS520 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Selfie 1
   os_family: Android
   browser_family: Chrome
@@ -6069,19 +5470,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Slimline) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Slimline
   os_family: Android
   browser_family: Chrome
@@ -6089,19 +5488,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; Fly IQ4404 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Spark
   os_family: Android
   browser_family: Android Browser
@@ -6109,19 +5506,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; FS401 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 1
   os_family: Android
   browser_family: Chrome
@@ -6129,19 +5524,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; FS402 Build/LMY47I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.2.0.915 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.2.0.915"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 2
   os_family: Android
   browser_family: Unknown
@@ -6149,19 +5542,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS404 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 3
   os_family: Android
   browser_family: Chrome
@@ -6169,19 +5560,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FS405 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 YaBrowser/16.6.0.8810.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.6.0.8810.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 4
   os_family: Android
   browser_family: Unknown
@@ -6189,19 +5578,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; FS406 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.2.0.915 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.2.0.915"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 5
   os_family: Android
   browser_family: Unknown
@@ -6209,19 +5596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FS407 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36 OPR/42.6.2246.114522
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "42.6.2246.114522"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 6
   os_family: Android
   browser_family: Opera
@@ -6229,19 +5614,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FS458 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 7
   os_family: Android
   browser_family: Chrome
@@ -6249,19 +5632,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FS409 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 YandexSearch/6.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Stratus 9
   os_family: Android
   browser_family: Chrome
@@ -6269,19 +5650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; IQ443 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Trend
   os_family: Android
   browser_family: Chrome
@@ -6289,19 +5668,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 2.3.4; Fly_IQ285 Build/GINGERBREAD) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31 OPR/14.0.1074.57453
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "14.0.1074.57453"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Turbo
   os_family: Android
   browser_family: Opera
@@ -6309,19 +5686,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.6; ru; IQ236) U2/1.0.0 UCBrowser/9.2.3.324 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.3.324"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Victory
   os_family: Android
   browser_family: Unknown
@@ -6329,19 +5704,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; IQ451 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Vista
   os_family: Android
   browser_family: Chrome
@@ -6349,19 +5722,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; IQ240 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Whizz
   os_family: Android
   browser_family: Android Browser
@@ -6369,19 +5740,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FS529 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FL
+    brand: Fly
     model: Сhamp
   os_family: Android
   browser_family: Chrome
@@ -6389,19 +5758,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FX100,7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FM
+    brand: Famoco
     model: FX100
   os_family: Android
   browser_family: Chrome
@@ -6409,19 +5776,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ConeXis A1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FN
+    brand: FNB
     model: ConeXis A1
   os_family: Android
   browser_family: Chrome
@@ -6429,19 +5794,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ConeXis A2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FN
+    brand: FNB
     model: ConeXis A2
   os_family: Android
   browser_family: Chrome
@@ -6449,19 +5812,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ConeXis X1 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FN
+    brand: FNB
     model: ConeXis X1
   os_family: Android
   browser_family: Chrome
@@ -6469,19 +5830,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ConeXis X2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FN
+    brand: FNB
     model: ConeXis X2
   os_family: Android
   browser_family: Chrome
@@ -6489,19 +5848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SP5045V Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Firefox/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Firefox
-    short_name: FF
     version: "39.0.0.0"
     engine: Gecko
     engine_version: ""
   device:
     type: smartphone
-    brand: FN
+    brand: FNB
     model: SP5045V
   os_family: Android
   browser_family: Firefox
@@ -6509,19 +5866,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; InFocus M2 Build/KVT49L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FO
+    brand: Foxconn
     model: InFocus M2
   os_family: Android
   browser_family: Unknown
@@ -6529,19 +5884,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; InFocus M310 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FO
+    brand: Foxconn
     model: InFocus M310
   os_family: Android
   browser_family: Unknown
@@ -6549,19 +5902,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; InFocus M810u Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FO
+    brand: Foxconn
     model: InFocus M810u
   os_family: Android
   browser_family: Chrome
@@ -6569,19 +5920,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Amosta 3G5 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FR
+    brand: Forstar
     model: Amosta 3G5
   os_family: Android
   browser_family: Chrome
@@ -6589,19 +5938,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FTE161E AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Ice 2
   os_family: Android
   browser_family: Chrome
@@ -6609,7 +5956,6 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FTE161G Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36 Instagram 89.0.0.21.101 Android 24/7.0; 320dpi; 720x1184; Plus One Japan Limited/FREETEL; FTE161G; ICE2plus;
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -6618,7 +5964,7 @@
     version: "89.0.0.21.101"
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Ice 2 Plus
   os_family: Android
   browser_family: Unknown
@@ -6626,19 +5972,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; FTJ161A AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Musashi
   os_family: Android
   browser_family: Chrome
@@ -6646,19 +5990,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FT141B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Nico
   os_family: Android
   browser_family: Chrome
@@ -6666,19 +6008,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FT142 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 2
   os_family: Android
   browser_family: Chrome
@@ -6686,19 +6026,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FT142A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 2
   os_family: Android
   browser_family: Chrome
@@ -6706,19 +6044,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ152A Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 3
   os_family: Android
   browser_family: Chrome
@@ -6726,19 +6062,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ152B Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 3S LTE
   os_family: Android
   browser_family: Chrome
@@ -6746,19 +6080,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; FTJ152B AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 3S LTE
   os_family: Android
   browser_family: Chrome
@@ -6766,19 +6098,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ162D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 4
   os_family: Android
   browser_family: Chrome
@@ -6786,19 +6116,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; FTJ162D AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Priori 4
   os_family: Android
   browser_family: Chrome
@@ -6806,19 +6134,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; FTJ162E AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Raijin
   os_family: Android
   browser_family: Chrome
@@ -6826,19 +6152,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; FTJ17A00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Rei 2 Dual
   os_family: Android
   browser_family: Chrome
@@ -6846,19 +6170,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ152D Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Samurai Kiwami
   os_family: Android
   browser_family: Chrome
@@ -6866,19 +6188,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ152C Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Samurai Miyabi
   os_family: Android
   browser_family: Chrome
@@ -6886,19 +6206,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FTJ161B Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: Samurai Rei
   os_family: Android
   browser_family: Chrome
@@ -6906,19 +6224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FT142D_LTEXM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FT
+    brand: Freetel
     model: XM
   os_family: Android
   browser_family: Chrome
@@ -6926,19 +6242,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; F-02L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows Be 3 F-02L
   os_family: Android
   browser_family: Chrome
@@ -6946,19 +6260,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; F-41A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows Be 4 F-41A
   os_family: Android
   browser_family: Chrome
@@ -6966,19 +6278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; F-04K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows Be F-04K
   os_family: Android
   browser_family: Chrome
@@ -6986,19 +6296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 901FJ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows J 901FJ
   os_family: Android
   browser_family: Chrome
@@ -7006,19 +6314,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; xx-xx; F-03D Build/F0001) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows Kiss F-03D
   os_family: Android
   browser_family: Android Browser
@@ -7026,19 +6332,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; F-03E Build/V18R26Dc) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows Kiss F-03E
   os_family: Android
   browser_family: Android Browser
@@ -7046,19 +6350,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; arrowsM03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows M03
   os_family: Android
   browser_family: Chrome
@@ -7066,19 +6368,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; ja-jp; F-01F Build/V10R22A) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows NX F-01F
   os_family: Android
   browser_family: Android Browser
@@ -7086,19 +6386,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; F-06E Build/V17R45B) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows NX F-06E
   os_family: Android
   browser_family: Chrome
@@ -7106,19 +6404,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ja-jp; F-02E Build/V19R50D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows X F-02E
   os_family: Android
   browser_family: Android Browser
@@ -7126,19 +6422,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; F-05D Build/F0001) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Arrows X LTE F-05D
   os_family: Android
   browser_family: Android Browser
@@ -7146,19 +6440,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; F-08D Build/V12R23A) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Disney Mobile F-08D
   os_family: Android
   browser_family: Android Browser
@@ -7166,19 +6458,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; F-01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: Easy Phone F-01L
   os_family: Android
   browser_family: Chrome
@@ -7186,19 +6476,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; F-04J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: FU
+    brand: Fujitsu
     model: F-04J
   os_family: Android
   browser_family: Chrome
@@ -7206,19 +6494,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; ru-ru; ML7J2CH/A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6
   os_family: Android
   browser_family: Android Browser
@@ -7226,19 +6512,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; ru-ru; ML7K2CH/A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6
   os_family: Android
   browser_family: Android Browser
@@ -7246,19 +6530,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; ru-ru; MG492CH/A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6 Plus
   os_family: Android
   browser_family: Android Browser
@@ -7266,19 +6548,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MGA92ZP/A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6 Plus
   os_family: Android
   browser_family: Chrome
@@ -7286,19 +6566,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MKU82ZP/A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6S
   os_family: Android
   browser_family: Chrome
@@ -7306,19 +6584,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MNGW2CH/A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I6S Plus
   os_family: Android
   browser_family: Chrome
@@ -7326,19 +6602,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; ru-ru; MN4A2ZP/A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I7
   os_family: Android
   browser_family: Android Browser
@@ -7346,19 +6620,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MNH02CH/A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I7
   os_family: Android
   browser_family: Chrome
@@ -7366,19 +6638,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; ru-ru; MN8J2ZP/A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I7 Plus
   os_family: Android
   browser_family: Android Browser
@@ -7386,19 +6656,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MNRM2CH/A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G0
+    brand: Goophone
     model: I7 Plus
   os_family: Android
   browser_family: Chrome
@@ -7406,19 +6674,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GO Onyx Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G1
+    brand: GoMobile
     model: Go Onyx
   os_family: Android
   browser_family: Chrome
@@ -7426,19 +6692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; GO1402 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G1
+    brand: GoMobile
     model: Go1402
   os_family: Android
   browser_family: Chrome
@@ -7446,19 +6710,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GO503 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G1
+    brand: GoMobile
     model: Go503
   os_family: Android
   browser_family: Chrome
@@ -7466,19 +6728,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GOME_C7_Note_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: C7 Note Plus
   os_family: Android
   browser_family: Chrome
@@ -7486,19 +6746,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; GOME 2017X05A Build/N6F26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: C71
   os_family: Android
   browser_family: Chrome
@@ -7506,19 +6764,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GOME 2018X38A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: C72
   os_family: Android
   browser_family: Chrome
@@ -7526,19 +6782,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; en-US; GOME 2016G68A Build/MMB29U) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.8.1210 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.8.1210"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: K1
   os_family: Android
   browser_family: Unknown
@@ -7546,19 +6800,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GOME S1 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: S1
   os_family: Android
   browser_family: Chrome
@@ -7566,19 +6818,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GOME S7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: S7
   os_family: Android
   browser_family: Chrome
@@ -7586,19 +6836,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GOME 2016M25A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: U1
   os_family: Android
   browser_family: Chrome
@@ -7606,19 +6854,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; en-us; GOME 2017M27A Build/JOP24G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: U7
   os_family: Android
   browser_family: Chrome
@@ -7626,19 +6872,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GOME_U9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G5
+    brand: Gome
     model: U9
   os_family: Android
   browser_family: Chrome
@@ -7646,19 +6890,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; G0215D Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G6
+    brand: Gree
     model: G0215D
   os_family: Android
   browser_family: Chrome
@@ -7666,19 +6908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; G0245D Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: G6
+    brand: Gree
     model: G0245D
   os_family: Android
   browser_family: Chrome
@@ -7686,19 +6926,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-CN; G0335D Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.7.2.954 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.7.2.954"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: G6
+    brand: Gree
     model: G0335D
   os_family: Android
   browser_family: Unknown
@@ -7706,19 +6944,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; ARIES_785 Build/GOCLEVER) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.16"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: ARIES 785
   os_family: Android
   browser_family: Android Browser
@@ -7726,19 +6962,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARIES_785 Build/GOCLEVER) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.169"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: ARIES 785
   os_family: Android
   browser_family: Chrome
@@ -7746,19 +6980,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARIES_7o Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: ARIES 7o
   os_family: Android
   browser_family: Chrome
@@ -7766,19 +6998,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; INSIGNIA 5 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 5
   os_family: Android
   browser_family: Chrome
@@ -7786,19 +7016,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; INSIGNIA_500 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 ACHEETAHI/2100501090
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 500
   os_family: Android
   browser_family: Chrome
@@ -7806,19 +7034,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; INSIGNIA_550i) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 550i
   os_family: Android
   browser_family: Chrome
@@ -7826,19 +7052,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; INSIGNIA 5X Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 5X
   os_family: Android
   browser_family: Android Browser
@@ -7846,19 +7070,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; QUANTUM_350 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 350
   os_family: Android
   browser_family: Android Browser
@@ -7866,19 +7088,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; QUANTUM 4 Build/GOCLEVER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 4
   os_family: Android
   browser_family: Android Browser
@@ -7886,19 +7106,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; QUANTUM 4 Build/GOCLEVER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 4
   os_family: Android
   browser_family: Android Browser
@@ -7906,19 +7124,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; QUANTUM_500 Build/GOCLEVER-2014.04.30) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 500
   os_family: Android
   browser_family: Android Browser
@@ -7926,19 +7142,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GEOTEL G1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GE
+    brand: Geotel
     model: G1
   os_family: Android
   browser_family: Chrome
@@ -7946,19 +7160,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GEOTEL_Note Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.119 Mobile Safari/537.36 YandexSearch/8.11 YandexSearchBrowser/8.11
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GE
+    brand: Geotel
     model: Note
   os_family: Android
   browser_family: Chrome
@@ -7966,19 +7178,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; hr-hr; GSmart Aku A1 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30/TansoDL
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Aku A1
   os_family: Android
   browser_family: Android Browser
@@ -7986,19 +7196,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; GSmart Aku A1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Aku A1
   os_family: Android
   browser_family: Chrome
@@ -8006,19 +7214,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; GSmart_Classic Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Classic
   os_family: Android
   browser_family: Chrome
@@ -8026,19 +7232,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; GSmart_Classic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Classic
   os_family: Android
   browser_family: Chrome
@@ -8046,19 +7250,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; zh-tw; GSmart G1310 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart G1310
   os_family: Android
   browser_family: Android Browser
@@ -8066,19 +7268,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; GSmart Maya M1 v2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Maya M1 v2
   os_family: Android
   browser_family: Android Browser
@@ -8086,19 +7286,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; GSmart Maya M1 v2 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Mobile Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Maya M1 v2
   os_family: Android
   browser_family: Opera
@@ -8106,19 +7304,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; sk-sk; GSmart Roma R2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: GSmart Roma R2
   os_family: Android
   browser_family: Android Browser
@@ -8126,19 +7322,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) PPC; 240x320; GIGABYTE-MS800
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.6"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: GG
+    brand: Gigabyte
     model: MS800
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8146,19 +7340,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; QS702 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GH
+    brand: Ghia
     model: QS702
   os_family: Android
   browser_family: Chrome
@@ -8166,19 +7358,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GHIA_ZEUS_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GH
+    brand: Ghia
     model: Zeus 3G
   os_family: Android
   browser_family: Chrome
@@ -8186,19 +7376,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; GIO-GiONEE_C600/CBD75B04_01_T9151 ; 320*480; CTC/2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: C600
   os_family: Android
   browser_family: Android Browser
@@ -8206,19 +7394,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GIO-GiONEE_C610/SV1.0; 480*800; CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: C610
   os_family: Android
   browser_family: Android Browser
@@ -8226,19 +7412,17 @@
   user_agent: OneBrowser/4.2.0/Adr(Linux; U; Android 4.1.2; en-us; Dream_D1 Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "4.2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: Dream D1
   os_family: Android
   browser_family: Unknown
@@ -8246,19 +7430,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn;GiONEE-E6/E6 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/E3BF0C8D6FBEE9E2CE5D6D89000FF784 RV/4.2.7 GNBR/v1.5.1.h (securitypay,securityinstalled) GNBR/2.1.2.aa (securitypay,securityinstalled)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: E6
   os_family: Android
   browser_family: Android Browser
@@ -8266,19 +7448,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; F100A Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: F100A
   os_family: Android
   browser_family: Unknown
@@ -8286,19 +7466,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F103 Pro Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: F103 Pro
   os_family: Android
   browser_family: Chrome
@@ -8306,19 +7484,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; F103S Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: F103S
   os_family: Android
   browser_family: Chrome
@@ -8326,19 +7502,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F106L Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: F106L
   os_family: Android
   browser_family: Chrome
@@ -8346,7 +7520,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; GN100 Build/GRK39F) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17 T5/1.0 baiduboxapp/5.0 (Baidu; P1 2.3.6)
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
@@ -8355,7 +7528,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN100
   os_family: Android
   browser_family: Unknown
@@ -8363,19 +7536,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; GN100T Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN100T
   os_family: Android
   browser_family: Unknown
@@ -8383,19 +7554,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn;GiONEE-GN139/GN139 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/B37369D9AE60677B9B43652147C76A1F RV/4.2.4 GNBR/2.0.4.f (securitypay,securityinstalled)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN139
   os_family: Android
   browser_family: Android Browser
@@ -8403,19 +7572,17 @@
   user_agent: GiONEE-GN160T_TD/1.0 Linux/2.6.35.7 Android/2.3.5 Release/10.24.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN160T
   os_family: Android
   browser_family: Android Browser
@@ -8423,7 +7590,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; GN205 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MicroMessenger/5.3.1.67_r745169.462 NetType/3gnet
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
@@ -8432,7 +7598,7 @@
     version: "5.3.1.67.r745169.462"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN205
   os_family: Android
   browser_family: Unknown
@@ -8440,19 +7606,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn;GiONEE-GN700W/GN700W Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/7A2F71FD020704E59AE3E279CF76E557 RV/4.0.2
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN700W
   os_family: Android
   browser_family: Android Browser
@@ -8460,19 +7624,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; GN700W Build/JRO03C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/4.5 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "4.5"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN700W
   os_family: Android
   browser_family: Unknown
@@ -8480,19 +7642,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn;GiONEE-GN705W/GN705W Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/8A69B3BBB1C1C7B43BCCA45AA630913B RV/4.2.0 GNBR/1.6.1.aw (securitypay,securityinstalled)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN705W
   os_family: Android
   browser_family: Android Browser
@@ -8500,7 +7660,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GN800 Build/IMM76D) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.6.1 (Baidu; P1 4.0.4)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
@@ -8509,7 +7668,7 @@
     version: "6.6.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN800
   os_family: Android
   browser_family: Unknown
@@ -8517,19 +7676,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; GN868 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN868
   os_family: Android
   browser_family: Android Browser
@@ -8537,7 +7694,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; GN878 Build/JZO54K) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.6.1 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -8546,7 +7702,7 @@
     version: "6.6.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN878
   os_family: Android
   browser_family: Unknown
@@ -8554,19 +7710,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; GN9000 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.5.489 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.5.489"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9000
   os_family: Android
   browser_family: Unknown
@@ -8574,7 +7728,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; GN9000L Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -8583,7 +7736,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9000L
   os_family: Android
   browser_family: Unknown
@@ -8591,7 +7744,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; GN9001 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -8600,7 +7752,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9001
   os_family: Android
   browser_family: Unknown
@@ -8608,7 +7760,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; GN9002 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/5.0 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -8617,7 +7768,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9002
   os_family: Android
   browser_family: Unknown
@@ -8625,7 +7776,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; GN9004 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -8634,7 +7784,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9004
   os_family: Android
   browser_family: Unknown
@@ -8642,7 +7792,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; GN9005 Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.5 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -8651,7 +7800,7 @@
     version: "6.5"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9005
   os_family: Android
   browser_family: Unknown
@@ -8659,19 +7808,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; GN9006 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9006
   os_family: Android
   browser_family: Chrome
@@ -8679,19 +7826,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-CN; GN9008 Build/LMY47I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: GN9008
   os_family: Android
   browser_family: Unknown
@@ -8699,19 +7844,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-in; GIONEE_Gpad_G1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: Gpad G1
   os_family: Android
   browser_family: Android Browser
@@ -8719,19 +7862,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GIONEE_Gpad_G2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: Gpad G2
   os_family: Android
   browser_family: Android Browser
@@ -8739,19 +7880,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; M7 Power Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: M7 Power
   os_family: Android
   browser_family: Chrome
@@ -8759,19 +7898,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P5 mini Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: P5 mini
   os_family: Android
   browser_family: Chrome
@@ -8779,19 +7916,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P7 Max Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: P7 Max
   os_family: Android
   browser_family: Chrome
@@ -8799,19 +7934,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn;GiONEE-V182/V182 Build/IMM76D) AppleWebKit534.30(KHTML,like Gecko)Version/4.0 Mobile Safari/534.30 Id/6B4B39B8CF813EE614E29ACE4FA26DD9 RV/4.2.0 GNBR/1.7.1.ai (securitypay,securityinstalled)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: V182
   os_family: Android
   browser_family: Android Browser
@@ -8819,19 +7952,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn;GiONEE-V185/ V185 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 QvodPlayerBrowser:3.3.45
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: V185
   os_family: Android
   browser_family: Android Browser
@@ -8839,19 +7970,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V188 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: V188
   os_family: Android
   browser_family: Chrome
@@ -8859,19 +7988,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; V188S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: GI
+    brand: Gionee
     model: V188S
   os_family: Android
   browser_family: Unknown
@@ -8879,7 +8006,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; GOLY A100 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.51_rdf8da56.600 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -8888,7 +8014,7 @@
     version: "6.2.4.51.rdf8da56.600"
   device:
     type: smartphone
-    brand: GL
+    brand: Goly
     model: A100
   os_family: Android
   browser_family: Unknown
@@ -8896,19 +8022,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-CN; Goly_X5 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GL
+    brand: Goly
     model: X5
   os_family: Android
   browser_family: Unknown
@@ -8916,19 +8040,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; GOLY X6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: GL
+    brand: Goly
     model: X6
   os_family: Android
   browser_family: Unknown
@@ -8936,19 +8058,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Garmin-Asus A10 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17; A10-V5.0.67-user-20101018
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: GM
+    brand: Garmin-Asus
     model: A10
   os_family: Android
   browser_family: Android Browser
@@ -8956,19 +8076,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Garmin-Asus A50 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17; A50-V5.0.68-user-20101020
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: GM
+    brand: Garmin-Asus
     model: A50
   os_family: Android
   browser_family: Android Browser
@@ -8976,19 +8094,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; en-us; Garminfone Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17; A50-V5.0.70-user-20101025
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: GM
+    brand: Garmin-Asus
     model: Garminfone
   os_family: Android
   browser_family: Android Browser
@@ -8996,19 +8112,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Windows Phone 6.5; garmin-asus-Nuvifone-M10/1.0)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: GM
+    brand: Garmin-Asus
     model: Nuvifone-M10
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9016,19 +8130,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; GM 5 Plus Build/OSR18O) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.13.5.1209 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GN
+    brand: General Mobile
     model: GM 5 Plus
   os_family: Android
   browser_family: Unknown
@@ -9036,19 +8148,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GN
+    brand: General Mobile
     model: GM 8
   os_family: Android
   browser_family: Chrome
@@ -9056,19 +8166,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GM8 go) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GN
+    brand: General Mobile
     model: GM 8 Go
   os_family: Android
   browser_family: Chrome
@@ -9076,19 +8184,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GM 8 d) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GN
+    brand: General Mobile
     model: GM 8D
   os_family: Android
   browser_family: Chrome
@@ -9096,19 +8202,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Galaxy Nexus Build/ICL53F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Chrome
@@ -9116,19 +8220,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Galaxy Nexus Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Android Browser
@@ -9136,19 +8238,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ms-my; Galaxy Nexus Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Android Browser
@@ -9156,19 +8256,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; Galaxy Nexus Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Android Browser
@@ -9176,19 +8274,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Galaxy Nexus Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/5.0 Mb2345Browser/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: 2345 Browser
-    short_name: 2B
     version: "4.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Chrome
@@ -9196,19 +8292,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Galaxy Nexus Build/JDQ23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Galaxy Nexus
   os_family: Android
   browser_family: Android Browser
@@ -9216,19 +8310,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Glass 1 Build/IMM76L; XE7) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Glass
   os_family: Android
   browser_family: Android Browser
@@ -9236,19 +8328,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; vi-vn; Nexus 4 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 4
   os_family: Android
   browser_family: Android Browser
@@ -9256,19 +8346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Nexus 4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 4
   os_family: Android
   browser_family: Chrome
@@ -9276,19 +8364,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; Nexus 4 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 4
   os_family: Android
   browser_family: Unknown
@@ -9296,19 +8382,17 @@
   user_agent: wp-android/2.7.2 (Android 4.4.2; de_DE; LGE Nexus 5/hammerhead)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 5
   os_family: Android
   browser_family: Android Browser
@@ -9316,19 +8400,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Nexus 5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus 5
   os_family: Android
   browser_family: Chrome
@@ -9336,19 +8418,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-es; Nexus One Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus One
   os_family: Android
   browser_family: Android Browser
@@ -9356,19 +8436,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; Nexus One Build/GRK39F; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus One
   os_family: Android
   browser_family: Android Browser
@@ -9376,19 +8454,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Nexus S - 4.1.1 - API 16 - 480x800 Build/JRO03S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus S
   os_family: Android
   browser_family: Android Browser
@@ -9396,19 +8472,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Nexus S 4G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus S
   os_family: Android
   browser_family: Android Browser
@@ -9416,19 +8490,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Nexus S Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Nexus S
   os_family: Android
   browser_family: Android Browser
@@ -9436,19 +8508,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; Pixel Build/NMF26V)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel
   os_family: Android
   browser_family: Android Browser
@@ -9456,19 +8526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pixel) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel
   os_family: Android
   browser_family: Chrome
@@ -9476,7 +8544,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; G011A Build/N2G48H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Safari/537.36 Viber/11.9.5.8
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
@@ -9485,7 +8552,7 @@
     version: "11.9.5.8"
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 2
   os_family: Android
   browser_family: Unknown
@@ -9493,19 +8560,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; Pixel 2 Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 2
   os_family: Android
   browser_family: Chrome
@@ -9513,19 +8578,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; Pixel 2 XL Build/OPD3.170816.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 2 XL
   os_family: Android
   browser_family: Chrome
@@ -9533,19 +8596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pixel 2 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 2 XL
   os_family: Android
   browser_family: Chrome
@@ -9553,19 +8614,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Google 2XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 2 XL
   os_family: Android
   browser_family: Chrome
@@ -9573,19 +8632,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pixel 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 3
   os_family: Android
   browser_family: Chrome
@@ -9593,19 +8650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pixel 3 XL Build/PQ1A.181105.016; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 3 XL
   os_family: Android
   browser_family: Chrome
@@ -9613,19 +8668,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Pixel 3a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 3a
   os_family: Android
   browser_family: Chrome
@@ -9633,19 +8686,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Pixel 3a XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 3a XL
   os_family: Android
   browser_family: Chrome
@@ -9653,19 +8704,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Pixel 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 4
   os_family: Android
   browser_family: Chrome
@@ -9673,19 +8722,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Pixel 4 XL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 4 XL
   os_family: Android
   browser_family: Chrome
@@ -9693,19 +8740,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; Pixel 4a Build/QD4A.200805.003)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel 4a
   os_family: Android
   browser_family: Android Browser
@@ -9713,19 +8758,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.2; Pixel XL Build/NPG05E)
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: GO
+    brand: Google
     model: Pixel XL
   os_family: Android
   browser_family: Android Browser
@@ -9733,19 +8776,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GTM-5.5v.8-Exclusive Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GP
+    brand: Grape
     model: GTM-5.5v.8-Exclusive
   os_family: Android
   browser_family: Chrome
@@ -9753,19 +8794,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; GTM-5v.5Pro Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GP
+    brand: Grape
     model: GTM-5v.5Pro
   os_family: Android
   browser_family: Chrome
@@ -9773,19 +8812,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; Grape_GTM-5v.7 Build/LMY47I; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GP
+    brand: Grape
     model: GTM-5v.7
   os_family: Android
   browser_family: Chrome
@@ -9793,19 +8830,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; GTM-5v5 Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GP
+    brand: Grape
     model: GTM-5v5
   os_family: Android
   browser_family: Chrome
@@ -9813,19 +8848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Gigaset GS160 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS160
   os_family: Android
   browser_family: Chrome
@@ -9833,19 +8866,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Gigaset GS170 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS170
   os_family: Android
   browser_family: Chrome
@@ -9853,19 +8884,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GS270) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS270
   os_family: Android
   browser_family: Chrome
@@ -9873,19 +8902,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GS270 plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS270 Plus
   os_family: Android
   browser_family: Chrome
@@ -9893,19 +8920,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GS370) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS370
   os_family: Android
   browser_family: Chrome
@@ -9913,19 +8938,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; GS370_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: GS370 Plus
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; GS55-6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: ME
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; GS57-6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: ME Pro
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; GS53-6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GS
+    brand: Gigaset
     model: ME Pure
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; G-TiDE E57 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: "57"
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; G-TiDE E60 Build/GRK39F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: "60"
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; G-TiDE E66 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: "66"
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; G-TiDE E72 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: "72"
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; G-TiDE E77 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: "77"
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; G-TiDE_A1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; G-TiDE_S3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: S3
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; G-TiDE_S4 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: S4
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; G-TiDE Shining7 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: Shining 7
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; G-TiDE V6 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GT
+    brand: G-TiDE
     model: V6
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; RS61D ULTIMATE Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS61D Ultimate
   os_family: Android
   browser_family: Android Browser
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; RS62D Ultimate Build/LMY47V AppleWebKit/537.36 KHTML, like Gecko Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS62D Ultimate
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; RS71D AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS71D
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; RS74D Build/1476762186)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS74D
   os_family: Android
   browser_family: Android Browser
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; RS81D Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36 OPR/51.3.2461.138727
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "51.3.2461.138727"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS81D
   os_family: Android
   browser_family: Opera
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RS8501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS8501
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; RS8502 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS8502
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Ginzzu RS94D Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS94D
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ginzzu_RS95D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS95D
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; RS9602 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS9602
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; RS96D AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS96D
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; RS97D Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: RS97D
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GINZZU_S4010 Build/AD3615_M52_DSK_D840) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S4010
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S4020 Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S4020
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S4030 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S4030
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Ginzzu S4710 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S4710
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S5040 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S5040
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S5050 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S5050
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S5120 Build/Ginzzu_S5120) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: S5120
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ginzzu ST6040 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: ST6040
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ginzzu ST6120 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.0.2569.141117
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.0.2569.141117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: GZ
+    brand: Ginzzu
     model: ST6120
   os_family: Android
   browser_family: Opera
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Neo_A100 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: Neo A100
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Neo_A300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: Neo A300
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Neo_A300 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: Neo A300
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Neo_A700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: Neo A700
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Neo_A900 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: Neo A900
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HOFFMANN X-Max Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36 AlohaBrowser/2.14.1
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "2.14.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: X Max
   os_family: Android
   browser_family: Unknown
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HOFFMANN X-Prime Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: X Prime
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Hoffmann X Twist Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H1
+    brand: Hoffmann
     model: X Twist
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BOOST II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Boost 2
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; Boost IIse Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 YaBrowser/16.9.0.1424.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.9.0.1424.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Boost 2 SE
   os_family: Android
   browser_family: Unknown
@@ -883,19 +795,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Boost3 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Boost 3
   os_family: Android
   browser_family: Android Browser
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy F Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy F
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; Highscreen Easy F PRO Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy F Pro
   os_family: Android
   browser_family: Unknown
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy L Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.18 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.18"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy L
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy L Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy L Pro
   os_family: Android
   browser_family: Chrome
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Easy-Power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy Power
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HIGHSCREEN Easy-Power-Pro Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 AlohaBrowser/2.4.0.3
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "2.4.0.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy Power Pro
   os_family: Android
   browser_family: Unknown
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Easy Power Pro Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy Power Pro
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; Easy-Power-Pro Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1153 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1153"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy Power Pro
   os_family: Android
   browser_family: Unknown
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy S
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy_S_Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy S Pro
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy XL Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 Mobile Safari/537.36 YaApp_Android/8.80 YaSearchBrowser/8.80
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy XL
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Easy XL Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Easy XL Pro
   os_family: Android
   browser_family: Chrome
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FestXL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Fest XL
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Power Five Evo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Evo
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Power Five Max Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Max
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PowerFiveMax2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Max 2
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PowerFiveMaxLite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Max Lite
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; PowerFivePro Build/LRX21M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36 YandexSearch/7.26
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Five Pro
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PowerFour Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Four
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; Power Ice Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 OPR/45.0.2254.144848
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "45.0.2254.144848"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Ice
   os_family: Android
   browser_family: Opera
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Power Ice Evo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Ice Evo
   os_family: Android
   browser_family: Chrome
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Power Ice Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Ice Max
   os_family: Android
   browser_family: Chrome
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Power Rage Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Rage
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Power Rage Evo Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Power Rage Evo
   os_family: Android
   browser_family: Chrome
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Pure_Power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Pure Power
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Razar_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Razar Pro
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tasty) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Tasty
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; HIGHSCREEN; WinWin) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537 UCBrowser/4.2.1.541 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: WinWin
   os_family: Windows Mobile
   browser_family: Unknown
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Zera F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Zera F
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Zera_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Zera S
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Zera-S-Power) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Zera S Power
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Zera U Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: H2
+    brand: Highscreen
     model: Zera U
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HM-G152-FL Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G152
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HM-G303-W Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G303
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; HM-G353-FL Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G353
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HM-G552-FL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G552
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HM-G700-FL Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G700
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HM-G701-FL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: G701
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Haier_HT-I600_TD/I600_MocorDroid2.2_W11.41_V1.00 Release/06.26.2012 Mozilla/5.0 (Linux; U; Android 2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HT-I600
   os_family: Android
   browser_family: Android Browser
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Haier HW-N86W Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HW-N86W
   os_family: Android
   browser_family: Android Browser
@@ -1703,19 +1533,17 @@
   user_agent: Haier_HW-W716_WCDMA/V1 Linux/3.4.5 Android/4.2.2 Release/06.01.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 System/Android 4.2.2
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HW-W716 WCDMA
   os_family: Android
   browser_family: Android Browser
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; Haier HW-W718 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HW-W718
   os_family: Android
   browser_family: Android Browser
@@ -1743,19 +1569,17 @@
   user_agent: Haier_HW-W860_WCDMA/V2 Linux/3.0.13 Android/4.2 Release/04.15.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.1
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HW-W860 WCDMA
   os_family: Android
   browser_family: Android Browser
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Haier HW-W910 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: HW-W910
   os_family: Android
   browser_family: Android Browser
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HM-I557-FL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: I557
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; I6_Infinity) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: I6 Infinity
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HM-N505-FL Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: I8
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HM-N501-FL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: L56
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; HM-N700-FL Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.4.1214 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.4.1214"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: L7
   os_family: Android
   browser_family: Unknown
@@ -1883,7 +1695,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; Haier-SY0880 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -1892,7 +1703,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: SY0880
   os_family: Android
   browser_family: Unknown
@@ -1900,19 +1711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Titan_T1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: Titan T1
   os_family: Android
   browser_family: Chrome
@@ -1920,19 +1729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Titan_T3 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 YaApp_Android/9.85 YaSearchBrowser/9.85
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: Titan T3
   os_family: Android
   browser_family: Chrome
@@ -1940,19 +1747,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; HW-W716 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: W716
   os_family: Android
   browser_family: Android Browser
@@ -1960,19 +1765,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; fr-FR; W716) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: W716
   os_family: Android
   browser_family: Unknown
@@ -1980,19 +1783,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; W757 Build/W757)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: W757
   os_family: Android
   browser_family: Android Browser
@@ -2000,19 +1801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; W860 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: W860
   os_family: Android
   browser_family: Chrome
@@ -2020,19 +1819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; W970 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HA
+    brand: Haier
     model: W970
   os_family: Android
   browser_family: Chrome
@@ -2040,19 +1837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Huadoo_HG04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HD
+    brand: Huadoo
     model: HG04
   os_family: Android
   browser_family: Chrome
@@ -2060,19 +1855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Huadoo HG06) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HD
+    brand: Huadoo
     model: HG06
   os_family: Android
   browser_family: Chrome
@@ -2080,19 +1873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Huadoo HG11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HD
+    brand: Huadoo
     model: HG11
   os_family: Android
   browser_family: Chrome
@@ -2100,19 +1891,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; Huadoo V3 Build/KOT49H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HD
+    brand: Huadoo
     model: V3
   os_family: Android
   browser_family: Opera
@@ -2120,19 +1909,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; Huadoo V4 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HD
+    brand: Huadoo
     model: V4
   os_family: Android
   browser_family: Chrome
@@ -2140,19 +1927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HAFURY MIX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HF
+    brand: Hafury
     model: MIX
   os_family: Android
   browser_family: Chrome
@@ -2160,19 +1945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HAFURY UMAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HF
+    brand: Hafury
     model: UMAX
   os_family: Android
   browser_family: Chrome
@@ -2180,19 +1963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE202N Build/PKQ1.190504.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -2200,19 +1981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HLTE203T Build/QP1A.190711.020; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A5 Pro CC
   os_family: Android
   browser_family: Chrome
@@ -2220,19 +1999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HLTE700T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A6
   os_family: Android
   browser_family: Chrome
@@ -2240,19 +2017,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; HLTE730T Build/PKQ1.190723.001) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.4.988 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.4.988"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: A6L
   os_family: Android
   browser_family: Unknown
@@ -2260,19 +2035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE221E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: E Max
   os_family: Android
   browser_family: Chrome
@@ -2280,19 +2053,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-cn; HS-Hisense E621T Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: E621T
   os_family: Android
   browser_family: Android Browser
@@ -2300,19 +2071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; HITV300C Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: E9
   os_family: Android
   browser_family: Chrome
@@ -2320,19 +2089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; HLTE200T Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F26
   os_family: Android
   browser_family: Chrome
@@ -2340,19 +2107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; HLTE210T Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F28
   os_family: Android
   browser_family: Chrome
@@ -2360,19 +2125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HLTE215T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F29
   os_family: Android
   browser_family: Chrome
@@ -2380,19 +2143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE217T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F30S
   os_family: Android
   browser_family: Chrome
@@ -2400,19 +2161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE227T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: F40
   os_family: Android
   browser_family: Chrome
@@ -2420,19 +2179,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-cn; HLTE500T Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H11
   os_family: Android
   browser_family: Unknown
@@ -2440,19 +2197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; HLTE310T Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H18
   os_family: Android
   browser_family: Chrome
@@ -2460,19 +2215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HLTE310M Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H18
   os_family: Android
   browser_family: Chrome
@@ -2480,19 +2233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; HLTE510T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H20
   os_family: Android
   browser_family: Chrome
@@ -2500,19 +2251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; HLTE510M Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.0.980 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.0.980"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H20
   os_family: Android
   browser_family: Unknown
@@ -2520,19 +2269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE223E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: H30
   os_family: Android
   browser_family: Chrome
@@ -2540,19 +2287,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-CN; HLTE200M Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.5.5.943 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.5.5.943"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HLTE200M
   os_family: Android
   browser_family: Unknown
@@ -2560,19 +2305,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; HLTE212T Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HLTE212T
   os_family: Android
   browser_family: Chrome
@@ -2580,19 +2323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; HLTE300T Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HLTE300T
   os_family: Android
   browser_family: Chrome
@@ -2600,19 +2341,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; HS-E920 Build/GRK39F) UC AppleWebKit/530+ (KHTML, like Gecko) Mobile Safari/530
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "530"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-E920
   os_family: Android
   browser_family: Unknown
@@ -2620,19 +2359,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HS-E968 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-E968
   os_family: Android
   browser_family: Android Browser
@@ -2640,7 +2377,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HS-EG970 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/5.0 (Baidu; P1 4.1.2)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -2649,7 +2385,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-EG970
   os_family: Android
   browser_family: Unknown
@@ -2657,19 +2393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; HS-G610 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-G610
   os_family: Android
   browser_family: Chrome
@@ -2677,19 +2411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HS-I630M Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-I630M
   os_family: Android
   browser_family: Chrome
@@ -2697,19 +2429,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; HS-I630T Build/KVT49L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-I630T
   os_family: Android
   browser_family: Unknown
@@ -2717,19 +2447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; HS-L691 Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-L691
   os_family: Android
   browser_family: Chrome
@@ -2737,13 +2465,12 @@
   user_agent: UNTRUSTED/1.0/HS-T39_TD/1.0 Release/03.03.2011 Threadx/4.0 Mocor/W10 Browser/NF4.0 Profile/MIDP-2.0 Config/CLDC-1.1
   os:
     name: ThreadX
-    short_name: TDX
     version: "4.0"
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-T39
   os_family: Real-time OS
   browser_family: Unknown
@@ -2751,19 +2478,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-CN; HS-T912 Build/MocorDroid2.3.5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.2.559 U3/0.8.0 Mobile Safari/534.30
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.2.559"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-T912
   os_family: Android
   browser_family: Unknown
@@ -2771,19 +2496,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; HS-T958 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.1.0.527 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.1.0.527"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-T958
   os_family: Android
   browser_family: Unknown
@@ -2791,19 +2514,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; HS-T959S1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.598 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.598"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-T959S1
   os_family: Android
   browser_family: Unknown
@@ -2811,19 +2532,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-CN; HS-T96 Build/IML74K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.2.394 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.2.394"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-T96
   os_family: Android
   browser_family: Unknown
@@ -2831,19 +2550,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-CN; HS-U8 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.2.404 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U8
   os_family: Android
   browser_family: Unknown
@@ -2851,19 +2568,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; HS-U820 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U820
   os_family: Android
   browser_family: Android Browser
@@ -2871,19 +2586,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; HS-U850 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U850
   os_family: Android
   browser_family: Android Browser
@@ -2891,19 +2604,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HS-U912 Build/IMM76I) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U912
   os_family: Android
   browser_family: Chrome
@@ -2911,19 +2622,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; HS-U912C Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U912C
   os_family: Android
   browser_family: Android Browser
@@ -2931,19 +2640,17 @@
   user_agent: HS-U929/1.0 Linux/3.4.5 Android/4.2.2 Browser/AppleWebKit534.30 Profile/MIDP-1.0 Configuration/CLDC-1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U929
   os_family: Android
   browser_family: Android Browser
@@ -2951,19 +2658,17 @@
   user_agent: HS-U939/1.0 Linux/3.4.5 Android/4.2.2 Browser/AppleWebKit534.30 Profile/MIDP-1.0 Configuration/CLDC-1.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U939
   os_family: Android
   browser_family: Android Browser
@@ -2971,7 +2676,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HS-U939 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -2980,7 +2684,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U939
   os_family: Android
   browser_family: Unknown
@@ -2988,19 +2692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HS-U950 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "29.0.1547.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U950
   os_family: Android
   browser_family: Chrome
@@ -3008,7 +2710,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HS-U966 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/5.0 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -3017,7 +2718,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U966
   os_family: Android
   browser_family: Unknown
@@ -3025,19 +2726,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; HS-U970 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U970
   os_family: Android
   browser_family: Chrome
@@ -3045,19 +2744,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; HS-U98 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-U98
   os_family: Android
   browser_family: Android Browser
@@ -3065,7 +2762,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; HS-X1 Build/KVT49L) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.74_r1098891.543 NetType/3gnet
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -3074,7 +2770,7 @@
     version: "6.1.0.74.r1098891.543"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-X1
   os_family: Android
   browser_family: Unknown
@@ -3082,19 +2778,17 @@
   user_agent: HS-X68T_LTE/1.0 Android/4.3 Release/20.3.2014 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-X68T
   os_family: Android
   browser_family: Android Browser
@@ -3102,7 +2796,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; HS-X68T Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -3111,7 +2804,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-X68T
   os_family: Android
   browser_family: Unknown
@@ -3119,7 +2812,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; HS-X8C Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -3128,7 +2820,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-X8C
   os_family: Android
   browser_family: Unknown
@@ -3136,19 +2828,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; HS-X8T Build/JSS15Q) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 V1_AND_SQ_5.7.2_260_YYB_D QQ/5.7.2.2490 NetType/WIFI WebP/0.3.0
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: HS-X8T
   os_family: Android
   browser_family: Unknown
@@ -3156,19 +2846,17 @@
   user_agent: Hisense I639M_LTE/1.0 Android/4.4 Release/15.12.2014 Browser/AppleWebKit537.36 Profile/MIDP-2.0 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: I639M LTE
   os_family: Android
   browser_family: Android Browser
@@ -3176,19 +2864,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Hisense I639T Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: I639T
   os_family: Android
   browser_family: Chrome
@@ -3196,19 +2882,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HLTE213T Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 4
   os_family: Android
   browser_family: Chrome
@@ -3216,19 +2900,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; HLTE311T Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1072 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1072"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 4 Pro
   os_family: Android
   browser_family: Unknown
@@ -3236,19 +2918,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE216T Build/PKQ1.190118.001; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 5
   os_family: Android
   browser_family: Chrome
@@ -3256,19 +2936,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE316T Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -3276,19 +2954,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLTE226T Build/PPR1.180610.011;wv) AppleWebKit/537.36(KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: King Kong 6
   os_family: Android
   browser_family: Chrome
@@ -3296,19 +2972,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; I46D1G Build/MOB30M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: Smartfren Andromax R
   os_family: Android
   browser_family: Android Browser
@@ -3316,19 +2990,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; EG680 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: Smartfren Andromax Z
   os_family: Android
   browser_family: Chrome
@@ -3336,19 +3008,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; HLTE501N Build/NGI77B) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.0.1060 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.0.1060"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HI
+    brand: Hisense
     model: V Plus
   os_family: Android
   browser_family: Unknown
@@ -3356,19 +3026,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; HT16 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT16
   os_family: Android
   browser_family: Android Browser
@@ -3376,19 +3044,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Homtom_ht16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT16
   os_family: Android
   browser_family: Chrome
@@ -3396,19 +3062,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; HT17 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT17
   os_family: Android
   browser_family: Android Browser
@@ -3416,19 +3080,17 @@
   user_agent: Dalvik/0.0.0 (Linux; U; Android 0.0.0; HT17Pro Build/ABCDEF)
   os:
     name: Android
-    short_name: AND
     version: "0.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT17Pro
   os_family: Android
   browser_family: Android Browser
@@ -3436,19 +3098,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; HT20 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT20
   os_family: Android
   browser_family: Android Browser
@@ -3456,19 +3116,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HT3 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT3
   os_family: Android
   browser_family: Android Browser
@@ -3476,19 +3134,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HT30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT30
   os_family: Android
   browser_family: Chrome
@@ -3496,19 +3152,17 @@
   user_agent: Dalvik/0.0.0 (Linux; U; Android 0.0.0; HT7 Pro Build/ABCDEF)
   os:
     name: Android
-    short_name: AND
     version: "0.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT7 Pro
   os_family: Android
   browser_family: Android Browser
@@ -3516,19 +3170,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HT7 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT7 Pro
   os_family: Android
   browser_family: Chrome
@@ -3536,19 +3188,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; HOMTOM HT7 Pro Build/LMY49J)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: HT7 Pro
   os_family: Android
   browser_family: Android Browser
@@ -3556,19 +3206,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; HOMTOM NT17Pro Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HM
+    brand: Homtom
     model: NT17Pro
   os_family: Android
   browser_family: Android Browser
@@ -3576,19 +3224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G25523K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Eternity G23
   os_family: Android
   browser_family: Chrome
@@ -3596,19 +3242,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G25524K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Eternity G24
   os_family: Android
   browser_family: Chrome
@@ -3616,19 +3260,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; G24027K Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Eternity G27
   os_family: Android
   browser_family: Chrome
@@ -3636,19 +3278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; W25042L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Eternity W42
   os_family: Android
   browser_family: Chrome
@@ -3656,19 +3296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Ultra Air Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Air
   os_family: Android
   browser_family: Chrome
@@ -3676,19 +3314,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Ultra Energy) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Energy
   os_family: Android
   browser_family: Chrome
@@ -3696,19 +3332,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ultra Energy Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Energy Lite
   os_family: Android
   browser_family: Chrome
@@ -3716,19 +3350,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Ultra Energy Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Energy Plus
   os_family: Android
   browser_family: Chrome
@@ -3736,19 +3368,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ultra Live II Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Live II
   os_family: Android
   browser_family: Chrome
@@ -3756,19 +3386,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ultra Storm Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Storm
   os_family: Android
   browser_family: Chrome
@@ -3776,19 +3404,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ultra Sync Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Sync
   os_family: Android
   browser_family: Chrome
@@ -3796,19 +3422,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ultra Trend Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Trend
   os_family: Android
   browser_family: Chrome
@@ -3816,19 +3440,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Ultra Vision) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Vision
   os_family: Android
   browser_family: Chrome
@@ -3836,19 +3458,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Ultra Wave) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HN
+    brand: Hyundai
     model: Ultra Wave
   os_family: Android
   browser_family: Chrome
@@ -3856,19 +3476,17 @@
   user_agent: HOSIN T50/V1 Linux/3.4.5 Android/4.2.2 Release/03.26.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HO
+    brand: Hosin
     model: T50
   os_family: Android
   browser_family: Android Browser
@@ -3876,7 +3494,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HOSIN T50(OPEN) Build/HOSINT50) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/4.2 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -3885,7 +3502,7 @@
     version: "4.2"
   device:
     type: smartphone
-    brand: HO
+    brand: Hosin
     model: T50(OPEN)
   os_family: Android
   browser_family: Unknown
@@ -3893,19 +3510,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; HOSIN T70 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HO
+    brand: Hosin
     model: T70
   os_family: Android
   browser_family: Unknown
@@ -3913,19 +3528,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; Hosin_U7 Build/HosinU7) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HO
+    brand: Hosin
     model: U7
   os_family: Android
   browser_family: Unknown
@@ -3933,7 +3546,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; HOSIN V70 Build/HOSINA728) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.0.54_r1169949.561 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
@@ -3942,7 +3554,7 @@
     version: "6.2.0.54.r1169949.561"
   device:
     type: smartphone
-    brand: HO
+    brand: Hosin
     model: V70
   os_family: Android
   browser_family: Unknown
@@ -3950,13 +3562,11 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; HP; Elite x3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "15"
     engine: Edge
     engine_version: "15"
@@ -3970,19 +3580,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Hasee E50 T1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HS
+    brand: Hasee
     model: E50 T1
   os_family: Android
   browser_family: Unknown
@@ -3990,19 +3598,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; hasee H45 T3 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HS
+    brand: Hasee
     model: H45 T3
   os_family: Android
   browser_family: Unknown
@@ -4010,7 +3616,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Hasee W50 T2 Build/Hasee) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.5.1 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -4019,7 +3624,7 @@
     version: "6.5.1"
   device:
     type: smartphone
-    brand: HS
+    brand: Hasee
     model: W50 T2
   os_family: Android
   browser_family: Unknown
@@ -4027,19 +3632,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Hasee X50 TS Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HS
+    brand: Hasee
     model: X50 TS
   os_family: Android
   browser_family: Unknown
@@ -4047,19 +3650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HTV32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: "10"
   os_family: Android
   browser_family: Chrome
@@ -4067,19 +3668,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; HTC 608 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: "608"
   os_family: Android
   browser_family: Android Browser
@@ -4087,19 +3686,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; HTC6500LVW 4G Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 6500LVW
   os_family: Android
   browser_family: Android Browser
@@ -4107,19 +3704,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; 7 Mozart; Orange)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 7 Mozart
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -4127,19 +3722,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; 7 Mozart T8698)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 7 Mozart T8698
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -4147,19 +3740,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; HTC; 7 Trophy)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 7 Trophy
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -4167,19 +3758,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; 7 Trophy T8686)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 7 Trophy T8686
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -4187,19 +3776,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ar-eg; HTC_802w Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: 802w
   os_family: Android
   browser_family: Android Browser
@@ -4207,19 +3794,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; HTC-A9192/1.0 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: A9192
   os_family: Android
   browser_family: Android Browser
@@ -4227,19 +3812,17 @@
   user_agent: OneBrowser/4.2.0/Adr(Linux; U; Android 2.3.4; en-us; ADR6325 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "4.2.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ADR6325
   os_family: Android
   browser_family: Unknown
@@ -4247,19 +3830,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ADR6410LVW Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ADR6410LVW
   os_family: Android
   browser_family: Chrome
@@ -4267,19 +3848,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ADR6410LVW 4G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ADR6410LVW 4G
   os_family: Android
   browser_family: Android Browser
@@ -4287,19 +3866,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ADR6425LVW 4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ADR6425LVW 4G
   os_family: Android
   browser_family: Android Browser
@@ -4307,19 +3884,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; HTC_Amaze Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Amaze
   os_family: Android
   browser_family: Android Browser
@@ -4327,19 +3902,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Amaze_4G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Amaze 4G
   os_family: Android
   browser_family: Android Browser
@@ -4347,19 +3920,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Amaze 4G Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Amaze 4G
   os_family: Android
   browser_family: Chrome
@@ -4367,19 +3938,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; Amaze 4G Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Amaze 4G
   os_family: Android
   browser_family: Unknown
@@ -4387,19 +3956,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Sprint APA7373KT Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: APA7373KT (Sprint)
   os_family: Android
   browser_family: Android Browser
@@ -4407,19 +3974,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; en-us; Sprint APA9292KT Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: APA9292KT (Sprint)
   os_family: Android
   browser_family: Android Browser
@@ -4427,19 +3992,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 2PYB2 Build/NRD90M; vi-vn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.117 Mobile Safari/537.36 Puffin/7.0.6.18027AP
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.0.6.18027"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Bolt
   os_family: Android
   browser_family: Unknown
@@ -4447,19 +4010,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HTC Butterfly Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Butterfly
   os_family: Android
   browser_family: Chrome
@@ -4467,19 +4028,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; HTC_Butterfly Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Butterfly
   os_family: Android
   browser_family: Android Browser
@@ -4487,19 +4046,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; butterfly2 Build/KOT49H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: butterfly 2
   os_family: Android
   browser_family: Unknown
@@ -4507,19 +4064,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_C525u-orange-LS/1.17.73.10 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: C525u-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -4527,19 +4082,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; C625b)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: C625b
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -4547,19 +4100,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; HTC_C715c Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: C715c
   os_family: Android
   browser_family: Android Browser
@@ -4567,19 +4118,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC_C715c Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: C715c
   os_family: Android
   browser_family: Android Browser
@@ -4587,19 +4136,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ao; HTC ChaCha A810e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ChaCha A810e
   os_family: Android
   browser_family: Android Browser
@@ -4607,19 +4154,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; pl-pl; HTC_ChaCha_A810e/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ChaCha A810e
   os_family: Android
   browser_family: Android Browser
@@ -4627,19 +4172,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; en-gb; HTC Desire 2.33.161.6 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire
   os_family: Android
   browser_family: Android Browser
@@ -4647,19 +4190,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; HTC Desire Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire
   os_family: Android
   browser_family: Android Browser
@@ -4667,19 +4208,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; HTC Desire Build/GRI40; MildWild CM-8.0 JG Stable) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MildWild
-    short_name: MLD
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire
   os_family: Android
   browser_family: Android Browser
@@ -4687,19 +4226,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-be; HTC_Desire_300 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 300
   os_family: Android
   browser_family: Android Browser
@@ -4707,19 +4244,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-gb; HTC_Desire_500 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 500
   os_family: Android
   browser_family: Android Browser
@@ -4727,19 +4262,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-at; HTC_Desire_500/1.17.112.2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 500
   os_family: Android
   browser_family: Android Browser
@@ -4747,7 +4280,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ch; HTC Desire 500 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -4756,7 +4288,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 500
   os_family: Android
   browser_family: Unknown
@@ -4764,19 +4296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 0PCV1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 510
   os_family: Android
   browser_family: Chrome
@@ -4784,19 +4314,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-ae; HTC_Desire_600_dual_sim Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 600 dual sim
   os_family: Android
   browser_family: Android Browser
@@ -4804,19 +4332,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HTC Desire 601 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 601
   os_family: Android
   browser_family: Chrome
@@ -4824,7 +4350,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HTC 608t Build/JZO54K) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025410 Mobile Safari/533.1 MicroMessenger/6.1.0.57_r1024329.540 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -4833,7 +4358,7 @@
     version: "6.1.0.57.r1024329.540"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 608t
   os_family: Android
   browser_family: Unknown
@@ -4841,19 +4366,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 0PM92 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire 626S
   os_family: Android
   browser_family: Chrome
@@ -4861,19 +4384,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; en-hk; HTC_Desire_A8181 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire A8181
   os_family: Android
   browser_family: Android Browser
@@ -4881,19 +4402,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; Desire_A8181 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire A8181
   os_family: Android
   browser_family: Android Browser
@@ -4901,19 +4420,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; cs-sk; HTC Desire C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C
   os_family: Android
   browser_family: Android Browser
@@ -4921,19 +4438,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; HTC_Desire_C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C
   os_family: Android
   browser_family: Android Browser
@@ -4941,19 +4456,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-de; HTC_Desire_C/2.00.111.3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C
   os_family: Android
   browser_family: Android Browser
@@ -4961,19 +4474,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.3; fr-IE; HTC_Desire_C) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C
   os_family: Android
   browser_family: Unknown
@@ -4981,19 +4492,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC_Desire_C_N/2.01.163.1 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C N
   os_family: Android
   browser_family: Android Browser
@@ -5001,19 +4510,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC_Desire_C-orange-LS Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire C-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -5021,19 +4528,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; HTC Desire HD 1.75.163.2 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD
   os_family: Android
   browser_family: Android Browser
@@ -5041,19 +4546,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; Desire HD Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD
   os_family: Android
   browser_family: Android Browser
@@ -5061,19 +4564,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-tn; HTC_Desire_HD Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD
   os_family: Android
   browser_family: Android Browser
@@ -5081,19 +4582,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HTC Desire HD Build/SVHD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD
   os_family: Android
   browser_family: Chrome
@@ -5101,19 +4600,17 @@
   user_agent: Dalvik/1.4.0 (Linux; U; Android 2.3.5; HTC Desire HD A9191 Build/GRJ90)
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD A9191
   os_family: Android
   browser_family: Android Browser
@@ -5121,19 +4618,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; HTC Desire HD A9191 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire HD A9191
   os_family: Android
   browser_family: Android Browser
@@ -5141,19 +4636,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; tr-de; HTC Desire S Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire S
   os_family: Android
   browser_family: Android Browser
@@ -5161,19 +4654,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; Desire S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire S
   os_family: Android
   browser_family: Android Browser
@@ -5181,19 +4672,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; HTC Desire SV Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire SV
   os_family: Android
   browser_family: Android Browser
@@ -5201,19 +4690,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-in; HTC_Desire_U_dual_sim Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire U dual sim
   os_family: Android
   browser_family: Android Browser
@@ -5221,19 +4708,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-pk; HTC Desire V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire V
   os_family: Android
   browser_family: Android Browser
@@ -5241,19 +4726,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-; HTC_Desire_V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire V
   os_family: Android
   browser_family: Android Browser
@@ -5261,19 +4744,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; hu-hu; HTC Desire V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire V
   os_family: Android
   browser_family: Android Browser
@@ -5281,19 +4762,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-kz; HTC Desire X Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire X
   os_family: Android
   browser_family: Android Browser
@@ -5301,19 +4780,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-ch; HTC_Desire_X Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire X
   os_family: Android
   browser_family: Android Browser
@@ -5321,19 +4798,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-es; HTC_Desire_X-orange-LS/1.14.75.1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Desire X-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -5341,19 +4816,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; HTC_DesireHD Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireHD
   os_family: Android
   browser_family: Android Browser
@@ -5361,19 +4834,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ar-qa; HTC_DesireHD_A9191 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireHD A9191
   os_family: Android
   browser_family: Android Browser
@@ -5381,19 +4852,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-ca; HTC_DesireHD_A9192 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireHD A9192
   os_family: Android
   browser_family: Android Browser
@@ -5401,19 +4870,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; HTC_DesireHD-orange-LS Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireHD-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -5421,19 +4888,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; HTC/DesireS/1.32.163.1 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireS
   os_family: Android
   browser_family: Android Browser
@@ -5441,19 +4906,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; HTC_DesireS_S510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireS S510e
   os_family: Android
   browser_family: Android Browser
@@ -5461,19 +4924,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; HTC_DesireS-orange-LS Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireS-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -5481,19 +4942,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_DesireSV Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireSV
   os_family: Android
   browser_family: Android Browser
@@ -5501,19 +4960,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; pl-pl; HTC_DesireZ_A7272 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: DesireZ A7272
   os_family: Android
   browser_family: Android Browser
@@ -5521,19 +4978,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.0; en-us; HTC_Dream) AppleWebKit/525.10+ (KHTML, like Gecko) Version/3.0.4 Mobile Safari/523.12.2
   os:
     name: Android
-    short_name: AND
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "525.10"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Dream
   os_family: Android
   browser_family: Android Browser
@@ -5541,19 +4996,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; ADR6300 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Droid Incredible
   os_family: Android
   browser_family: Android Browser
@@ -5561,19 +5014,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; ar-eg; ADR6300 Build/GRJ22; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Droid Incredible
   os_family: Android
   browser_family: Chrome
@@ -5581,19 +5032,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ADR6410LRA Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Droid Incredible 3
   os_family: Android
   browser_family: Android Browser
@@ -5601,19 +5050,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC/EVO_3D/3.28.163.1 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO 3D
   os_family: Android
   browser_family: Android Browser
@@ -5621,19 +5068,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; HTC EVO 3D GSM Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO 3D GSM
   os_family: Android
   browser_family: Android Browser
@@ -5641,7 +5086,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Evo 3D GSM Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30HTC-Evo 3D GSM__weibo__4.2.6__android__android4.2.2
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -5650,7 +5094,7 @@
     version: "4.2.6"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Evo 3D GSM
   os_family: Android
   browser_family: Unknown
@@ -5658,19 +5102,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3.1; de-de; Evo 3D GSM Build/JLS36I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 CyanogenMod/10.2/shooteru
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Evo 3D GSM
   os_family: Android
   browser_family: Android Browser
@@ -5678,19 +5120,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-jo; HTC EVO 3D X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO 3D X515m
   os_family: Android
   browser_family: Android Browser
@@ -5698,19 +5138,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-tw; HTC EVO 3D X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO 3D X515m
   os_family: Android
   browser_family: Android Browser
@@ -5718,19 +5156,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC EVO 3D X515m Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.63 Mobile Safari/537.36 OPR/15.0.1162.61541
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "15.0.1162.61541"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO 3D X515m
   os_family: Android
   browser_family: Opera
@@ -5738,19 +5174,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; PG86100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Evo 3G
   os_family: Android
   browser_family: Android Browser
@@ -5758,19 +5192,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; PC36100 Build/GRI40; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Evo 4G
   os_family: Android
   browser_family: Android Browser
@@ -5778,19 +5210,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; EVO3D_X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO3D X515m
   os_family: Android
   browser_family: Android Browser
@@ -5798,19 +5228,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-it; EVO3D_X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: EVO3D X515m
   os_family: Android
   browser_family: Android Browser
@@ -5818,19 +5246,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Windows CE; Smartphone; 320x240; SPV E600; OpVer 20.118.15.755)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "4.01"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Excalibur
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -5838,19 +5264,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-es; HTC/Explorer/1.41.161.3 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Explorer
   os_family: Android
   browser_family: Android Browser
@@ -5858,19 +5282,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-in; HTC Explorer A310e Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Explorer A310e
   os_family: Android
   browser_family: Android Browser
@@ -5878,19 +5300,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-ch; HTC_Explorer_A310e Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Explorer A310e
   os_family: Android
   browser_family: Android Browser
@@ -5898,19 +5318,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; HTC Glacier Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Glacier
   os_family: Android
   browser_family: Unknown
@@ -5918,19 +5336,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; HTC_Gratia_A6380 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Gratia A6380
   os_family: Android
   browser_family: Android Browser
@@ -5938,19 +5354,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; HTC_H1000C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: H1000C
   os_family: Android
   browser_family: Android Browser
@@ -5958,19 +5372,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; HTC_H2000C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: H2000C
   os_family: Android
   browser_family: Android Browser
@@ -5978,19 +5390,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_HD_mini-orange-LS; Windows Phone 6.5.3.5)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5.3.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD mini-orange-LS
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -5998,19 +5408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; cs-cz; NexusHD2 Build/GRK39F) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2
   os_family: Android
   browser_family: Android Browser
@@ -6018,19 +5426,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; NexusHD2 Build/JZO54K; CyanogenMod-10.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2
   os_family: Android
   browser_family: Android Browser
@@ -6038,19 +5444,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; HTC HD2 Build/GRI40; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2
   os_family: Android
   browser_family: Android Browser
@@ -6058,19 +5462,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) Vodafone/1.0/HTC_HD2/3.14.163.3 (04666)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6078,19 +5480,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_HD2_T8585; Windows Phone 6.5)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2 T8585
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6098,19 +5498,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) PPC; 480x800; HTC_HD2_T8585-Orange; OpVer 114.143.2.731
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2 T8585-Orange
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6118,19 +5516,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; HTC_HD2_T8585-Orange; Windows Phone 6.5)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD2 T8585-Orange
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6138,19 +5534,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; HD7)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD7
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6158,19 +5552,17 @@
   user_agent: 'UCWEB/2.0 (Linux; U; Adr 2.2.2; zh-CN; HTC HD7 LTE 4G+ For AT&amp;T) U2/1.0.0 UCBrowser/9.5.1.381 U2/1.0.0 Mobile'
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.1.381"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD7 LTE
   os_family: Android
   browser_family: Unknown
@@ -6178,19 +5570,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/ 7.0; WpsLondonTest; HTC; HD7 T9292)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD7 T9292
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6198,19 +5588,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 8.0; Trident/5.0; IEMobile/9.0; WpsLondonTest; HTC; HD7 T9292)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: HD7 T9292
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6218,19 +5606,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.5; en-gb; HTC Hero Build/CUPCAKE) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Hero
   os_family: Android
   browser_family: Android Browser
@@ -6238,19 +5624,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; XV6975)
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Imagio
   os_family: Windows
   browser_family: Internet Explorer
@@ -6258,19 +5642,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; sr-pl; HTC Incredible S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Incredible S
   os_family: Android
   browser_family: Android Browser
@@ -6278,19 +5660,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC_IncredibleS_S710e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: IncredibleS S710e
   os_family: Android
   browser_family: Android Browser
@@ -6298,19 +5678,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-gb; IncredibleS_S710e Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: IncredibleS S710e
   os_family: Android
   browser_family: Android Browser
@@ -6318,19 +5696,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HTL23 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: J Butterfly
   os_family: Android
   browser_family: Chrome
@@ -6338,19 +5714,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HTL22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: J One
   os_family: Android
   browser_family: Chrome
@@ -6358,19 +5732,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; HTC Legend 2.05.163.1 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Legend
   os_family: Android
   browser_family: Android Browser
@@ -6378,19 +5750,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; HTC Liberty Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Liberty
   os_family: Android
   browser_family: Android Browser
@@ -6398,19 +5768,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; HTC Magic Build/DRC92) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Magic
   os_family: Android
   browser_family: Android Browser
@@ -6418,19 +5786,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; HTC Merge Build/GRJ22; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Merge
   os_family: Android
   browser_family: Android Browser
@@ -6438,19 +5804,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HTC 802d Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ffcs/icity
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Android Browser
@@ -6458,19 +5822,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; de-de; HTC_One/3.63.161.6 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Android Browser
@@ -6478,19 +5840,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; nl-nl; HTC_One Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Android Browser
@@ -6498,19 +5858,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; HTC One Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Chrome
@@ -6518,7 +5876,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; HTCONE Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.1.24.941712.arm
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ARM
   client:
@@ -6527,7 +5884,7 @@
     version: "3.1.24.941712"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ONE
   os_family: Android
   browser_family: Unknown
@@ -6535,19 +5892,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; HTC One Build/KOT49H.H1)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Android Browser
@@ -6555,19 +5910,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-tw; HTC One 801e Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One
   os_family: Android
   browser_family: Android Browser
@@ -6575,19 +5928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 2PQ93) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One A9
   os_family: Android
   browser_family: Chrome
@@ -6595,19 +5946,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HTC One dual sim Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One dual sim
   os_family: Android
   browser_family: Chrome
@@ -6615,19 +5964,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 0PAJ5 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One E8
   os_family: Android
   browser_family: Chrome
@@ -6635,19 +5982,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; fr-fr; HTC One_M8 Build/KOT49H) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.16
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.16"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One M8
   os_family: Android
   browser_family: Android Browser
@@ -6655,19 +6000,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; One M8 Build/LMY48B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One M8
   os_family: Android
   browser_family: Chrome
@@ -6675,19 +6018,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 0PJA10 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One M9
   os_family: Android
   browser_family: Chrome
@@ -6695,19 +6036,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 0PJA2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One M9
   os_family: Android
   browser_family: Chrome
@@ -6715,19 +6054,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; fr-fr; HTC_One_mini Build/JSS15Q) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One mini
   os_family: Android
   browser_family: Android Browser
@@ -6735,7 +6072,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; fr-fr; HTC One mini Build/JSS15Q) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ARM
   client:
@@ -6744,7 +6080,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One mini
   os_family: Android
   browser_family: Unknown
@@ -6752,19 +6088,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; fr-ch; HTC_One_mini/3.10.161.6 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One mini
   os_family: Android
   browser_family: Android Browser
@@ -6772,19 +6106,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-; HTC One S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6792,19 +6124,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ro-ro; HTC One S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6812,19 +6142,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; HTC_One_S Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6832,19 +6160,17 @@
   user_agent: HTC One S Linux/3.0.13 Android/4.1.1 Release/11.07.2012 Browser/AppleWebKit534.30 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/534.30 Android 4.0.1;
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6852,19 +6178,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-gb; HTC_One_S/3.16.161.9 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6872,19 +6196,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; HTC One S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S
   os_family: Android
   browser_family: Android Browser
@@ -6892,19 +6214,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-es; HTC_One_S-orange-LS Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One S-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -6912,19 +6232,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; HTC One SV Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One SV
   os_family: Android
   browser_family: Android Browser
@@ -6932,19 +6250,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ar-; HTC One V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One V
   os_family: Android
   browser_family: Android Browser
@@ -6952,19 +6268,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-th; HTC One V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One V
   os_family: Android
   browser_family: Android Browser
@@ -6972,19 +6286,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; nl-nl; HTC_One_V Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One V
   os_family: Android
   browser_family: Android Browser
@@ -6992,19 +6304,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-tw; HTC One X Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7012,19 +6322,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; HTC One X Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7032,19 +6340,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; PJ83100/2.20.502.7 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7052,19 +6358,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; HTC_One_X Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7072,19 +6376,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; nl-nl; HTC_One_X/4.17.161.2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7092,19 +6394,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; One X Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Chrome
@@ -7112,19 +6412,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; HTC One X Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 CyanogenMod/10.1.2/endeavoru
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X
   os_family: Android
   browser_family: Android Browser
@@ -7132,19 +6430,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; bg-bg; HTC One X+ Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X+
   os_family: Android
   browser_family: Android Browser
@@ -7152,19 +6448,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; En-bg; X525a Build/JRO03C) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One X+
   os_family: Android
   browser_family: Android Browser
@@ -7172,19 +6466,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-gb; HTC_One_XL Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One XL
   os_family: Android
   browser_family: Android Browser
@@ -7192,19 +6484,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; HTC One XL Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One XL
   os_family: Android
   browser_family: Android Browser
@@ -7212,19 +6502,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; HTC/One_XL/5.08.163.2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: One XL
   os_family: Android
   browser_family: Android Browser
@@ -7232,19 +6520,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; HTC_OneSV Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: OneSV
   os_family: Android
   browser_family: Android Browser
@@ -7252,19 +6538,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-sg; HTC_OneXplus Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: OneXplus
   os_family: Android
   browser_family: Android Browser
@@ -7272,19 +6556,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ca; HTC Panache Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Panache
   os_family: Android
   browser_family: Android Browser
@@ -7292,19 +6574,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; fr-fr;HTC_PG09410/1.30.502.1 Build/HMJ15) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: PG09410
   os_family: Android
   browser_family: Android Browser
@@ -7312,19 +6592,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; HTC_PH06130/1.23.502.1 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: PH06130
   os_family: Android
   browser_family: Android Browser
@@ -7332,19 +6610,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; HTC_PN071-orange-LS/1.28.73.10 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: PN071-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -7352,19 +6628,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Radar 4G)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Radar 4G
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7372,19 +6646,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Radar C110e)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Radar C110e
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7392,19 +6664,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-eg; HTC_Rhyme_S510b Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Rhyme S510b
   os_family: Android
   browser_family: Android Browser
@@ -7412,19 +6682,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Rhyme S510b Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Rhyme S510b
   os_family: Android
   browser_family: Chrome
@@ -7432,19 +6700,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-ca; HTC_Ruby Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Ruby
   os_family: Android
   browser_family: Android Browser
@@ -7452,19 +6718,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.6) HTCS620;Smartphone;320x240
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.6"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: S620
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7472,19 +6736,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-gb; HTC_Salsa_C510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Salsa C510e
   os_family: Android
   browser_family: Android Browser
@@ -7492,19 +6754,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Schubert)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Schubert
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7512,19 +6772,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; HTC/Sensation/3.32.161.52 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation
   os_family: Android
   browser_family: Android Browser
@@ -7532,19 +6790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Sensation Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation
   os_family: Android
   browser_family: Chrome
@@ -7552,19 +6808,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; SensationXE_Beats_Z715e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE Beats Z715e
   os_family: Android
   browser_family: Android Browser
@@ -7572,19 +6826,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.4; en-US; HTC_Sensation_XE_with_Beats_Audio) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio
   os_family: Android
   browser_family: Unknown
@@ -7592,19 +6844,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-de; HTC Sensation XE with Beats Audio Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio
   os_family: Android
   browser_family: Android Browser
@@ -7612,19 +6862,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Sensation XE with Beats Audio Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio
   os_family: Android
   browser_family: Chrome
@@ -7632,19 +6880,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-au; HTC Sensation XE with Beats Audio Z715a Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio Z715a
   os_family: Android
   browser_family: Android Browser
@@ -7652,19 +6898,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; HTC Sensation XE with Beats Audio Z715e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio Z715e
   os_family: Android
   browser_family: Android Browser
@@ -7672,19 +6916,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Sensation XE with Beats Audio Z715e Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XE with Beats Audio Z715e
   os_family: Android
   browser_family: Chrome
@@ -7692,19 +6934,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; SensationXL_Beats_X315e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XL Beats X315e
   os_family: Android
   browser_family: Android Browser
@@ -7712,19 +6952,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-ch; HTC Sensation XL with Beats Audio X315e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation XL with Beats Audio X315e
   os_family: Android
   browser_family: Android Browser
@@ -7732,19 +6970,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-tw; HTC Sensation Z710e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation Z710e
   os_family: Android
   browser_family: Android Browser
@@ -7752,19 +6988,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-gb; Sensation_Z710e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation Z710e
   os_family: Android
   browser_family: Android Browser
@@ -7772,19 +7006,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; Sensation_Z710e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation Z710e
   os_family: Android
   browser_family: Android Browser
@@ -7792,19 +7024,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC_Sensation-orange-LS Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Sensation-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -7812,19 +7042,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; HTC_SensationXE_Beats_Z715e Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: SensationXE Beats Z715e
   os_family: Android
   browser_family: Android Browser
@@ -7832,19 +7060,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; HTC_SensationXL_Beats-orange-LS Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: SensationXL Beats-orange-LS
   os_family: Android
   browser_family: Android Browser
@@ -7852,19 +7078,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0) HTC_Snap_S510
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Snap S510
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7872,19 +7096,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HTC; Spark)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Spark
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7892,19 +7114,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; HTC_T120C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T120C
   os_family: Android
   browser_family: Android Browser
@@ -7912,19 +7132,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC_T327w Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T327w
   os_family: Android
   browser_family: Android Browser
@@ -7932,19 +7150,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-ca; HTC T328w Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T328w
   os_family: Android
   browser_family: Android Browser
@@ -7952,19 +7168,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_T329w Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T329w
   os_family: Android
   browser_family: Android Browser
@@ -7972,19 +7186,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; HTC T528d Build/JRO03H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.2.404 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T528d
   os_family: Android
   browser_family: Unknown
@@ -7992,19 +7204,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; HTC_T528w Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: T528w
   os_family: Android
   browser_family: Android Browser
@@ -8012,19 +7222,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; ADR6400L 4G Build/GRJ22) AppleWebKit/533.1 (KHTML
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: ThunderBolt
   os_family: Android
   browser_family: Android Browser
@@ -8032,19 +7240,17 @@
   user_agent: HTC_Touch_3G_T3232 Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 7.11)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.11"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Touch 3G T3232
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8052,19 +7258,17 @@
   user_agent: HTC_Touch2_T3333 Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 8.12; MSIEMobile 6.0)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "8.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Touch2 T3333
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8072,19 +7276,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 2PZC5 Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: U11
   os_family: Android
   browser_family: Chrome
@@ -8092,19 +7294,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HTV33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: U11
   os_family: Android
   browser_family: Chrome
@@ -8112,19 +7312,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 601HT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: U11
   os_family: Android
   browser_family: Chrome
@@ -8132,19 +7330,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HTC Velocity 4G Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Velocity 4G
   os_family: Android
   browser_family: Chrome
@@ -8152,19 +7348,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; HTC_Velocity_4G_X710s Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Velocity 4G X710s
   os_family: Android
   browser_family: Android Browser
@@ -8172,19 +7366,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; pl-pl; HTC Vision Build/GRI40; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Vision
   os_family: Android
   browser_family: Android Browser
@@ -8192,19 +7384,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ca; HTC-Vivo Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Vivo
   os_family: Android
   browser_family: Android Browser
@@ -8212,19 +7402,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HTC VLE_U Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: VLE U
   os_family: Android
   browser_family: Chrome
@@ -8232,19 +7420,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows CE; IEMobile 6.12) Smartphone; 240x320; SPV E650; OpVer 22.114.2.733
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "6.12"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Vox
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8252,19 +7438,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-es; HTC Wildfire 2.24.164.1 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire
   os_family: Android
   browser_family: Android Browser
@@ -8272,19 +7456,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; HTC Wildfire Build/GRI40; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire
   os_family: Android
   browser_family: Android Browser
@@ -8292,19 +7474,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; en-sg; HTC_Wildfire_A3333 Build/FRG83D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire A3333
   os_family: Android
   browser_family: Android Browser
@@ -8312,19 +7492,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Wildfire E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/54.3.2672.50220
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "54.3.2672.50220"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire E
   os_family: Android
   browser_family: Opera
@@ -8332,19 +7510,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; HTC Wildfire S A510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire S A510e
   os_family: Android
   browser_family: Android Browser
@@ -8352,19 +7528,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Wildfire S A510e Build/ASN0020121128; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Wildfire S A510e
   os_family: Android
   browser_family: Android Browser
@@ -8372,19 +7546,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; Windows Phone 8S by HTC)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Windows Phone 8S by HTC
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8392,19 +7564,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HTC; Windows Phone 8X by HTC)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: Windows Phone 8X by HTC
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8412,19 +7582,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; HTC_X515C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: X515C
   os_family: Android
   browser_family: Android Browser
@@ -8432,19 +7600,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; HTC_X515E Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: X515E
   os_family: Android
   browser_family: Android Browser
@@ -8452,19 +7618,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HTC X515m Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HT
+    brand: HTC
     model: X515m
   os_family: Android
   browser_family: Android Browser
@@ -8472,19 +7636,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HUAWEI; 4Afrika)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: 4Afrika
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8492,19 +7654,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-AL00a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: 9S
   os_family: Android
   browser_family: Chrome
@@ -8512,19 +7672,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-TL00a Build/HUAWEIPOT-TL00a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36 OPR/46.1.2246.127339
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "46.1.2246.127339"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: 9S
   os_family: Android
   browser_family: Opera
@@ -8532,19 +7690,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-CN; U9500 Build/HuaweiU9500) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend D1
   os_family: Android
   browser_family: Unknown
@@ -8552,19 +7708,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HUAWEI Z100-UL00 Build/HuaweiZ100-UL00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend D3
   os_family: Android
   browser_family: Unknown
@@ -8572,19 +7726,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; U8818 Build/HuaweiU8818) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G300
   os_family: Android
   browser_family: Unknown
@@ -8592,19 +7744,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; G527-U081) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G527
   os_family: Android
   browser_family: Chrome
@@ -8612,19 +7762,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; G620S-L01 Build/HuaweiG620S-L01C150B265) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G620S
   os_family: Android
   browser_family: Chrome
@@ -8632,19 +7780,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; G620S-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G620S
   os_family: Android
   browser_family: Chrome
@@ -8652,19 +7798,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; C8817D Build/XXXXX C8817D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G620S
   os_family: Android
   browser_family: Chrome
@@ -8672,19 +7816,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; G630-U251) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G630
   os_family: Android
   browser_family: Chrome
@@ -8692,19 +7834,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; G7-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G7
   os_family: Android
   browser_family: Chrome
@@ -8712,19 +7852,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; G7-TL00 Build/G7-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G7
   os_family: Android
   browser_family: Android Browser
@@ -8732,19 +7870,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HUAWEI G730-C00 Build/HuaweiG730-C00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MApi 1.0 (com.dianping.v1 7.0.0 om_sd_yingyongbao HUAWEI_G730-C00; Android 4.1.2) MApi 1.0 (com.dianping.v1 7.0.0 om_sd_yingyongbao HUAWEI_G730-C00; Android 4.1.2) efte/1.0 (efte-for-android)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend G730
   os_family: Android
   browser_family: Android Browser
@@ -8752,19 +7888,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; U9200 Build/HuaweiU9200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend P1
   os_family: Android
   browser_family: Chrome
@@ -8772,19 +7906,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; H1711) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend XT2
   os_family: Android
   browser_family: Chrome
@@ -8792,19 +7924,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8812,19 +7942,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8832,19 +7960,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8852,19 +7978,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8872,19 +7996,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U43) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8892,19 +8014,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Y221-U53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y221
   os_family: Android
   browser_family: Chrome
@@ -8912,19 +8032,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.3; zh-CN; HUAWEI Y320-T00) U2/1.0.0 UCBrowser/9.5.0.360 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y320
   os_family: Android
   browser_family: Unknown
@@ -8932,19 +8050,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; tr-tr; HUAWEI Y320-U10 Build/HUAWEIY320-U10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y320
   os_family: Android
   browser_family: Android Browser
@@ -8952,19 +8068,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Y320-U10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.2729.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.2729.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y320
   os_family: Android
   browser_family: Chrome
@@ -8972,19 +8086,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Bucare Y330-U05 Build/BucareY330-U05) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y330
   os_family: Android
   browser_family: Chrome
@@ -8992,19 +8104,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Y541-U02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ascend Y5C
   os_family: Android
   browser_family: Chrome
@@ -9012,19 +8122,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.2.2; zh-cn; HW-HUAWEI_C8500S/C8500SV100R001C92B627SP01; 240*320; CTC/2.0) AppleWebKit/533.1 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: C8500S
   os_family: Android
   browser_family: Android Browser
@@ -9032,19 +8140,17 @@
   user_agent: MQQBrowser/25/Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; HUAWEI C8812 Build/HuaweiC8812) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "25"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: C8812
   os_family: Android
   browser_family: Unknown
@@ -9052,19 +8158,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_C8813/C8813V100R001C92B169; 480*854; CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: C8813
   os_family: Android
   browser_family: Android Browser
@@ -9072,19 +8176,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-CN; HUAWEI C8813Q Build/HuaweiC8813Q) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.2.365 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.2.365"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: C8813Q
   os_family: Android
   browser_family: Unknown
@@ -9092,19 +8194,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HW-HUAWEI_C8815/C8815V100R001C92B130; 540*960; CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: C8815
   os_family: Android
   browser_family: Android Browser
@@ -9112,19 +8212,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ART-AL00x Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10
   os_family: Android
   browser_family: Chrome
@@ -9132,19 +8230,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; ART-AL00m Build/XXXXX ART-AL00m) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10
   os_family: Android
   browser_family: Unknown
@@ -9152,19 +8248,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; ART-TL00x Build/XXXXX ART-TL00x) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10
   os_family: Android
   browser_family: Unknown
@@ -9172,19 +8266,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; STK-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -9192,19 +8284,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; STK-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -9212,19 +8302,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MED-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10E
   os_family: Android
   browser_family: Chrome
@@ -9232,19 +8320,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MED-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10E
   os_family: Android
   browser_family: Chrome
@@ -9252,19 +8338,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AQM-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10S
   os_family: Android
   browser_family: Chrome
@@ -9272,19 +8356,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AQM-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 10S
   os_family: Android
   browser_family: Chrome
@@ -9292,19 +8374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TAG-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 5S
   os_family: Android
   browser_family: Chrome
@@ -9312,19 +8392,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TAG-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 5S
   os_family: Android
   browser_family: Chrome
@@ -9332,19 +8410,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TAG-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 5S
   os_family: Android
   browser_family: Chrome
@@ -9352,19 +8428,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NCE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 6
   os_family: Android
   browser_family: Chrome
@@ -9372,19 +8446,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NCE-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 6
   os_family: Android
   browser_family: Chrome
@@ -9392,19 +8464,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-CN; NCE-TL10 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.2.1072 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.2.1072"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 6
   os_family: Android
   browser_family: Unknown
@@ -9412,19 +8482,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 6S
   os_family: Android
   browser_family: Chrome
@@ -9432,19 +8500,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 6S
   os_family: Android
   browser_family: Chrome
@@ -9452,19 +8518,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7
   os_family: Android
   browser_family: Chrome
@@ -9472,19 +8536,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7
   os_family: Android
   browser_family: Chrome
@@ -9492,19 +8554,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRT-AL00 Build/HONORTRT-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7 Plus
   os_family: Android
   browser_family: Chrome
@@ -9512,19 +8572,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRT-AL00A Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7 Plus
   os_family: Android
   browser_family: Chrome
@@ -9532,19 +8590,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FIG-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7S
   os_family: Android
   browser_family: Chrome
@@ -9552,19 +8608,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FIG-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7S
   os_family: Android
   browser_family: Chrome
@@ -9572,19 +8626,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FIG-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.119 YaBrowser/19.3.2.347.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.3.2.347.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 7S
   os_family: Android
   browser_family: Unknown
@@ -9592,19 +8644,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8
   os_family: Android
   browser_family: Chrome
@@ -9612,19 +8662,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8
   os_family: Android
   browser_family: Chrome
@@ -9632,19 +8680,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-TL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8
   os_family: Android
   browser_family: Chrome
@@ -9652,19 +8698,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; zh-Hans-CN; LDN-TL00 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Quark/4.1.2.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "4.1.2.133"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8
   os_family: Android
   browser_family: Chrome
@@ -9672,19 +8716,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ATU-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8e
   os_family: Android
   browser_family: Chrome
@@ -9692,19 +8734,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ATU-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 8e
   os_family: Android
   browser_family: Chrome
@@ -9712,19 +8752,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; MRD-TL00 Build/HUAWEIMRD-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 9e
   os_family: Android
   browser_family: Chrome
@@ -9732,19 +8770,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Enjoy 9e
   os_family: Android
   browser_family: Chrome
@@ -9752,19 +8788,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; U8665 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Fusion 2
   os_family: Android
   browser_family: Chrome
@@ -9772,19 +8806,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; G735-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play
   os_family: Android
   browser_family: Chrome
@@ -9792,19 +8824,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; G735-L12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play
   os_family: Android
   browser_family: Chrome
@@ -9812,19 +8842,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; G735-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play
   os_family: Android
   browser_family: Chrome
@@ -9832,19 +8860,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CHC-U01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play Mini
   os_family: Android
   browser_family: Chrome
@@ -9852,19 +8878,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CHC-U03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play Mini
   os_family: Android
   browser_family: Chrome
@@ -9872,19 +8896,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CHC-U23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G Play Mini
   os_family: Android
   browser_family: Chrome
@@ -9894,13 +8916,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: ""
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G2800
   os_family: Unknown
   browser_family: Unknown
@@ -9908,19 +8929,17 @@
   user_agent: MQQBrowser/3.4/Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; HUAWEI G510-0010 Build/HuaweiG510-0010) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "3.4"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G510-0010
   os_family: Android
   browser_family: Unknown
@@ -9928,19 +8947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; HuaweiG510-0100 Build/HuaweiG510-0100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G510-0100
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-6.yml
+++ b/Tests/fixtures/smartphone-6.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; HUAWEI G525-U00 Build/HuaweiG525-U00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G525-U00
   os_family: Android
   browser_family: Android Browser
@@ -23,7 +21,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.2; zh-cn; HUAWEI G610-C00 Build/HuaweiG610-C00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/0_0.4_diordna_0_0/LUN_61_0.0_LUN/7300001a/EEB27C92151A0822DA4BE5D066926039%7CA95B2008/1'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
@@ -32,7 +29,7 @@
     version: "0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G610-C00
   os_family: Android
   browser_family: Unknown
@@ -40,19 +37,17 @@
   user_agent: Mozilla 5.0 (Linux; U; Android 4.1.2; en-us; HUAWEI G610-C00 Build HuaweiG610-C00) UC AppleWebKit 534.31 (KHTML, like Gecko) Mobile Safari 534.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G610-C00
   os_family: Android
   browser_family: Unknown
@@ -60,19 +55,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; HUAWEI G610-U00 Build/HuaweiG610-U00) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 OneBrowser/4.1.2 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: ONE Browser
-    short_name: OE
     version: "4.1.2"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G610-U00
   os_family: Android
   browser_family: Unknown
@@ -80,19 +73,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; G621-TL00M Build/HonorG621-TL00M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G621
   os_family: Android
   browser_family: Chrome
@@ -100,7 +91,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; G621-TL00 Build/HonorG621-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 MicroMessenger/6.0.2.56_r958800.520 NetType/cmnet
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -109,7 +99,7 @@
     version: "6.0.2.56.r958800.520"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G621
   os_family: Android
   browser_family: Unknown
@@ -119,13 +109,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q03C"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G6310
   os_family: Unknown
   browser_family: Unknown
@@ -133,19 +122,17 @@
   user_agent: 'Huawei/1.0/HUAWEI-G6609   Browser/Opera MMS/1.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 Opera/9.80 (MTK; Nucleus; Opera Mobi/4000; U; fr-FR) Presto/2.5.28 Version/10.10'
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "10.10"
     engine: Presto
     engine_version: "2.5.28"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G6609
   os_family: Real-time OS
   browser_family: Opera
@@ -153,19 +140,17 @@
   user_agent: HUAWEI_G6800 (MRE2.3.00(25600) resolution240320 chipsetMT6255 touch1 tpannel1 camera gsensor keyboardqwerty) MAUI/MAUI.11B.W12.12.MP.V2 Release/31.12.2010 Browser/Opera Profile/MIDP-2.0 Configuration/CLDC-1.1 Sync/SyncClient1.1 Opera/9.80 (MTK; Nucleus;
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: G6800
   os_family: Real-time OS
   browser_family: Opera
@@ -173,19 +158,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: GR3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -193,19 +176,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: GR3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -213,19 +194,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KII-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: GR5
   os_family: Android
   browser_family: Chrome
@@ -233,19 +212,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLL-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: GR5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -253,19 +230,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RIO-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: GX8
   os_family: Android
   browser_family: Chrome
@@ -273,19 +248,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Huawei-H867G Build/HuaweiH867G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: H867G
   os_family: Android
   browser_family: Chrome
@@ -293,19 +266,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HUAWEI H881C Build/HuaweiH881C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: H881C
   os_family: Android
   browser_family: Chrome
@@ -313,19 +284,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; Huawei; H883G; HuaweiH883G)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: H883G
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -333,19 +302,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; U8860 Build/HuaweiU8860) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor
   os_family: Android
   browser_family: Android Browser
@@ -353,19 +320,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; COL-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10
   os_family: Android
   browser_family: Chrome
@@ -373,19 +338,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HRY-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -393,19 +356,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HRY-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -413,19 +374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HRY-LX1MEB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -433,19 +392,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HRY-AL00a Build/HRY-AL00a; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -453,19 +410,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HRY-LX1T Build/HONORHRY-LX1T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.128"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 10I
   os_family: Android
   browser_family: Chrome
@@ -473,19 +428,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HUAWEI U9508 Build/HuaweiU9508) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 2
   os_family: Android
   browser_family: Chrome
@@ -493,19 +446,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YAL-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20
   os_family: Android
   browser_family: Chrome
@@ -513,19 +464,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YAL-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20
   os_family: Android
   browser_family: Chrome
@@ -533,19 +482,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; YAL-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20
   os_family: Android
   browser_family: Chrome
@@ -553,19 +500,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LRA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20 Lite
   os_family: Android
   browser_family: Chrome
@@ -573,19 +518,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YAL-L41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20 Pro
   os_family: Android
   browser_family: Chrome
@@ -593,19 +536,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YAL-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20 Pro
   os_family: Android
   browser_family: Chrome
@@ -613,19 +554,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HRY-AL00Ta Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36 T7/11.11
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20I
   os_family: Android
   browser_family: Chrome
@@ -633,19 +572,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HRY-AL00T Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20I
   os_family: Android
   browser_family: Chrome
@@ -653,19 +590,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YAL-AL50) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20S
   os_family: Android
   browser_family: Chrome
@@ -673,19 +608,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX1H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 OPR/55.1.2719.50626
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "55.1.2719.50626"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 20S
   os_family: Android
   browser_family: Opera
@@ -693,19 +626,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MXW-AN00 Build/HONORMXW-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30
   os_family: Android
   browser_family: Chrome
@@ -713,19 +644,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; BMH-AN10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30
   os_family: Android
   browser_family: Chrome
@@ -733,19 +662,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; BMH-AN20 Build/XXXXX BMH-AN20X) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30
   os_family: Android
   browser_family: Unknown
@@ -753,19 +680,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-cn; EBG-AN00 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30 Pro
   os_family: Android
   browser_family: Unknown
@@ -773,19 +698,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; EBG-AN10 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.0.2.995 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.0.2.995"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30 Pro Plus
   os_family: Android
   browser_family: Unknown
@@ -793,19 +716,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; CDY-AN90 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1079 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1079"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 30S
   os_family: Android
   browser_family: Unknown
@@ -813,19 +734,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; H30-U10 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Chrome
@@ -833,19 +752,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; H30-T00 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Unknown
@@ -853,19 +770,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.2.2; zh-CN; H30-T10) U2/1.0.0 UCBrowser/9.6.2.404 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Unknown
@@ -873,19 +788,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; HW-H30-C00/H30-C00V100R001C92B180; 1280*720; CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Android Browser
@@ -893,19 +806,17 @@
   user_agent: HONOR_H30-L01M_TD/5.0 Android/4.4.2 (Linux; U; Android 4.4.2; zh-cn) Release/07.10.2014 Browser/WAP2.0 (AppleWebKit/537.36) Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Android Browser
@@ -913,7 +824,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; HONOR H30-L01M Build/HonorH30-L01M) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.0.1 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -922,7 +832,7 @@
     version: "6.0.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Unknown
@@ -930,19 +840,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; HONOR H30-L02 Build/HonorH30-L02) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Unknown
@@ -950,7 +858,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; HONOR H30-L01 Build/HonorH30-L01) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.1.0.74_r1098891.543 NetType/WIFI
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -959,7 +866,7 @@
     version: "6.1.0.74.r1098891.543"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C
   os_family: Android
   browser_family: Unknown
@@ -967,19 +874,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; Hol-U19 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3C Lite
   os_family: Android
   browser_family: Chrome
@@ -987,19 +892,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HUAWEI G750-T01 Build/HuaweiG750-T01) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 MApi 1.0 (com.dianping.v1 7.0.0 om_sd_sogousz1 HUAWEI_G750-T01; Android 4.4.2) MApi 1.0 (com.dianping.v1 7.0.0 om_sd_sogousz1 HUAWEI_G750-T01; Android 4.4.2) efte/1.0 (efte-for-android)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 3X
   os_family: Android
   browser_family: Chrome
@@ -1007,19 +910,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-cn; SCL-TL00H Build/HonorSCL-TL00H) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4A
   os_family: Android
   browser_family: Unknown
@@ -1027,19 +928,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-CN; SCL-CL00 Build/HonorSCL-CL00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4A
   os_family: Android
   browser_family: Unknown
@@ -1047,7 +946,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-cn; SCL-AL00 Build/HonorSCL-AL00) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.51_rdf8da56.600 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -1056,7 +954,7 @@
     version: "6.2.4.51.rdf8da56.600"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4A
   os_family: Android
   browser_family: Unknown
@@ -1064,19 +962,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CHM-U01 Build/HonorCHM-U01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4C
   os_family: Android
   browser_family: Chrome
@@ -1084,19 +980,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AQM-AL10 Build/HONORAQM-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4T Pro
   os_family: Android
   browser_family: Chrome
@@ -1104,19 +998,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; Che2-TL00M Build/HonorChe2-TL00M) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/6.1.1.0 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "6.1.1.0"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Baidu
@@ -1124,19 +1016,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Che2-L11 Build/HonorChe2-L11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
@@ -1144,19 +1034,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CHE2-L12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
@@ -1164,19 +1052,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Che2-UL00 Build/HonorChe2-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
@@ -1184,19 +1070,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; Che2-TL00 Build/HonorChe2-TL00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.1.597 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.1.597"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Unknown
@@ -1204,7 +1088,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; CHE-TL00H Build/HonorCHE-TL00H) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1213,7 +1096,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Unknown
@@ -1221,7 +1104,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; Che2-TL00H Build/HonorChe2-TL00H) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1230,7 +1112,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Unknown
@@ -1238,19 +1120,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; HW-Che1-CL10 Build/Che1-CL10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Android Browser
@@ -1258,19 +1138,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; Che1-CL10 Build/Che1-CL10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.2.559 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.2.559"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Unknown
@@ -1278,19 +1156,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; Che1-CL20 Build/Che1-CL20) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.1.576 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.1.576"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Unknown
@@ -1298,19 +1174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Che1-L04 Build/Che1-L04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
@@ -1318,19 +1192,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Che2-L23 Build/HonorChe2-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 4X
   os_family: Android
   browser_family: Chrome
@@ -1338,19 +1210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CUN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5 Play
   os_family: Android
   browser_family: Chrome
@@ -1358,19 +1228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CUN-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5 Play
   os_family: Android
   browser_family: Chrome
@@ -1378,19 +1246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAM-AL00 Build/HONORCAM-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5A
   os_family: Android
   browser_family: Chrome
@@ -1398,19 +1264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAM-TL00 Build/HONORCAM-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5A
   os_family: Android
   browser_family: Chrome
@@ -1418,19 +1282,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAM-TL00H Build/HONORCAM-TL00H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5A
   os_family: Android
   browser_family: Chrome
@@ -1438,19 +1300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-L51 Build/HONORNEM-L51) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C
   os_family: Android
   browser_family: Chrome
@@ -1458,19 +1318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-AL10 Build/HONORNEM-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C
   os_family: Android
   browser_family: Chrome
@@ -1478,19 +1336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-UL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C
   os_family: Android
   browser_family: Chrome
@@ -1498,19 +1354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C
   os_family: Android
   browser_family: Chrome
@@ -1518,19 +1372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-TL00H Build/HONORNEM-TL00H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -1538,19 +1390,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NEM-L22 Build/HONORNEM-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5C Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -1558,19 +1408,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KIW-L22 Build/HONORKIW-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1578,19 +1426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KIW-L24 Build/HONORKIW-L24) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1598,19 +1444,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KIW-CL00 Build/HONORKIW-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1618,19 +1462,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KIW-L21 Build/HONORKIW-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1638,19 +1480,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KIW-AL10 Build/HONORKIW-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1658,19 +1498,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KIW-UL00 Build/HONORKIW-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1678,19 +1516,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KIW-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Chrome
@@ -1698,19 +1534,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-CN; KIW-TL00H Build/HONORKIW-TL00H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 UCBrowser/11.7.0.953 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.7.0.953"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Unknown
@@ -1718,19 +1552,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; KIW-L23 Build/NMF26V)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 5X
   os_family: Android
   browser_family: Android Browser
@@ -1738,19 +1570,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HW-H60-J1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Chrome
@@ -1758,19 +1588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; H60-L01 Build/HDH60-L01) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Chrome
@@ -1778,19 +1606,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; H60-L03 Build/HDH60-L03) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Chrome
@@ -1798,19 +1624,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; H60-L11 Build/HDH60-L11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Chrome
@@ -1818,7 +1642,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; H60-L02) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 baidubrowser/5.3.4.0 (Baidu; P1 4.3.1) tieba/6.7.2 BMW
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1827,7 +1650,7 @@
     version: "6.7.2"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Unknown
@@ -1835,19 +1658,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; H60-L04) U2/1.0.0 UCBrowser/9.3.1.476 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.1.476"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Unknown
@@ -1855,7 +1676,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; H60-L12 Build/HDH60-L12) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_TW
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1864,7 +1684,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6
   os_family: Android
   browser_family: Unknown
@@ -1872,19 +1692,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-TL10 Build/HONORMYA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6 Play
   os_family: Android
   browser_family: Chrome
@@ -1892,19 +1710,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; PE-TL00M AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6 Plus
   os_family: Android
   browser_family: Chrome
@@ -1912,19 +1728,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; PE-TL20 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6 Plus
   os_family: Android
   browser_family: Chrome
@@ -1932,19 +1746,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PE-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6 Plus
   os_family: Android
   browser_family: Chrome
@@ -1952,19 +1764,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 6.0; PE-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.2.90.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.2.90.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6 Plus
   os_family: Android
   browser_family: Unknown
@@ -1972,7 +1782,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DLI-AL10 Build/HONORDLI-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/35.0.1916.138 Mobile Safari/537.36 T7/7.4 baiduboxapp/8.1 (Baidu; P1 7.0)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -1981,7 +1790,7 @@
     version: "8.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6A
   os_family: Android
   browser_family: Unknown
@@ -1989,19 +1798,17 @@
   user_agent: Mozilla/5.0(Linux; Android 7.0; DLI-L42 Build/HONORDLI-L42)AppleWebKit/537.36(KHTML, like Gecko)Chrome/61.0.3163.98MobileSafari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6A
   os_family: Android
   browser_family: Chrome
@@ -2009,19 +1816,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DLI-TL20 Build/HONORDLI-TL20; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36 YandexSearch/7.20
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6A
   os_family: Android
   browser_family: Chrome
@@ -2029,19 +1834,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DLI-L22 Build/HONORDLI-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6A
   os_family: Android
   browser_family: Chrome
@@ -2049,19 +1852,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-L21HN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6C
   os_family: Android
   browser_family: Chrome
@@ -2069,19 +1870,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JMM-L22 Build/HUAWEIJMM-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6C Pro
   os_family: Android
   browser_family: Chrome
@@ -2089,19 +1888,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BLN-TL10 Build/HONORBLN-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2109,19 +1906,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-L22 Build/HONORBLN-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2129,19 +1924,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-TL00 Build/HONORBLN-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2149,19 +1942,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-L21 Build/HONORBLN-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2169,19 +1960,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-L24 Build/HONORBLN-L24) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2189,19 +1978,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-AL20 Build/HONORBLN-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2209,19 +1996,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLN-AL30 Build/HONORBLN-AL30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Chrome
@@ -2229,19 +2014,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0;ru-by; BLN-AL40 Build/HONORBLN-AL40) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 6X
   os_family: Android
   browser_family: Unknown
@@ -2249,19 +2032,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; HW-PLK-CL00 Build/HONORPLK-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Android Browser
@@ -2269,7 +2050,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; PLK-UL00 Build/HONORPLK-UL00) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 5.0.2)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
@@ -2278,7 +2058,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Unknown
@@ -2286,19 +2066,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; PLK-L01 Build/HONORPLK-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Chrome
@@ -2306,19 +2084,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; PLK-TL00 Build/HONORPLK-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Chrome
@@ -2326,19 +2102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; PLK-TL01H Build/HONORPLK-TL01H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Chrome
@@ -2346,7 +2120,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; PLK-AL10 Build/HONORPLK-AL10) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_r13c59e9.581 NetType/cmnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
@@ -2355,7 +2128,7 @@
     version: "6.2.2.54.r13c59e9.581"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Unknown
@@ -2363,19 +2136,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PLK Build/HONORPLK-L01; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7
   os_family: Android
   browser_family: Chrome
@@ -2383,19 +2154,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NEM-L21 Build/HONORNEM-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7 Lite
   os_family: Android
   browser_family: Chrome
@@ -2403,19 +2172,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AUM-TL20 Build/HONORAUM-TL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7A
   os_family: Android
   browser_family: Chrome
@@ -2423,19 +2190,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AUM-L33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7A
   os_family: Android
   browser_family: Chrome
@@ -2443,19 +2208,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AUM-AL20 Build/HONORAUM-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7A
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2226,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0;ru-ua; AUM-AL00 Build/HONORAUM-AL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7A
   os_family: Android
   browser_family: Unknown
@@ -2483,19 +2244,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LND-L29 Build/HONORLND-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7C
   os_family: Android
   browser_family: Chrome
@@ -2503,19 +2262,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; LND-TL40 Build/HONORLND-TL40 AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7C
   os_family: Android
   browser_family: Chrome
@@ -2523,19 +2280,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AUM-L41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7C
   os_family: Android
   browser_family: Chrome
@@ -2543,19 +2298,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; LND-AL30 Build/HONORLND-AL30) AppleWebKit/537.36 (KHTML, like Gecko) MQQBrowser/7.3 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "7.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7C
   os_family: Android
   browser_family: Unknown
@@ -2563,19 +2316,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ATH-AL00 Build/HONORATH-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7i
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2334,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; ru-ru; ATH-UL00) Build/HONORATH-UL00 AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7i
   os_family: Android
   browser_family: Unknown
@@ -2603,19 +2352,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; ru-ua; ATH-TL00H) Build/HONORATH-TL00H AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7i
   os_family: Android
   browser_family: Unknown
@@ -2623,19 +2370,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUA-L22 Build/HONORDUA-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7S
   os_family: Android
   browser_family: Chrome
@@ -2643,19 +2388,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUA-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7S
   os_family: Android
   browser_family: Chrome
@@ -2663,19 +2406,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUA-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7S
   os_family: Android
   browser_family: Chrome
@@ -2683,19 +2424,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BND-AL10 Build/HONORBND-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2703,19 +2442,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BND-L21 Build/HONORBND-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2723,19 +2460,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BND-L31 Build/HONORBND-L31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2743,19 +2478,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BND-L24 Build/HONORBND-L24) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2763,19 +2496,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BND-TL10 Build/HONORBND-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2783,19 +2514,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BND-AL00 Build/HONORBND-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 7X
   os_family: Android
   browser_family: Chrome
@@ -2803,19 +2532,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; FRD-L04) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2823,19 +2550,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VAT-L19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2843,19 +2568,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FRD-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2863,19 +2586,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FRD-L14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2604,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FRD-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2903,19 +2622,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FRD-L19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2640,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; zh-cn; FRD-AL00 Build/HUAWEIFRD-AL00) AppleWebKit/537.36 (KHTML, like Gecko) MQQBrowser/7.3 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "7.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Unknown
@@ -2943,19 +2658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FRD-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2676,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FRD-DL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8
   os_family: Android
   browser_family: Chrome
@@ -2983,19 +2694,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-AL00X Build/HONORPRA-AL00X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Lite
   os_family: Android
   browser_family: Chrome
@@ -3003,19 +2712,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-AL00 Build/HONORPRA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Lite
   os_family: Android
   browser_family: Chrome
@@ -3023,19 +2730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; PRA-TL10 Build/HONORPRA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.0.465.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.11.0.465.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Lite
   os_family: Android
   browser_family: Unknown
@@ -3043,19 +2748,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DUK-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Pro
   os_family: Android
   browser_family: Chrome
@@ -3063,19 +2766,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DUK-TL30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Pro
   os_family: Android
   browser_family: Chrome
@@ -3083,19 +2784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VEN-L22 Build/HONORVEN-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Smart
   os_family: Android
   browser_family: Chrome
@@ -3103,19 +2802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VEN-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8 Smart
   os_family: Android
   browser_family: Chrome
@@ -3123,19 +2820,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JAT-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8A
   os_family: Android
   browser_family: Chrome
@@ -3143,19 +2838,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JAT-LX1 Build/HONORJAT-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.0.2551.140375
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.0.2551.140375"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8A
   os_family: Android
   browser_family: Opera
@@ -3163,19 +2856,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JAT-L41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8A Pro
   os_family: Android
   browser_family: Chrome
@@ -3183,19 +2874,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BKK-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Chrome
@@ -3203,19 +2892,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BKK-AL10 Build/HONORBKK-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Chrome
@@ -3223,19 +2910,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BKK-L21 Build/HONORBKK-L21; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Chrome
@@ -3243,19 +2928,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BKK-L22 Build/HONORBKK-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Chrome
@@ -3263,19 +2946,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BKK-LX2 Build/HONORBKK-LX2; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Chrome
@@ -3283,19 +2964,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; BKK-TL00 Build/HONORBKK-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8C
   os_family: Android
   browser_family: Unknown
@@ -3303,19 +2982,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KSA-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8S
   os_family: Android
   browser_family: Chrome
@@ -3323,19 +3000,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KSA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8S
   os_family: Android
   browser_family: Chrome
@@ -3343,19 +3018,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KSA-LX9 Build/HONORKSA-LX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.4.2517.140781
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.4.2517.140781"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8S
   os_family: Android
   browser_family: Opera
@@ -3363,19 +3036,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KSA-LX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.4.349.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.4.349.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8S
   os_family: Android
   browser_family: Unknown
@@ -3383,19 +3054,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JSN-L21 Build/HONORJSN-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Chrome
@@ -3403,19 +3072,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JSN-L42 Build/HONORJSN-L42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Chrome
@@ -3423,19 +3090,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JSN-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3108,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JSN-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Chrome
@@ -3463,19 +3126,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JSN-AL00a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Chrome
@@ -3483,19 +3144,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JSN-AL00 Build/HONORJSN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 OPR/51.3.2461.138727
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "51.3.2461.138727"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X
   os_family: Android
   browser_family: Opera
@@ -3503,19 +3162,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X Max
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3180,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARE-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X Max
   os_family: Android
   browser_family: Chrome
@@ -3543,19 +3198,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X Max
   os_family: Android
   browser_family: Chrome
@@ -3563,19 +3216,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARE-L22HN Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X Max
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3234,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ARE-L22HN Build/HONORARE-L22HN; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36 OPR/43.3.2254.141404
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.3.2254.141404"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 8X Max
   os_family: Android
   browser_family: Opera
@@ -3603,7 +3252,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; STF-AL10 Build/HUAWEISTF-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044208 Mobile Safari/537.36 MicroMessenger/6.7.2.1340(0x2607023A) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -3612,7 +3260,7 @@
     version: "6.7.2.1340(0x2607023A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9
   os_family: Android
   browser_family: Unknown
@@ -3620,19 +3268,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; STF-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9
   os_family: Android
   browser_family: Chrome
@@ -3640,19 +3286,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; STF-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9
   os_family: Android
   browser_family: Chrome
@@ -3660,19 +3304,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; STF-AL00 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9
   os_family: Android
   browser_family: Chrome
@@ -3680,7 +3322,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; LLD-AL00 Build/HONORLLD-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044109 Mobile Safari/537.36 MicroMessenger/6.6.7.1321(0x26060739) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -3689,7 +3330,7 @@
     version: "6.6.7.1321(0x26060739)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9 Lite
   os_family: Android
   browser_family: Unknown
@@ -3697,19 +3338,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-L21 Build/HONORLLD-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9 Lite
   os_family: Android
   browser_family: Chrome
@@ -3717,19 +3356,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9 Lite
   os_family: Android
   browser_family: Chrome
@@ -3737,19 +3374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-AL10 Build/HONORLLD-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9 Lite
   os_family: Android
   browser_family: Chrome
@@ -3757,19 +3392,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-L31 Build/HONORLLD-L31; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9 Lite
   os_family: Android
   browser_family: Chrome
@@ -3777,19 +3410,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MOA-LX9N Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9A
   os_family: Android
   browser_family: Chrome
@@ -3797,19 +3428,17 @@
   user_agent: mozilla/5.0 (linux; android 10; aka-l29 build/XXXXX; wv) applewebkit/537.36 (khtml, like gecko) version/4.0 chrome/78.0.3904.108 mobile safari/537.36 yandexsearch/10.80 yandexsearchwebview/10.80
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9C
   os_family: Android
   browser_family: Chrome
@@ -3817,19 +3446,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-AL20 Build/HONORLLD-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9i
   os_family: Android
   browser_family: Chrome
@@ -3837,19 +3464,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LLD-AL30 Build/HONORLLD-AL30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9i
   os_family: Android
   browser_family: Chrome
@@ -3857,19 +3482,17 @@
   user_agent: mozilla/5.0 (linux; android 10; dua-lx9 build/XXXXX; wv) applewebkit/537.36 (khtml, like gecko) version/4.0 chrome/78.0.3904.108 mobile safari/537.36 yandexsearch/9.85 yandexsearchwebview/9.85
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9S
   os_family: Android
   browser_family: Chrome
@@ -3877,7 +3500,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLK-AL00 Build/HONORHLK-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Mobile Safari/537.36 baiduboxapp/10.5.0.10 (Baidu; P1 9)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
@@ -3886,7 +3508,7 @@
     version: "10.5.0.10"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9X
   os_family: Android
   browser_family: Unknown
@@ -3894,19 +3516,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HLK-AL00a Build/HONORHLK-AL00a; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9X
   os_family: Android
   browser_family: Chrome
@@ -3914,19 +3534,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HLK-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor 9X Pro
   os_family: Android
   browser_family: Chrome
@@ -3934,19 +3552,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NTS-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Magic
   os_family: Android
   browser_family: Chrome
@@ -3954,19 +3570,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TNY-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Magic 2
   os_family: Android
   browser_family: Chrome
@@ -3974,19 +3588,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TNY-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Magic 2
   os_family: Android
   browser_family: Chrome
@@ -3994,19 +3606,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; RVL-AL09 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Note 10
   os_family: Android
   browser_family: Chrome
@@ -4014,19 +3624,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EDI-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Note 8
   os_family: Android
   browser_family: Chrome
@@ -4034,19 +3642,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VKY-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor P10 Plus
   os_family: Android
   browser_family: Chrome
@@ -4054,19 +3660,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VOG-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor P30 Pro
   os_family: Android
   browser_family: Chrome
@@ -4074,19 +3678,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ANA-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor P40
   os_family: Android
   browser_family: Chrome
@@ -4094,19 +3696,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ANA-TN00 Build/XXXXX ANA-TN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor P40
   os_family: Android
   browser_family: Chrome
@@ -4114,7 +3714,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; COR-AL10 Build/HUAWEICOR-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044408 Mobile Safari/537.36 MMWEBID/347 MicroMessenger/7.0.1380(0x2700003A) Process/tools NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
@@ -4123,7 +3722,7 @@
     version: "7.0.1380(0x2700003A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play
   os_family: Android
   browser_family: Unknown
@@ -4131,19 +3730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; COR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play
   os_family: Android
   browser_family: Chrome
@@ -4151,19 +3748,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; COR-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play
   os_family: Android
   browser_family: Chrome
@@ -4171,19 +3766,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ASK-AL00x) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 3
   os_family: Android
   browser_family: Chrome
@@ -4191,19 +3784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KSA-AL10 Build/HONORKSA-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 3E
   os_family: Android
   browser_family: Chrome
@@ -4211,19 +3802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TNNH-AN00 Build/HONORTNNH-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4
   os_family: Android
   browser_family: Chrome
@@ -4231,19 +3820,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; CHM-TL00 Build/HonorCHM-TL00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.5.2.598 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.5.2.598"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4C
   os_family: Android
   browser_family: Unknown
@@ -4251,19 +3838,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; CHM-TL00H Build/HonorCHM-TL00H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4C
   os_family: Android
   browser_family: Unknown
@@ -4271,7 +3856,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; CHM-UL00 Build/HonorCHM-UL00) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -4280,7 +3864,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4C
   os_family: Android
   browser_family: Unknown
@@ -4288,19 +3872,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; HW-CHM-CL00 Build/CHM-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4C
   os_family: Android
   browser_family: Android Browser
@@ -4308,19 +3890,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; AKA-AL10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 4T
   os_family: Android
   browser_family: Chrome
@@ -4328,19 +3908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; DUA-TL00 Build/HONORDUA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 7
   os_family: Android
   browser_family: Chrome
@@ -4348,19 +3926,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUA-AL00 Build/HONORDUA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 7
   os_family: Android
   browser_family: Chrome
@@ -4368,19 +3944,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JAT-TL00 Build/HONORJAT-TL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 8A
   os_family: Android
   browser_family: Chrome
@@ -4388,19 +3962,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MOA-AL00 Build/HONORMOA-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Play 9A
   os_family: Android
   browser_family: Chrome
@@ -4408,19 +3980,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BKL-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V10
   os_family: Android
   browser_family: Chrome
@@ -4428,19 +3998,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; BKL-AL20 Build/HUAWEIBKL-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/9.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "9.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V10
   os_family: Android
   browser_family: Unknown
@@ -4448,19 +4016,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCT-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V20
   os_family: Android
   browser_family: Chrome
@@ -4468,19 +4034,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCT-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V20
   os_family: Android
   browser_family: Chrome
@@ -4488,19 +4052,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; KNT-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V8
   os_family: Android
   browser_family: Chrome
@@ -4508,19 +4070,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; KNT-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V8
   os_family: Android
   browser_family: Chrome
@@ -4528,19 +4088,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; KNT-UL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V8
   os_family: Android
   browser_family: Chrome
@@ -4548,19 +4106,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; KNT-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V8
   os_family: Android
   browser_family: Chrome
@@ -4568,7 +4124,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DUK-AL20 Build/HUAWEIDUK-AL20; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044205 Mobile Safari/537.36 MicroMessenger/6.7.2.1340(0x2607023A) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -4577,7 +4132,7 @@
     version: "6.7.2.1340(0x2607023A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V9
   os_family: Android
   browser_family: Unknown
@@ -4585,19 +4140,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JMM-AL00 Build/HONORJMM-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V9 Play
   os_family: Android
   browser_family: Chrome
@@ -4605,19 +4158,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JMM-AL10 Build/HONORJMM-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V9 Play
   os_family: Android
   browser_family: Chrome
@@ -4625,19 +4176,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JMM-TL10 Build/HONORJMM-TL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V9 Play
   os_family: Android
   browser_family: Chrome
@@ -4645,7 +4194,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; JMM-AL00 Build/HONORJMM-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 SogouSearch Android1.0 version3.0 AppVersion/6002
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -4654,7 +4202,7 @@
     version: "3.0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor V9 Play
   os_family: Android
   browser_family: Unknown
@@ -4662,19 +4210,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; OXF-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor View 30
   os_family: Android
   browser_family: Chrome
@@ -4682,19 +4228,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; OXF-AN10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor View 30 Pro
   os_family: Android
   browser_family: Chrome
@@ -4702,19 +4246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-TN00 Build/HONORTEL-TN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.156 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.156"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -4722,19 +4264,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-AN00a Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -4742,19 +4282,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-AN00 Build/HONORTEL-AN00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -4762,19 +4300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TEL-AN10 Build/HONORTEL-AN10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10
   os_family: Android
   browser_family: Chrome
@@ -4782,19 +4318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; KKG-AN00 Build/HONORKKG-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor X10 Max
   os_family: Android
   browser_family: Chrome
@@ -4802,19 +4336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SCL-L01 Build/SCL-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Y6
   os_family: Android
   browser_family: Chrome
@@ -4822,19 +4354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; HW-SCL-L32 Build/HW-SCL-L32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Y6
   os_family: Android
   browser_family: Chrome
@@ -4842,19 +4372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI LYO-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Y6 II Compact
   os_family: Android
   browser_family: Chrome
@@ -4862,19 +4390,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 5.1; LYO-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.7.115.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.7.115.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Honor Y6 II Compact
   os_family: Android
   browser_family: Unknown
@@ -4882,19 +4408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; it-it; Ideos Build/B827SP01) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos
   os_family: Android
   browser_family: Android Browser
@@ -4902,19 +4426,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; IDEOS S7 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos S7
   os_family: Android
   browser_family: Android Browser
@@ -4922,19 +4444,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; IDEOS S7 Slim Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos S7 Slim
   os_family: Android
   browser_family: Android Browser
@@ -4942,19 +4462,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-ma; U8500 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos X2
   os_family: Android
   browser_family: Android Browser
@@ -4962,19 +4480,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-gb; U8510 Build/HuaweiU8510) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos X3
   os_family: Android
   browser_family: Android Browser
@@ -4982,19 +4498,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; IDEOS X5 Build/HuaweiU8800Pro) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos X5
   os_family: Android
   browser_family: Android Browser
@@ -5002,19 +4516,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; u8800 Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Ideos X5
   os_family: Android
   browser_family: Android Browser
@@ -5024,13 +4536,12 @@
   client:
     type: browser
     name: Obigo
-    short_name: OB
     version: "Q05A"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: M636
   os_family: Unknown
   browser_family: Unknown
@@ -5038,19 +4549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HUAWEI-M931 Build/HuaweiM931) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: M931
   os_family: Android
   browser_family: Chrome
@@ -5058,19 +4567,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-cn; HUAWEI MLA-AL10 Build/HUAWEIMLA-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.9 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.9"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Maimang 5
   os_family: Android
   browser_family: Unknown
@@ -5078,19 +4585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; POT-AL10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Maimang 8
   os_family: Android
   browser_family: Chrome
@@ -5098,19 +4603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; ALP-AL00 Build/HUAWEIALP-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10
   os_family: Android
   browser_family: Chrome
@@ -5118,19 +4621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ALP-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10
   os_family: Android
   browser_family: Chrome
@@ -5138,19 +4639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RNE-L21 Build/HUAWEIRNE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -5158,19 +4657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RNE-L03 Build/HUAWEIRNE-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -5178,7 +4675,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; RNE-AL00 Build/HUAWEIRNE-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044408 Mobile Safari/537.36 MMWEBID/7065 MicroMessenger/7.0.1380(0x27000034) Process/tools NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -5187,7 +4683,7 @@
     version: "7.0.1380(0x27000034)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Lite
   os_family: Android
   browser_family: Unknown
@@ -5195,19 +4691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; RNE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Lite
   os_family: Android
   browser_family: Chrome
@@ -5215,19 +4709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BLA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5235,19 +4727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BLA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5255,19 +4745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BLA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5275,19 +4763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HMA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20
   os_family: Android
   browser_family: Chrome
@@ -5295,19 +4781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HMA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20
   os_family: Android
   browser_family: Chrome
@@ -5315,19 +4799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HMA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20
   os_family: Android
   browser_family: Chrome
@@ -5335,19 +4817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SNE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 Lite
   os_family: Android
   browser_family: Chrome
@@ -5355,19 +4835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LYA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 Pro
   os_family: Android
   browser_family: Chrome
@@ -5375,19 +4853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LYA-L0C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 Pro
   os_family: Android
   browser_family: Chrome
@@ -5395,19 +4871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LYA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 Pro
   os_family: Android
   browser_family: Chrome
@@ -5415,19 +4889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LYA-AL00 Build/HUAWEILYA-AL00L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 HuaweiBrowser/9.0.2.305 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Huawei Browser
-    short_name: HU
     version: "9.0.2.305"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 Pro
   os_family: Android
   browser_family: Unknown
@@ -5435,19 +4907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LYA-AL00P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 RS
   os_family: Android
   browser_family: Chrome
@@ -5455,19 +4925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; EVR-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 X
   os_family: Android
   browser_family: Chrome
@@ -5475,19 +4943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; EVR-N29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 X
   os_family: Android
   browser_family: Chrome
@@ -5495,19 +4961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; EVR-AL00 Build/HUAWEIEVR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 HuaweiBrowser/9.0.1.323 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Huawei Browser
-    short_name: HU
     version: "9.0.1.323"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 X
   os_family: Android
   browser_family: Unknown
@@ -5515,19 +4979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; EVR-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 20 X
   os_family: Android
   browser_family: Chrome
@@ -5535,19 +4997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TAS-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30
   os_family: Android
   browser_family: Chrome
@@ -5555,19 +5015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TAS-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30
   os_family: Android
   browser_family: Chrome
@@ -5575,19 +5033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TAS-L29 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30
   os_family: Android
   browser_family: Chrome
@@ -5595,19 +5051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TAS-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 5G
   os_family: Android
   browser_family: Chrome
@@ -5615,19 +5069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SPN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Lite
   os_family: Android
   browser_family: Chrome
@@ -5635,19 +5087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; LIO-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Pro
   os_family: Android
   browser_family: Chrome
@@ -5655,19 +5105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; LIO-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Pro
   os_family: Android
   browser_family: Chrome
@@ -5675,19 +5123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; LIO-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Pro
   os_family: Android
   browser_family: Chrome
@@ -5695,19 +5141,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 10; LIO-AN00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 YaBrowser/19.12.1.121.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.12.1.121.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 30 Pro
   os_family: Android
   browser_family: Unknown
@@ -5715,19 +5159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NXT-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 8
   os_family: Android
   browser_family: Chrome
@@ -5735,7 +5177,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; HUAWEI NXT-AL10 Build/HUAWEINXT-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044408 Mobile Safari/537.36 MMWEBID/5305 MicroMessenger/7.0.1380(0x2700003A) Process/tools NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -5744,7 +5185,7 @@
     version: "7.0.1380(0x2700003A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 8
   os_family: Android
   browser_family: Unknown
@@ -5752,19 +5193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MHA-L09 Build/HUAWEIMHA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 9
   os_family: Android
   browser_family: Chrome
@@ -5772,7 +5211,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; MHA-AL00 Build/HUAWEIMHA-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044304 Mobile Safari/537.36 MicroMessenger/6.7.2.1340(0x2607023A) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
@@ -5781,7 +5219,7 @@
     version: "6.7.2.1340(0x2607023A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 9
   os_family: Android
   browser_family: Unknown
@@ -5789,19 +5227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; MHA-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 9
   os_family: Android
   browser_family: Chrome
@@ -5809,19 +5245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MHA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 9
   os_family: Android
   browser_family: Chrome
@@ -5829,19 +5263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BLL-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate 9 Lite
   os_family: Android
   browser_family: Chrome
@@ -5849,19 +5281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; NEO-AL00 Build/HUAWEINEO-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate RS
   os_family: Android
   browser_family: Chrome
@@ -5869,19 +5299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; NEO-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate RS Porsche Design
   os_family: Android
   browser_family: Chrome
@@ -5889,19 +5317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HUAWEI CRR-UL00 Build/HUAWEICRR-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate S
   os_family: Android
   browser_family: Chrome
@@ -5909,19 +5335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRR-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate S
   os_family: Android
   browser_family: Chrome
@@ -5929,19 +5353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BND-L34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate SE
   os_family: Android
   browser_family: Chrome
@@ -5949,19 +5371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; TAH-AN00m Build/XXXXX TAH-AN00m; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Mate XS
   os_family: Android
   browser_family: Chrome
@@ -5969,19 +5389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAZ-AL00 Build/HUAWEICAZ-AL00) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Android Browser
@@ -5989,19 +5407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAZ-AL10 Build/HUAWEICAZ-AL10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Android Browser
@@ -6009,19 +5425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAZ-TL10 Build/HUAWEICAZ-TL10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Android Browser
@@ -6029,19 +5443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAZ-TL20 Build/HUAWEICAZ-TL20) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Android Browser
@@ -6049,19 +5461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L01 Build/HUAWEICAN-L01; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6069,19 +5479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L02 Build/HUAWEICAN-L02; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6089,19 +5497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L03 Build/HUAWEICAN-L03; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6109,19 +5515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L11 Build/HUAWEICAN-L11; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6129,19 +5533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L12 Build/HUAWEICAN-L12; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6149,19 +5551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI CAN-L13 Build/HUAWEICAN-L13; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova
   os_family: Android
   browser_family: Chrome
@@ -6169,19 +5569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PIC-AL00 Build/HUAWEIPIC-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2
   os_family: Android
   browser_family: Chrome
@@ -6189,19 +5587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PIC-TL00 Build/HUAWEIPIC-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2
   os_family: Android
   browser_family: Chrome
@@ -6209,19 +5605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; HWV31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2
   os_family: Android
   browser_family: Chrome
@@ -6229,19 +5623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; 704HW Build/HUAWEI704HW; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2 Lite
   os_family: Android
   browser_family: Chrome
@@ -6249,19 +5641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BAC-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -6269,19 +5659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BAC-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2 Plus
   os_family: Android
   browser_family: Chrome
@@ -6289,19 +5677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; zh-cn; BAC-AL00 Build/HUAWEIBAC-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/9.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "9.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2 Plus Dual SIM
   os_family: Android
   browser_family: Unknown
@@ -6309,19 +5695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RNE-L22 Build/HONORRNE-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2I
   os_family: Android
   browser_family: Chrome
@@ -6329,19 +5713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RNE-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2I
   os_family: Android
   browser_family: Chrome
@@ -6349,19 +5731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; HWI-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2S
   os_family: Android
   browser_family: Chrome
@@ -6369,19 +5749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HWI-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 2S
   os_family: Android
   browser_family: Chrome
@@ -6389,19 +5767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PAR-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3
   os_family: Android
   browser_family: Chrome
@@ -6409,19 +5785,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0zh-cn; PAR-AL00 Build/HUAWEIPAR-AL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3
   os_family: Android
   browser_family: Unknown
@@ -6429,19 +5803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PAR-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3
   os_family: Android
   browser_family: Chrome
@@ -6449,19 +5821,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; PAR-TL20 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3
   os_family: Android
   browser_family: Chrome
@@ -6469,19 +5839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-AL00 Build/HUAWEIANE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3e
   os_family: Android
   browser_family: Chrome
@@ -6489,19 +5857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3i
   os_family: Android
   browser_family: Chrome
@@ -6509,19 +5875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0zh-cn; INE-TL00 Build/HUAWEIINE-TL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 3i
   os_family: Android
   browser_family: Unknown
@@ -6529,19 +5893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VCE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 4
   os_family: Android
   browser_family: Chrome
@@ -6549,19 +5911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VCE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 4
   os_family: Android
   browser_family: Chrome
@@ -6569,19 +5929,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; MAR-AL00 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 4e
   os_family: Android
   browser_family: Chrome
@@ -6589,19 +5947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SEA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 5
   os_family: Android
   browser_family: Chrome
@@ -6609,19 +5965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SEA-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 5 Pro
   os_family: Android
   browser_family: Chrome
@@ -6629,19 +5983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; GLK-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 5i
   os_family: Android
   browser_family: Chrome
@@ -6649,19 +6001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; GLK-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 5i
   os_family: Android
   browser_family: Chrome
@@ -6669,19 +6019,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-cn; SPN-TL00 Build/XXXXX SPN-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 5i Pro
   os_family: Android
   browser_family: Unknown
@@ -6689,19 +6037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; WLZ-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 6
   os_family: Android
   browser_family: Chrome
@@ -6709,19 +6055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; WLZ-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 6 5G
   os_family: Android
   browser_family: Chrome
@@ -6729,19 +6073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JNY-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 6 SE
   os_family: Android
   browser_family: Chrome
@@ -6749,19 +6091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JEF-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 5G
   os_family: Android
   browser_family: Chrome
@@ -6769,19 +6109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JEF-TN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 5G
   os_family: Android
   browser_family: Chrome
@@ -6789,19 +6127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JER-TN10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -6809,19 +6145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JER-AN10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 Pro 5G
   os_family: Android
   browser_family: Chrome
@@ -6829,19 +6163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-Hans-CN; CDY-TN00 Build/HUAWEICDY-TN00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -6849,19 +6181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CDY-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7 SE 5G
   os_family: Android
   browser_family: Chrome
@@ -6869,19 +6199,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; JNY-LX2 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova 7i
   os_family: Android
   browser_family: Unknown
@@ -6889,19 +6217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova Smart
   os_family: Android
   browser_family: Chrome
@@ -6909,19 +6235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; WAS-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Nova Youth
   os_family: Android
   browser_family: Chrome
@@ -6929,19 +6253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FIG-LX1 Build/HUAWEIFIG-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart
   os_family: Android
   browser_family: Chrome
@@ -6949,19 +6271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FIG-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart
   os_family: Android
   browser_family: Chrome
@@ -6969,19 +6289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-LX2J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart (2019)
   os_family: Android
   browser_family: Chrome
@@ -6989,19 +6307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart (2019)
   os_family: Android
   browser_family: Chrome
@@ -7009,19 +6325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart (2019)
   os_family: Android
   browser_family: Chrome
@@ -7029,19 +6343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-LX1AF) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart (2019)
   os_family: Android
   browser_family: Chrome
@@ -7049,19 +6361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; POT-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart (2019)
   os_family: Android
   browser_family: Chrome
@@ -7069,19 +6379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; STK-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.2.338.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.2.338.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P smart Z
   os_family: Android
   browser_family: Unknown
@@ -7089,19 +6397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VTR-L09 Build/HUAWEIVTR-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10
   os_family: Android
   browser_family: Chrome
@@ -7109,19 +6415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VTR-AL00 Build/HUAWEIVTR-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10
   os_family: Android
   browser_family: Android Browser
@@ -7129,19 +6433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VTR-L29 Build/HUAWEIVTR-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10
   os_family: Android
   browser_family: Chrome
@@ -7149,19 +6451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VTR-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10
   os_family: Android
   browser_family: Chrome
@@ -7169,19 +6469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VTR-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10
   os_family: Android
   browser_family: Chrome
@@ -7189,19 +6487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; WAS-LX1 Build/HUAWEIWAS-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Lite
   os_family: Android
   browser_family: Chrome
@@ -7209,19 +6505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; WAS-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Lite
   os_family: Android
   browser_family: Chrome
@@ -7229,19 +6523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; WAS-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Lite
   os_family: Android
   browser_family: Chrome
@@ -7249,19 +6541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; WAS-LX1A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Lite
   os_family: Android
   browser_family: Chrome
@@ -7269,19 +6559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VKY-L29 Build/HUAWEIVKY-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Plus
   os_family: Android
   browser_family: Chrome
@@ -7289,19 +6577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VKY-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Plus
   os_family: Android
   browser_family: Chrome
@@ -7309,19 +6595,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; zh-cn; VKY-AL00 Build/HUAWEIVKY-AL00) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Plus
   os_family: Android
   browser_family: Unknown
@@ -7329,19 +6613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BAC-L23 Build/HUAWEIBAC-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36 mCent/0.13.1127
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: mCent
-    short_name: M1
     version: "0.13.1127"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P10 Selfie
   os_family: Android
   browser_family: Chrome
@@ -7349,7 +6631,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1; EML-AL00 Build/HUAWEIEML-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044208 Mobile Safari/537.36 MicroMessenger/6.7.2.1340(0x2607023A) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.1"
     platform: ""
   client:
@@ -7358,7 +6639,7 @@
     version: "6.7.2.1340(0x2607023A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20
   os_family: Android
   browser_family: Unknown
@@ -7366,19 +6647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; EML-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20
   os_family: Android
   browser_family: Chrome
@@ -7386,19 +6665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; EML-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20
   os_family: Android
   browser_family: Chrome
@@ -7406,19 +6683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; EML-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20
   os_family: Android
   browser_family: Chrome
@@ -7426,19 +6701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX3 Build/HUAWEIANE-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7446,19 +6719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX1 Build/HUAWEIANE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7466,19 +6737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7486,19 +6755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7506,19 +6773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-LX2J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7526,19 +6791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ANE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7546,19 +6809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HWV32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Lite
   os_family: Android
   browser_family: Chrome
@@ -7566,19 +6827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; CLT-TL01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7586,19 +6845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CLT-AL01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7606,19 +6863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CLT-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7626,19 +6881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CLT-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7646,19 +6899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CLT-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7666,19 +6917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CLT-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7686,7 +6935,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 8.1.0; CLT-L29 Build/HUAWEICLT-L29; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/167.0.0.28.94;]'
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -7695,7 +6943,7 @@
     version: "167.0.0.28.94"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Unknown
@@ -7703,19 +6951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CLT-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7723,19 +6969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HW-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P20 Pro
   os_family: Android
   browser_family: Chrome
@@ -7743,19 +6987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ELE-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30
   os_family: Android
   browser_family: Chrome
@@ -7763,19 +7005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ELE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30
   os_family: Android
   browser_family: Chrome
@@ -7783,19 +7023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7803,19 +7041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7823,19 +7059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NIC-LX1A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7843,19 +7077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX1B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7863,19 +7095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX3Bm) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7883,19 +7113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX1M Build/HUAWEIMAR-L21MEA; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36 VivoBrowser/6.4.1.3
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: vivo Browser
-    short_name: VV
     version: "6.4.1.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Unknown
@@ -7903,19 +7131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX1M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 YaBrowser/19.6.4.349.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.6.4.349.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Unknown
@@ -7923,19 +7149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; HWV33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7943,19 +7167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MAR-LX2J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite
   os_family: Android
   browser_family: Chrome
@@ -7963,19 +7185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX1A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -7983,19 +7203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MAR-LX3A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Lite Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8003,19 +7221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VOG-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Pro
   os_family: Android
   browser_family: Chrome
@@ -8023,19 +7239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; HW-02L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Pro
   os_family: Android
   browser_family: Chrome
@@ -8043,19 +7257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VOG-AL10 Build/HUAWEIVOG-AL10; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P30 Pro
   os_family: Android
   browser_family: Chrome
@@ -8063,19 +7275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; JNY-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Lite
   os_family: Android
   browser_family: Chrome
@@ -8083,19 +7293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-AN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro
   os_family: Android
   browser_family: Chrome
@@ -8103,19 +7311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-TN00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro
   os_family: Android
   browser_family: Chrome
@@ -8123,19 +7329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; ELS-NX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36 OPR/58.1.2878.53288
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "58.1.2878.53288"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P40 Pro
   os_family: Android
   browser_family: Opera
@@ -8143,19 +7347,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; HUAWEI P6-U06 Build/HuaweiP6-U06) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P6-U06
   os_family: Android
   browser_family: Android Browser
@@ -8163,19 +7365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HUAWEI GRA-UL00 Build/HUAWEIGRA-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8
   os_family: Android
   browser_family: Chrome
@@ -8183,19 +7383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HUAWEI GRA-L09 Build/HUAWEIGRA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8
   os_family: Android
   browser_family: Chrome
@@ -8203,19 +7401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALE-L21 Build/HuaweiALE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2015)
   os_family: Android
   browser_family: Chrome
@@ -8223,19 +7419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALE-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2015)
   os_family: Android
   browser_family: Chrome
@@ -8243,19 +7437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALE-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2015)
   os_family: Android
   browser_family: Chrome
@@ -8263,19 +7455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALE-UL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2015)
   os_family: Android
   browser_family: Chrome
@@ -8283,19 +7473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; hi6210sft Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -8303,19 +7491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-LX1 Build/HONORPRA-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -8323,19 +7509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-LX1 Build/HUAWEIPRA-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -8343,19 +7527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-LA1 Build/HONORPRA-LA1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -8363,19 +7545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRA-LX3 Build/HUAWEIPRA-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P8 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -8383,19 +7563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVA-L09 Build/HUAWEIEVA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8403,19 +7581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVA-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8423,19 +7599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; EVA-DL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8443,19 +7617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; EVA-CL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8463,19 +7635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; EVA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8483,19 +7653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; EVA-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9
   os_family: Android
   browser_family: Chrome
@@ -8503,19 +7671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VNS-L62) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite
   os_family: Android
   browser_family: Chrome
@@ -8523,19 +7689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI VNS-L31 Build/HUAWEIVNS-L31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite
   os_family: Android
   browser_family: Chrome
@@ -8543,19 +7707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HUAWEI VNS-L21 Build/HUAWEIVNS-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite
   os_family: Android
   browser_family: Chrome
@@ -8563,19 +7725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VNS-L22 Build/XXXXVNS-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.83
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite
   os_family: Android
   browser_family: Chrome
@@ -8583,19 +7743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite Mini
   os_family: Android
   browser_family: Chrome
@@ -8603,19 +7761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SLA-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite Mini
   os_family: Android
   browser_family: Chrome
@@ -8623,19 +7779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; DIG-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Lite Smart
   os_family: Android
   browser_family: Chrome
@@ -8643,7 +7797,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIE-L09 Build/HUAWEIVIE-L09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36 BingWeb/6.9.25207603
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -8652,7 +7805,7 @@
     version: "6.9.25207603"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Plus
   os_family: Android
   browser_family: Unknown
@@ -8660,19 +7813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIE-L29 Build/HUAWEIVIE-L29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Plus
   os_family: Android
   browser_family: Chrome
@@ -8680,19 +7831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VIE-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: P9 Plus
   os_family: Android
   browser_family: Chrome
@@ -8700,19 +7849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ATH-UL01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: ShotX
   os_family: Android
   browser_family: Chrome
@@ -8720,19 +7867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ATH-UL06) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: ShotX
   os_family: Android
   browser_family: Chrome
@@ -8740,19 +7885,17 @@
   user_agent: HuaweiT8100_TD/1.0 Android/2.2 Release/12.25.2010 Browser/WAP2.0 Profile/MIDP-2.0 Configuration/CLDC-1.1 AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: T8100
   os_family: Android
   browser_family: Android Browser
@@ -8760,19 +7903,17 @@
   user_agent: HUAWEI_T8300_TD/1.0 OPhone/2.5 (Linux;Android 2.2) Release/03.20.2011 Browser/WAP2.0(AppleWebKit/533.1) Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: T8300
   os_family: Android
   browser_family: Android Browser
@@ -8780,19 +7921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-mx; U8185 Build/HuaweiU8185) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8185
   os_family: Android
   browser_family: Android Browser
@@ -8800,19 +7939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.5; da-dk; U8230 Build/CRB17) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8230
   os_family: Android
   browser_family: Android Browser
@@ -8820,19 +7957,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; U8655-1 Build/HuaweiU8655) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8655
   os_family: Android
   browser_family: Android Browser
@@ -8840,19 +7975,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; U8655-51 Build/HuaweiU8655) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8655
   os_family: Android
   browser_family: Android Browser
@@ -8860,19 +7993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; hr-hr; U8655-1 Build/HuaweiU8655) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8655
   os_family: Android
   browser_family: Android Browser
@@ -8880,19 +8011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Huawei-U8665 Build/HuaweiU8665B037) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8665
   os_family: Android
   browser_family: Android Browser
@@ -8900,19 +8029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; pt-br; U8667 Build/HuaweiU8667) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8667
   os_family: Android
   browser_family: Android Browser
@@ -8920,19 +8047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Prism II Build/HuaweiU8686) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8686
   os_family: Android
   browser_family: Chrome
@@ -8940,19 +8065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-cd; U8800Pro Build/HuaweiU8800Pro) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8800Pro
   os_family: Android
   browser_family: Android Browser
@@ -8960,19 +8083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-ca; U8815 Build/HuaweiU8815) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815
   os_family: Android
   browser_family: Android Browser
@@ -8980,19 +8101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; HUAWEI U8815 Build/HuaweiU8815) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815
   os_family: Android
   browser_family: Android Browser
@@ -9000,19 +8119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; HUAWEI U8815 Build/HuaweiU8815) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815
   os_family: Android
   browser_family: Chrome
@@ -9020,19 +8137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; U8815-51 Build/HuaweiU8815) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815
   os_family: Android
   browser_family: Chrome
@@ -9040,19 +8155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; U8815 Build/HuaweiU8815C02B885) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815C02B885
   os_family: Android
   browser_family: Android Browser
@@ -9060,19 +8173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; U8815 Build/HuaweiU8815C02B895) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815C02B895
   os_family: Android
   browser_family: Android Browser
@@ -9080,19 +8191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ro-ro; U8815 Build/HuaweiU8815C02B895) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8815C02B895
   os_family: Android
   browser_family: Android Browser
@@ -9100,19 +8209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; HUAWEI U8825-1 Build/HuaweiU8825-1) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8825-1
   os_family: Android
   browser_family: Chrome
@@ -9120,19 +8227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-in; HUAWEI U8950-1 Build/HuaweiU8950-1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U8950-1
   os_family: Android
   browser_family: Android Browser
@@ -9140,19 +8245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; U9202L-1 Build/HuaweiU9202L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U9202L
   os_family: Android
   browser_family: Chrome
@@ -9160,19 +8263,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; zh-CN; HUAWEI U9510E) U2/1.0.0 UCBrowser/9.4.2.365 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.2.365"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: U9510E
   os_family: Android
   browser_family: Unknown
@@ -9180,19 +8281,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; HUAWEI; W1-U00)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: W1-U00
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9200,19 +8299,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; HUAWEI; W2-U00)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: W2-U00
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9220,19 +8317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARS-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y Max
   os_family: Android
   browser_family: Chrome
@@ -9240,19 +8335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARS-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y Max
   os_family: Android
   browser_family: Chrome
@@ -9260,19 +8353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARS-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y Max
   os_family: Android
   browser_family: Chrome
@@ -9280,19 +8371,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-ph; HUAWEI Y210-0100 Build/HuaweiY210-0100) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y210-0100
   os_family: Android
   browser_family: Android Browser
@@ -9300,19 +8389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRO-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9320,19 +8407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRO-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9340,19 +8425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRO-U00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9360,19 +8443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CAG-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9380,19 +8461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CAG-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9400,19 +8479,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; HUAWEI Y300-0100 Build/HuaweiY300-0100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y300-0100
   os_family: Android
   browser_family: Android Browser
@@ -9420,19 +8497,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; HW-HUAWEI_Y300C/Y300CV100R001C92B168; 480*800; CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y300C
   os_family: Android
   browser_family: Android Browser
@@ -9440,19 +8515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI LUA-U22 Build/HUAWEILUA-U22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3II
   os_family: Android
   browser_family: Chrome
@@ -9460,19 +8533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI LUA-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3II
   os_family: Android
   browser_family: Chrome
@@ -9480,19 +8551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lua-U03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3II
   os_family: Android
   browser_family: Chrome
@@ -9500,19 +8569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LUA-L22 Build/HDLUA-L22) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y3II
   os_family: Android
   browser_family: Chrome
@@ -9520,19 +8587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9540,19 +8605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-U29) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9560,19 +8623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2017)
   os_family: Android
   browser_family: Chrome
@@ -9580,19 +8641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9600,19 +8659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9620,19 +8677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2018)
   os_family: Android
   browser_family: Chrome
@@ -9640,19 +8695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AMN-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2019)
   os_family: Android
   browser_family: Chrome
@@ -9660,19 +8713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AMN-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2019)
   os_family: Android
   browser_family: Chrome
@@ -9680,19 +8731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AMN-LX9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 (2019)
   os_family: Android
   browser_family: Chrome
@@ -9700,19 +8749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-LX5 Build/HUAWEIDRA-LX5; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 lite
   os_family: Android
   browser_family: Chrome
@@ -9720,19 +8767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRO-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -9740,19 +8785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CRO-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -9760,19 +8803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAG-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Lite (2018)
   os_family: Android
   browser_family: Chrome
@@ -9780,19 +8821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAG-L23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Lite (2018)
   os_family: Android
   browser_family: Chrome
@@ -9800,19 +8839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Prime (2018)
   os_family: Android
   browser_family: Chrome
@@ -9820,19 +8857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Prime (2018)
   os_family: Android
   browser_family: Chrome
@@ -9840,19 +8875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DRA-TL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5 Prime (2018)
   os_family: Android
   browser_family: Chrome
@@ -9860,19 +8893,17 @@
   user_agent: HUAWEI Y511-T00_TD/V1 Linux/3.4.5 Android/4.2.2 Release/05.02.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y511-T00
   os_family: Android
   browser_family: Android Browser
@@ -9880,19 +8911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L01 Build/HUAWEICUN-L01; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -9900,19 +8929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L02 Build/HUAWEICUN-L02; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-7.yml
+++ b/Tests/fixtures/smartphone-7.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L03 Build/HUAWEICUN-L03; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L21 Build/HUAWEICUN-L21; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L22 Build/HUAWEICUN-L22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L23 Build/HUAWEICUN-L23; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-L33 Build/HUAWEICUN-L33; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI CUN-U29 Build/HUAWEICUN-U29; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y5II
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; HUAWEI SCC-U21 Build/HuaweiSCC-U21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-L11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2016)
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-L41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2017)
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MYA-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2017)
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ATU-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2018)
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ATU-L22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2018)
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2019)
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/F966A5
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2019)
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-LX1N) AppleWebKit/537.36; (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2019)
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-LX1F Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 (2019)
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; ATU-L31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 Prime (2018)
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HUAWEI TIT-AL00 Build/HUAWEITIT-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 Pro
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; TIT-U02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 Pro
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MRD-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6 Pro (2019)
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Kavak Y625-U03 Build/ORINOQUIAY625-U03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y625
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Y635-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y635
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Y635-L02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y635
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Y635-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y635
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Y635-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y635 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAM-L21 Build/HUAWEICAM-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6II
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HUAWEI CAM-L03 Build/HUAWEICAM-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6II
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CAM-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6II
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CAM-L32 Build/CAM-L32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6II
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; MED-LX9N Build/HUAWEIMED-LX9N)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6p
   os_family: Android
   browser_family: Android Browser
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MED-LX9; HMSCore 5.0.2.301) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 HuaweiBrowser/10.1.4.303 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Huawei Browser
-    short_name: HU
     version: "10.1.4.303"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y6p
   os_family: Android
   browser_family: Unknown
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRT-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRT-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 (2017)
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-TL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 (2019)
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DUB-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 (2019)
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DUB-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 (2019)
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TRT-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Prime
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-L21 Build/HUAWEILDN-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Prime
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-L21) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Prime
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; zh-CN; LDN-AL00 Build/HUAWEILDN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.1.3.993 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.1.3.993"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Prime
   os_family: Android
   browser_family: Unknown
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LDN-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Prime (2018)
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Pro (2019)
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; DUB-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Pro (2019)
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; DUB-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y7 Pro (2019)
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; AQM-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y8p
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FLA-AL20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2018)
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FLA-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2018)
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; FLA-TL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2018)
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; JKM-TL00 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2019)
   os_family: Android
   browser_family: Chrome
@@ -983,7 +885,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JKM-AL00 Build/HUAWEIJKM-AL00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/044432 Mobile Safari/537.36 MMWEBID/1418 MicroMessenger/7.0.1380(0x2700003A) Process/tools NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
@@ -992,7 +893,7 @@
     version: "7.0.1380(0x2700003A)"
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2019)
   os_family: Android
   browser_family: Unknown
@@ -1000,19 +901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JKM-LX1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2019)
   os_family: Android
   browser_family: Chrome
@@ -1020,19 +919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JKM-LX2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2019)
   os_family: Android
   browser_family: Chrome
@@ -1040,19 +937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JKM-LX3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 (2019)
   os_family: Android
   browser_family: Chrome
@@ -1060,19 +955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; STK-L21 Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HU
+    brand: Huawei
     model: Y9 Prime (2019)
   os_family: Android
   browser_family: Chrome
@@ -1080,19 +973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Pearl K2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Pearl K2
   os_family: Android
   browser_family: Chrome
@@ -1100,19 +991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus_X10 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X10
   os_family: Android
   browser_family: Chrome
@@ -1120,19 +1009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus X12 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X12
   os_family: Android
   browser_family: Chrome
@@ -1140,19 +1027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus X14 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X14
   os_family: Android
   browser_family: Chrome
@@ -1160,19 +1045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus X15 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X15
   os_family: Android
   browser_family: Chrome
@@ -1180,19 +1063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus_X16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X16
   os_family: Android
   browser_family: Chrome
@@ -1200,19 +1081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venus X19 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: HV
+    brand: Hotwav
     model: Venus X19
   os_family: Android
   browser_family: Chrome
@@ -1220,19 +1099,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; IF9035 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.3.1202 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.3.1202"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: A2
   os_family: Android
   browser_family: Unknown
@@ -1240,19 +1117,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; IF9007 Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.12.2.1188 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: A3
   os_family: Android
   browser_family: Unknown
@@ -1260,19 +1135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; IF9001 Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.12.2.1188 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: Turbo 5
   os_family: Android
   browser_family: Unknown
@@ -1280,19 +1153,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; IF9021 Build/NRD90M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.12.5.1189 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: Turbo 5 Plus
   os_family: Android
   browser_family: Unknown
@@ -1300,19 +1171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IF9031) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: Vision 3
   os_family: Android
   browser_family: Chrome
@@ -1320,19 +1189,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; IF9031 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.6.1205 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.6.1205"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: I0
+    brand: InFocus
     model: Vision 3
   os_family: Android
   browser_family: Unknown
@@ -1340,19 +1207,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; W180 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.2.523 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.2.523"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: W180
   os_family: Android
   browser_family: Unknown
@@ -1360,19 +1225,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; es-es; iOCEAN X7 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X7
   os_family: Android
   browser_family: Android Browser
@@ -1380,19 +1243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; iOCEAN X7 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X7
   os_family: Android
   browser_family: Chrome
@@ -1400,19 +1261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X7S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X7S Elite
   os_family: Android
   browser_family: Chrome
@@ -1420,19 +1279,17 @@
   user_agent: mozilla/5.0 (linux; android 4.4.2; x7s-t build/kot49h) applewebkit/537.36 (khtml, like gecko) version/4.0 chrome/30.0.0.0 mobile safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X7S-T
   os_family: Android
   browser_family: Chrome
@@ -1440,19 +1297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X8 mini Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X8 Mini
   os_family: Android
   browser_family: Chrome
@@ -1460,19 +1315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X8 mini pro Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I1
+    brand: iOcean
     model: X8 Mini Pro
   os_family: Android
   browser_family: Chrome
@@ -1480,19 +1333,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; NT-3506M Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I2
+    brand: IconBIT
     model: NetTAB Mercury Quad FHD
   os_family: Android
   browser_family: Android Browser
@@ -1500,19 +1351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A502 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.106 YaBrowser/16.7.0.2777.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.7.0.2777.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: A502
   os_family: Android
   browser_family: Unknown
@@ -1520,19 +1369,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; I10-LE Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: I10-LE
   os_family: Android
   browser_family: Android Browser
@@ -1540,19 +1387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImSmart_A401 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: ImSmart A401
   os_family: Android
   browser_family: Chrome
@@ -1560,19 +1405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImSmart A501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: ImSmart A501
   os_family: Android
   browser_family: Chrome
@@ -1580,19 +1423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ImSmart A503 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: ImSmart A503
   os_family: Android
   browser_family: Chrome
@@ -1600,19 +1441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; ImSmart C501 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: ImSmart C501
   os_family: Android
   browser_family: Chrome
@@ -1620,19 +1459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Impression ImSmart C571 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I3
+    brand: Impression
     model: ImSmart C571
   os_family: Android
   browser_family: Chrome
@@ -1640,19 +1477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; INOI_2 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -1660,19 +1495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI 2 2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 2 (2019)
   os_family: Android
   browser_family: Chrome
@@ -1680,19 +1513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; INOI_2_LITE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 2 LITE
   os_family: Android
   browser_family: Chrome
@@ -1700,19 +1531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI 2 Lite 2019 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 YaBrowser/19.1.0.130 (lite) Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser Lite
-    short_name: YL
     version: "19.1.0.130"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 2 Lite (2019)
   os_family: Android
   browser_family: Unknown
@@ -1720,19 +1549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI 2 Lite 4Gb) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 2 Lite 4Gb
   os_family: Android
   browser_family: Chrome
@@ -1740,19 +1567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI_3_POWER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 3 POWER
   os_family: Android
   browser_family: Chrome
@@ -1760,19 +1585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI_5i_Lite Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 5i Lite
   os_family: Android
   browser_family: Chrome
@@ -1780,19 +1603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; INOI_7_LITE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 YaBrowser/18.11.2.730.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.2.730.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I4
+    brand: Inoi
     model: 7 LITE
   os_family: Android
   browser_family: Unknown
@@ -1800,19 +1621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo 2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -1820,19 +1639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo 2 LTE Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: 2 LTE
   os_family: Android
   browser_family: Chrome
@@ -1840,19 +1657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; InnJoo 3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "3"
   os_family: Android
   browser_family: Chrome
@@ -1860,19 +1675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; InnJoo 4 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: "4"
   os_family: Android
   browser_family: Chrome
@@ -1880,19 +1693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Halo2 3G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 2 3G
   os_family: Android
   browser_family: Chrome
@@ -1900,19 +1711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Halo 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 4
   os_family: Android
   browser_family: Chrome
@@ -1920,19 +1729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Halo_4_mini_LTE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo 4 Mini LTE
   os_family: Android
   browser_family: Chrome
@@ -1940,19 +1747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Halo Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo Plus
   os_family: Android
   browser_family: Chrome
@@ -1960,19 +1765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Halo X LTE Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Halo X LTE
   os_family: Android
   browser_family: Chrome
@@ -1980,19 +1783,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; Innjoo ONE 3G Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: One 3G
   os_family: Android
   browser_family: Android Browser
@@ -2000,19 +1801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; InnJoo_Pro2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: Pro 2
   os_family: Android
   browser_family: Chrome
@@ -2020,19 +1819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo X Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: X
   os_family: Android
   browser_family: Chrome
@@ -2040,19 +1837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; InnJoo X3 Build/InnJoo-X3-5.1-20161228-V1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I5
+    brand: InnJoo
     model: X3
   os_family: Android
   browser_family: Chrome
@@ -2060,19 +1855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP05 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP05
   os_family: Android
   browser_family: Chrome
@@ -2080,19 +1873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP06 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP06
   os_family: Android
   browser_family: Chrome
@@ -2100,19 +1891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP20 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP20
   os_family: Android
   browser_family: Chrome
@@ -2120,19 +1909,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 6.0; SP21 Build/MRA58K
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP21
   os_family: Android
   browser_family: Android Browser
@@ -2140,19 +1927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP401) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP401
   os_family: Android
   browser_family: Chrome
@@ -2160,19 +1945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP402 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP402
   os_family: Android
   browser_family: Chrome
@@ -2180,19 +1963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SP41 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP41
   os_family: Android
   browser_family: Chrome
@@ -2200,19 +1981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SP42 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP42
   os_family: Android
   browser_family: Chrome
@@ -2220,19 +1999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SP43 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP43
   os_family: Android
   browser_family: Chrome
@@ -2240,19 +2017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP453) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP453
   os_family: Android
   browser_family: Chrome
@@ -2260,19 +2035,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 7.0; SP454 Build/NRD90M
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP454
   os_family: Android
   browser_family: Android Browser
@@ -2280,19 +2053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP455 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP455
   os_family: Android
   browser_family: Chrome
@@ -2300,19 +2071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SP46 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP46
   os_family: Android
   browser_family: Chrome
@@ -2320,19 +2089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP493) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP493
   os_family: Android
   browser_family: Chrome
@@ -2340,19 +2107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP494) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP494
   os_family: Android
   browser_family: Chrome
@@ -2360,19 +2125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SP50 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP50
   os_family: Android
   browser_family: Chrome
@@ -2380,19 +2143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP510
   os_family: Android
   browser_family: Chrome
@@ -2400,19 +2161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP511) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP511
   os_family: Android
   browser_family: Chrome
@@ -2420,19 +2179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP514) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP514
   os_family: Android
   browser_family: Chrome
@@ -2440,19 +2197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP517) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP517
   os_family: Android
   browser_family: Chrome
@@ -2460,19 +2215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP531) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP531
   os_family: Android
   browser_family: Chrome
@@ -2480,19 +2233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP541) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP541
   os_family: Android
   browser_family: Chrome
@@ -2500,19 +2251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP542) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP542
   os_family: Android
   browser_family: Chrome
@@ -2520,19 +2269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP550
   os_family: Android
   browser_family: Chrome
@@ -2540,19 +2287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP551) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP551
   os_family: Android
   browser_family: Chrome
@@ -2560,19 +2305,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SP552) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP552
   os_family: Android
   browser_family: Chrome
@@ -2580,19 +2323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP554) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP554
   os_family: Android
   browser_family: Chrome
@@ -2600,19 +2341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SP571) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I6
+    brand: Irbis
     model: SP571
   os_family: Android
   browser_family: Chrome
@@ -2620,19 +2359,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; iLA_Silk Build/iLA_Silk)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: I7
+    brand: iLA
     model: Silk
   os_family: Android
   browser_family: Android Browser
@@ -2640,19 +2377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iLA-X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I7
+    brand: iLA
     model: X
   os_family: Android
   browser_family: Chrome
@@ -2660,19 +2395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LAMCY L350) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: I8
+    brand: iVA
     model: Lamcy L350
   os_family: Android
   browser_family: Chrome
@@ -2680,19 +2413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; APACHE G6 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IC
+    brand: iDroid
     model: Apache G6
   os_family: Android
   browser_family: Chrome
@@ -2700,19 +2431,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; en-US; Infinix_BUZZ) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: BUZZ
   os_family: Android
   browser_family: Unknown
@@ -2720,19 +2449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Infinix HOT 4 Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 4 Lite
   os_family: Android
   browser_family: Chrome
@@ -2740,19 +2467,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Infinix HOT 4 Pro Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.8.855 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.8.855"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 4 Pro
   os_family: Android
   browser_family: Unknown
@@ -2760,19 +2485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Infinix X606C Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 6
   os_family: Android
   browser_family: Chrome
@@ -2780,19 +2503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Infinix X608 Build/OPR1.170623.032; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 6 Pro
   os_family: Android
   browser_family: Chrome
@@ -2800,19 +2521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Infinix X624) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 7
   os_family: Android
   browser_family: Chrome
@@ -2820,19 +2539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X650C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 8
   os_family: Android
   browser_family: Chrome
@@ -2840,19 +2557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; Infinix X680B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot 9 Play
   os_family: Android
   browser_family: Chrome
@@ -2860,19 +2575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Infinix-X521 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot S
   os_family: Android
   browser_family: Chrome
@@ -2880,19 +2593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Infinix X573B Build/OPR1.170623.032; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Hot S3
   os_family: Android
   browser_family: Chrome
@@ -2900,19 +2611,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Infinix X450 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Race Bolt
   os_family: Android
   browser_family: Android Browser
@@ -2920,19 +2629,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; Infinix X501 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Race Jet
   os_family: Android
   browser_family: Android Browser
@@ -2940,19 +2647,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; Infinix X401 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Race Lite
   os_family: Android
   browser_family: Android Browser
@@ -2960,19 +2665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X626B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: S4
   os_family: Android
   browser_family: Chrome
@@ -2980,19 +2683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X652A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: S5
   os_family: Android
   browser_family: Chrome
@@ -3000,19 +2701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Infinix X653) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Smart 4
   os_family: Android
   browser_family: Chrome
@@ -3020,19 +2719,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Infinix X503 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 VIDObrowser Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Surf Bravo
   os_family: Android
   browser_family: Android Browser
@@ -3040,19 +2737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Infinix X352 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Surf Smart 2
   os_family: Android
   browser_family: Android Browser
@@ -3060,19 +2755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Infinix X351 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: Surf Smart 3G
   os_family: Android
   browser_family: Android Browser
@@ -3080,7 +2773,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Infinix X530 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -3089,7 +2781,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: IF
+    brand: Infinix
     model: X530
   os_family: Android
   browser_family: Unknown
@@ -3097,19 +2789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AlienXLite2020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Alien X Lite (2020)
   os_family: Android
   browser_family: Chrome
@@ -3117,19 +2807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iHunt_Like Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Like
   os_family: Android
   browser_family: Chrome
@@ -3137,19 +2825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Like_3 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Like 3
   os_family: Android
   browser_family: Chrome
@@ -3157,19 +2843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Like_3_Pro Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Like 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -3177,19 +2861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Like_4U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Like 4U
   os_family: Android
   browser_family: Chrome
@@ -3197,19 +2879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; One_ Love_ Dual _Camera Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: One Love
   os_family: Android
   browser_family: Chrome
@@ -3217,19 +2897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; S10_Tank_2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: S10 Tank (2019)
   os_family: Android
   browser_family: Chrome
@@ -3237,19 +2915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; S60_Discovery_2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: S60 Discovery (2019)
   os_family: Android
   browser_family: Chrome
@@ -3257,19 +2933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TITAN_P11000_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: Titan P11000 Pro
   os_family: Android
   browser_family: Chrome
@@ -3277,19 +2951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X300 Elite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IH
+    brand: iHunt
     model: X300 Elite
   os_family: Android
   browser_family: Chrome
@@ -3297,19 +2969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; intki_E86 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baidubrowser/3.1.6.4 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "3.1.6.4"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: II
+    brand: Inkti
     model: E86
   os_family: Android
   browser_family: Baidu
@@ -3317,19 +2987,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; es-es; Elektra L Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: Elektra L
   os_family: Android
   browser_family: Android Browser
@@ -3337,19 +3005,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Elektra XL Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: Elektra XL
   os_family: Android
   browser_family: Android Browser
@@ -3357,19 +3023,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; i-Joy i-Call Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: i-Call
   os_family: Android
   browser_family: Android Browser
@@ -3377,19 +3041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; i-Call 300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: i-Call 300
   os_family: Android
   browser_family: Android Browser
@@ -3397,19 +3059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; i-Call 300v2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: i-Call 300v2
   os_family: Android
   browser_family: Android Browser
@@ -3417,19 +3077,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ro-ro; i-Call 504 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IJ
+    brand: i-Joy
     model: i-Call 504
   os_family: Android
   browser_family: Android Browser
@@ -3437,19 +3095,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; IMO Discovery II Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: Discovery II
   os_family: Android
   browser_family: Android Browser
@@ -3457,19 +3113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; IMO FEEL A2 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: Feel A2
   os_family: Android
   browser_family: Chrome
@@ -3477,19 +3131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; IMO Q2 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: Q2
   os_family: Android
   browser_family: Chrome
@@ -3497,19 +3149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; IMO Q2 Plus Build/O21019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: Q2 Plus
   os_family: Android
   browser_family: Chrome
@@ -3517,19 +3167,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; IMO Q8 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: Q8 Clarity
   os_family: Android
   browser_family: Android Browser
@@ -3537,19 +3185,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; IMO S50 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S50 Light
   os_family: Android
   browser_family: Android Browser
@@ -3557,19 +3203,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; id-id; IMO S67 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S67 Blast
   os_family: Android
   browser_family: Android Browser
@@ -3577,19 +3221,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; in-id; IMO S78 Build/GRK39F) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S78 Glory
   os_family: Android
   browser_family: Android Browser
@@ -3597,19 +3239,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; IMO S87 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S87 Raptor
   os_family: Android
   browser_family: Android Browser
@@ -3617,19 +3257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; IMO S88 Build/IMM76D) AppleWebKit/537.36 (KHTML like Gecko) Chrome/29.0.1547.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "29.0.1547.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S88 Discovery
   os_family: Android
   browser_family: Chrome
@@ -3637,19 +3275,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; IMO S89 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S89 Miracle
   os_family: Android
   browser_family: Android Browser
@@ -3657,19 +3293,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; IMO S98 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S98 Champion
   os_family: Android
   browser_family: Android Browser
@@ -3677,19 +3311,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; id-id; IMO S99 Build/JZO54K) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IL
+    brand: IMO Mobile
     model: S99 Ocean
   os_family: Android
   browser_family: Android Browser
@@ -3697,19 +3329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; i-STYLE2.1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 2.1
   os_family: Android
   browser_family: Android Browser
@@ -3717,19 +3347,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; i-STYLE2.1A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 2.1A
   os_family: Android
   browser_family: Android Browser
@@ -3737,19 +3365,17 @@
   user_agent: Android 4.4.2;AppleWebKit/537.36;Build/KOT49H;i-mobile I-STYLE 217 Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 217
   os_family: Android
   browser_family: Android Browser
@@ -3757,19 +3383,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; th-th; i-mobile i-STYLE 4 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 4
   os_family: Android
   browser_family: Android Browser
@@ -3777,19 +3401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; i-mobile i-style 7.1 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 7.1
   os_family: Android
   browser_family: Android Browser
@@ -3797,19 +3419,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; th-th; i-mobile i-STYLE 7.2 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 7.2
   os_family: Android
   browser_family: Android Browser
@@ -3817,19 +3437,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; km-kh; i-mobile i-STYLE 7.8 DTV Build/i_style_7_8_DTV) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 7.8 DTV
   os_family: Android
   browser_family: Android Browser
@@ -3837,19 +3455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; i-mobile i-style 8 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style 8
   os_family: Android
   browser_family: Chrome
@@ -3857,19 +3473,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; th-th; i-mobile i-STYLE Q2 DUO Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: i-Style Q2 DUO
   os_family: Android
   browser_family: Android Browser
@@ -3877,19 +3491,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; i-mobile IQ 1068 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 1068
   os_family: Android
   browser_family: Android Browser
@@ -3897,19 +3509,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; i-mobile IQ 3 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 3
   os_family: Android
   browser_family: Android Browser
@@ -3917,19 +3527,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; th-th; i-mobile IQ 5.1A Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 5.1A
   os_family: Android
   browser_family: Android Browser
@@ -3937,19 +3545,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; IQ 5.5 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 5.5
   os_family: Android
   browser_family: Android Browser
@@ -3957,19 +3563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; i-mobile IQ 5.5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 5.5
   os_family: Android
   browser_family: Android Browser
@@ -3977,19 +3581,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; IQ 5.6 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 5.6
   os_family: Android
   browser_family: Android Browser
@@ -3997,19 +3599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; IQ 5.6A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 5.6A
   os_family: Android
   browser_family: Android Browser
@@ -4017,19 +3617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; i-mobile IQ 6A Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 6A
   os_family: Android
   browser_family: Chrome
@@ -4037,19 +3635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; IQ9.1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ 9.1
   os_family: Android
   browser_family: Chrome
@@ -4057,19 +3653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; i-mobile IQ X3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ X3
   os_family: Android
   browser_family: Android Browser
@@ -4077,19 +3671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; i-mobile IQ1-1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ1-1
   os_family: Android
   browser_family: Android Browser
@@ -4097,19 +3689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; i-mobile IQ5.1 Pro Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IO
+    brand: i-mobile
     model: IQ5.1 Pro
   os_family: Android
   browser_family: Android Browser
@@ -4117,19 +3707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Jade7s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IP
+    brand: iPro
     model: Jade 7s
   os_family: Android
   browser_family: Chrome
@@ -4137,19 +3725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Kylin 5.0 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IP
+    brand: iPro
     model: Kylin 5.0
   os_family: Android
   browser_family: Chrome
@@ -4157,19 +3743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Kylin_5.0S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IP
+    brand: iPro
     model: Kylin 5.0S
   os_family: Android
   browser_family: Chrome
@@ -4177,19 +3761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Kylin 5.5 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IP
+    brand: iPro
     model: Kylin 5.5
   os_family: Android
   browser_family: Chrome
@@ -4197,19 +3779,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; INQ Cloud Touch Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IQ
+    brand: INQ
     model: Cloud Touch
   os_family: Android
   browser_family: Android Browser
@@ -4217,19 +3797,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; INQ Cloud Touch -parrot Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IQ
+    brand: INQ
     model: Cloud Touch -parrot
   os_family: Android
   browser_family: Android Browser
@@ -4237,19 +3815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; inew_one Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: one
   os_family: Android
   browser_family: Chrome
@@ -4257,19 +3833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; INEW V3 Build/KOT49H) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3
   os_family: Android
   browser_family: Chrome
@@ -4277,19 +3851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V3 Plus Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3 Plus
   os_family: Android
   browser_family: Chrome
@@ -4297,19 +3869,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; V3-E Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3-E
   os_family: Android
   browser_family: Android Browser
@@ -4317,19 +3887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V3E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3-E
   os_family: Android
   browser_family: Chrome
@@ -4337,19 +3905,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fa-ir; V3C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30/TansoDL
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3C
   os_family: Android
   browser_family: Android Browser
@@ -4357,19 +3923,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; V3C) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.460"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V3C
   os_family: Android
   browser_family: Unknown
@@ -4377,19 +3941,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V7A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IW
+    brand: iNew
     model: V7A
   os_family: Android
   browser_family: Chrome
@@ -4397,19 +3959,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Aqua_3G) U2/1.0.0 UCBrowser/9.2.0.419 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.419"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua 3G
   os_family: Android
   browser_family: Unknown
@@ -4417,19 +3977,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Aqua.Active Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Active
   os_family: Android
   browser_family: Android Browser
@@ -4437,19 +3995,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; hi-in; Aqua Glory Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Glory
   os_family: Android
   browser_family: Android Browser
@@ -4457,19 +4013,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Aqua_i-4+) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua i-4+
   os_family: Android
   browser_family: Unknown
@@ -4477,19 +4031,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Intex Aqua Marvel Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Marvel
   os_family: Android
   browser_family: Android Browser
@@ -4497,19 +4049,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-in; Aqua Star Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Star
   os_family: Android
   browser_family: Android Browser
@@ -4517,19 +4067,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Aqua Style Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Style
   os_family: Android
   browser_family: Unknown
@@ -4537,19 +4085,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; Aqua_Sx) U2/1.0.0 UCBrowser/9.0.1.379 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Sx
   os_family: GNU/Linux
   browser_family: Opera
@@ -4557,19 +4103,17 @@
   user_agent: Aqua Y2/V1 Linux/3.4.5 Android/4.2.2 Release/03.26.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Aqua Y2
   os_family: Android
   browser_family: Android Browser
@@ -4577,19 +4121,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Cloud Fame 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud Fame 4G
   os_family: Android
   browser_family: Chrome
@@ -4597,19 +4139,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; INTEX_CLOUD_X1) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: CLOUD X1
   os_family: Android
   browser_family: Unknown
@@ -4617,19 +4157,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; INTEX Cloud X11 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud X11
   os_family: Android
   browser_family: Android Browser
@@ -4637,19 +4175,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3; en-US; Cloud_X2) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud X2
   os_family: Android
   browser_family: Unknown
@@ -4657,19 +4193,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; en-US; Cloud_X2 Build/MocorDroid4.0.1) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 UCBrowser/9.2.0.419 Mobile
   os:
     name: MocorDroid
-    short_name: MCD
     version: "4.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.419"
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud X2
   os_family: Android
   browser_family: Unknown
@@ -4677,19 +4211,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Intex Cloud X4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/18.0.1025.133 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud X4
   os_family: Android
   browser_family: Chrome
@@ -4697,19 +4229,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-in; Cloud X5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud X5
   os_family: Android
   browser_family: Android Browser
@@ -4717,19 +4247,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Cloud Y2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud Y2
   os_family: Android
   browser_family: Android Browser
@@ -4737,19 +4265,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; INTEX Cloud Y4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IX
+    brand: Intex
     model: Cloud Y4
   os_family: Android
   browser_family: Android Browser
@@ -4757,19 +4283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; AUXUS AX01 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IY
+    brand: iBerry
     model: AX01
   os_family: Android
   browser_family: Chrome
@@ -4777,19 +4301,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; iberry AUXUS AX02 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IY
+    brand: iBerry
     model: AX02
   os_family: Android
   browser_family: Android Browser
@@ -4797,19 +4319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AUXUS Nuclea N1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.64462
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "16.0.1212.64462"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IY
+    brand: iBerry
     model: Nuclea N1
   os_family: Android
   browser_family: Opera
@@ -4817,19 +4337,17 @@
   user_agent: 'JUC (Linux; U; 2.3.5; zh-cn; iNote_beyond; 480*854) UCWEB7.9.0.94/139/444'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "7.9.0.94"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: iNote beyond
   os_family: GNU/Linux
   browser_family: Unknown
@@ -4837,19 +4355,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; iNote beyond Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: iNote beyond
   os_family: Android
   browser_family: Android Browser
@@ -4857,19 +4373,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; iNote_mini) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: iNote mini
   os_family: Android
   browser_family: Unknown
@@ -4877,19 +4391,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; iNote mini Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: iNote mini
   os_family: Android
   browser_family: Android Browser
@@ -4897,19 +4409,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; itel_IT1351) U2/1.0.0 UCBrowser/9.1.1.420 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: IT1351
   os_family: GNU/Linux
   browser_family: Opera
@@ -4917,19 +4427,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; itel IT1351 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: IT1351
   os_family: Android
   browser_family: Android Browser
@@ -4937,19 +4445,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-be; itel IT1351E Build/JZO57K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: IT1351E
   os_family: Android
   browser_family: Android Browser
@@ -4957,19 +4463,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.1.2; fr-BE; itel_IT1351E) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: IT1351E
   os_family: Android
   browser_family: Unknown
@@ -4977,19 +4481,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; fr-FR; itel_it1400) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1400
   os_family: Android
   browser_family: Unknown
@@ -4997,19 +4499,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-be; itel it1500 Build/JZO57K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1500
   os_family: Android
   browser_family: Android Browser
@@ -5017,19 +4517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; itel-it1512) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/D2881C
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1512
   os_family: Android
   browser_family: Chrome
@@ -5037,19 +4535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; itel-it1520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: IZ
+    brand: iTel
     model: it1520
   os_family: Android
   browser_family: Chrome
@@ -5057,19 +4553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BLASTER Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Blaster
   os_family: Android
   browser_family: Chrome
@@ -5077,19 +4571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; BLASTER 2 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Blaster 2
   os_family: Android
   browser_family: Chrome
@@ -5097,19 +4589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; COSMO_L707 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Cosmo L707
   os_family: Android
   browser_family: Chrome
@@ -5117,19 +4607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; COSMO L808) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Cosmo L808
   os_family: Android
   browser_family: Chrome
@@ -5137,19 +4625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FREEDOM Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Freedom
   os_family: Android
   browser_family: Chrome
@@ -5157,19 +4643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FREEDOM C100 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Freedom C100
   os_family: Android
   browser_family: Chrome
@@ -5177,19 +4661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FREEDOM_M303 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Freedom M303
   os_family: Android
   browser_family: Chrome
@@ -5197,19 +4679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; FREEDOM X1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Freedom X1
   os_family: Android
   browser_family: Chrome
@@ -5217,19 +4697,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; JUST5SPACER Build/JUST5JUST5SPACER) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.0.1183 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.0.1183"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Spacer
   os_family: Android
   browser_family: Unknown
@@ -5237,19 +4715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Just5-SPACER2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Spacer 2
   os_family: Android
   browser_family: Chrome
@@ -5257,19 +4733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Just5-SPACER2s Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: J5
+    brand: Just5
     model: Spacer 2S
   os_family: Android
   browser_family: Chrome
@@ -5277,19 +4751,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.9; ru-ru; jFone JS501 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: JF
+    brand: JFone
     model: JS501
   os_family: Android
   browser_family: Android Browser
@@ -5297,19 +4769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Jinga Basco L3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Basco L3
   os_family: Android
   browser_family: Chrome
@@ -5317,19 +4787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Jinga Basco neo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Basco Neo
   os_family: Android
   browser_family: Chrome
@@ -5337,19 +4805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hotz_M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Hotz M1
   os_family: Android
   browser_family: Chrome
@@ -5357,19 +4823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; JINGA_IGO_L2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: IGO L2
   os_family: Android
   browser_family: Chrome
@@ -5377,19 +4841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; JINGA_IGO_M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: IGO M1
   os_family: Android
   browser_family: Chrome
@@ -5397,19 +4859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Jinga Iron) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Iron
-    short_name: IR
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Iron
   os_family: Android
   browser_family: Chrome
@@ -5417,19 +4877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Optim4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Optim 4G
   os_family: Android
   browser_family: Chrome
@@ -5437,19 +4895,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; ru-RU; PassPlus Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.6.6.900
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.6.6.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Pass Plus
   os_family: Android
   browser_family: Unknown
@@ -5457,19 +4913,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Jinga Trezor S1 Plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JG
+    brand: Jinga
     model: Trezor S1 Plus
   os_family: Android
   browser_family: Chrome
@@ -5477,19 +4931,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Jiayu G2F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G2F
   os_family: Android
   browser_family: Chrome
@@ -5497,19 +4949,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Jiayu G3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G3
   os_family: Android
   browser_family: Chrome
@@ -5517,19 +4967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; JIAYU G3S Build/HM2013023) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G3S
   os_family: Android
   browser_family: Chrome
@@ -5537,19 +4985,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Jiayu G4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G4
   os_family: Android
   browser_family: Chrome
@@ -5557,19 +5003,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; JY-G4\G5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G4/G5
   os_family: Android
   browser_family: Chrome
@@ -5577,19 +5021,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Jiayu G4_G5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G4/G5
   os_family: Android
   browser_family: Chrome
@@ -5597,19 +5039,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; JY-G4_G5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G4/G5
   os_family: Android
   browser_family: Unknown
@@ -5617,19 +5057,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Jiayu G4S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: G4S
   os_family: Android
   browser_family: Chrome
@@ -5637,19 +5075,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; JY-G2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: JY-G2
   os_family: Android
   browser_family: Android Browser
@@ -5657,19 +5093,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; JY-G3 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: JY-G3
   os_family: Android
   browser_family: Android Browser
@@ -5677,19 +5111,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; JY-G4 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: JY-G4
   os_family: Android
   browser_family: Android Browser
@@ -5697,19 +5129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; JY-G5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: JY-G5
   os_family: Android
   browser_family: Android Browser
@@ -5717,19 +5147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; JIAYU S2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: S2
   os_family: Android
   browser_family: Chrome
@@ -5737,19 +5165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; JIAYU-S3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JI
+    brand: Jiayu
     model: S3
   os_family: Android
   browser_family: Chrome
@@ -5757,19 +5183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; JKL A28 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: JK
+    brand: JKL
     model: A28
   os_family: Android
   browser_family: Chrome
@@ -5777,19 +5201,17 @@
   user_agent: Mozilla/5.0 (Maemo; Linux; U; Jolla; Sailfish; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0 SailfishBrowser/1.0 like Safari/538.1
   os:
     name: Sailfish OS
-    short_name: SAF
     version: ""
     platform: ""
   client:
     type: browser
     name: Sailfish Browser
-    short_name: SA
     version: "1.0"
     engine: Gecko
     engine_version: "26.0"
   device:
     type: smartphone
-    brand: JO
+    brand: Jolla
     model: ""
   os_family: GNU/Linux
   browser_family: Sailfish Browser
@@ -5797,19 +5219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elegance_4_5 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 4.5"
   os_family: Android
   browser_family: Chrome
@@ -5817,19 +5237,17 @@
   user_agent: Elegance_5_0/V1 Linux/3.10.72 Android/5.1 Release/03.10.2015 Browser/AppleWebKit537.36 Chrome/39.0.0.0 Mobile Safari/537.36 System/Android 5.1;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 5.0"
   os_family: Android
   browser_family: Chrome
@@ -5837,19 +5255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elegance_5_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 5.1"
   os_family: Android
   browser_family: Chrome
@@ -5857,19 +5273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ELEGANCE_5_1_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 5.1" Pro
   os_family: Android
   browser_family: Chrome
@@ -5877,19 +5291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elegance_5_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 5.5"
   os_family: Android
   browser_family: Chrome
@@ -5897,19 +5309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elegance_5_5_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K1
+    brand: Kiano
     model: Elegance 5.5" Pro
   os_family: Android
   browser_family: Chrome
@@ -5917,19 +5327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; NET1100 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K2
+    brand: KRONO
     model: NET 1100
   os_family: Android
   browser_family: Chrome
@@ -5937,19 +5345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KENEKSI_Amber Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Amber
   os_family: Android
   browser_family: Chrome
@@ -5957,19 +5363,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Amulet AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Amulet
   os_family: Android
   browser_family: Unknown
@@ -5977,19 +5381,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Chance AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Chance
   os_family: Android
   browser_family: Chrome
@@ -5997,19 +5399,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Choice AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Choice
   os_family: Android
   browser_family: Chrome
@@ -6017,19 +5417,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Crystal AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Crystal
   os_family: Android
   browser_family: Unknown
@@ -6037,19 +5435,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI_Delta_Dual Build/HD AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Delta Dual
   os_family: Android
   browser_family: Chrome
@@ -6057,19 +5453,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI-Dream Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Dream
   os_family: Android
   browser_family: Android Browser
@@ -6077,19 +5471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI-Fire Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Fire
   os_family: Android
   browser_family: Android Browser
@@ -6097,19 +5489,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Flame AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Flame
   os_family: Android
   browser_family: Chrome
@@ -6117,19 +5507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI-FLASH Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Flash
   os_family: Android
   browser_family: Android Browser
@@ -6137,19 +5525,17 @@
   user_agent: KENEKSI-Flora/V1 Linux/3.4.39 Android/4.2.2 Release/09.24.2014 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Flora
   os_family: Android
   browser_family: Android Browser
@@ -6157,19 +5543,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Glass Build/JDQ39; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.81 Mobile Safari/537.36 Puffin/7.8.2.40664AP
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.2.40664"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Glass
   os_family: Android
   browser_family: Unknown
@@ -6177,19 +5561,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; Hemera Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Hemera
   os_family: Android
   browser_family: Opera
@@ -6197,19 +5579,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; KENEKSI_liberty Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Liberty
   os_family: Android
   browser_family: Android Browser
@@ -6217,19 +5597,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Libra_Dual Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Libra Dual
   os_family: Android
   browser_family: Chrome
@@ -6237,19 +5615,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; KENEKSI-Moon Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Moon
   os_family: Android
   browser_family: Android Browser
@@ -6257,19 +5633,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Norma AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Norma
   os_family: Android
   browser_family: Unknown
@@ -6277,19 +5651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI_Norma 2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Norma 2
   os_family: Android
   browser_family: Android Browser
@@ -6297,19 +5669,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Rock AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Rock
   os_family: Android
   browser_family: Chrome
@@ -6317,19 +5687,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI_Sigma AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Sigma
   os_family: Android
   browser_family: Chrome
@@ -6337,19 +5705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI_Sky Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Sky
   os_family: Android
   browser_family: Android Browser
@@ -6357,19 +5723,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Solo Build/JDQ39; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.81 Mobile Safari/537.36 Puffin/7.8.0.40457AP
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.0.40457"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Solo
   os_family: Android
   browser_family: Unknown
@@ -6377,19 +5741,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Soul AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Soul
   os_family: Android
   browser_family: Chrome
@@ -6397,19 +5759,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI_Star Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Star
   os_family: Android
   browser_family: Opera
@@ -6417,19 +5777,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; KENEKSI_Step AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Step
   os_family: Android
   browser_family: Chrome
@@ -6437,19 +5795,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; KENEKSI_Storm AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Storm
   os_family: Android
   browser_family: Chrome
@@ -6457,19 +5813,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; KENEKSI-SUN Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Sun
   os_family: Android
   browser_family: Android Browser
@@ -6477,19 +5831,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; Teta Dual Build/HD AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Teta Dual
   os_family: Android
   browser_family: Chrome
@@ -6497,19 +5849,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI-Wind AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.1011.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.1011.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Wind
   os_family: Android
   browser_family: Unknown
@@ -6517,19 +5867,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; KENEKSI_Zeta AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K3
+    brand: Keneksi
     model: Zeta
   os_family: Android
   browser_family: Chrome
@@ -6537,19 +5885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN_A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K4
+    brand: Kaan
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -6557,19 +5903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN N1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K4
+    brand: Kaan
     model: N1
   os_family: Android
   browser_family: Chrome
@@ -6577,19 +5921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KAAN_N2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K4
+    brand: Kaan
     model: N2
   os_family: Android
   browser_family: Chrome
@@ -6597,19 +5939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; KULIAO K10 Build/073; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: K8
+    brand: Kuliao
     model: K10
   os_family: Android
   browser_family: Chrome
@@ -6617,19 +5957,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; Kooper-mobile-W502 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: K9
+    brand: Kooper
     model: Mobile W502
   os_family: Android
   browser_family: Android Browser
@@ -6637,19 +5975,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Karbonn A1* Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: 'A1*'
   os_family: Android
   browser_family: Android Browser
@@ -6657,19 +5993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Karbonn A1+ Duple Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A1+ Duple
   os_family: Android
   browser_family: Android Browser
@@ -6677,19 +6011,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; Karbonn_A1+_Duple) U2/1.0.0 UCBrowser/9.0.2.389 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A1+ Duple
   os_family: GNU/Linux
   browser_family: Opera
@@ -6697,19 +6029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Karbonn A10 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 UCBrowser/3.1.0.403
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.1.0.403"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A10
   os_family: Android
   browser_family: Unknown
@@ -6717,19 +6047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Karbonn A2 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A2
   os_family: Android
   browser_family: Unknown
@@ -6737,19 +6065,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Karbonn_A2+) U2/1.0.0 UCBrowser/9.0.2.389 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.389"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A2+
   os_family: Android
   browser_family: Unknown
@@ -6757,19 +6083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Karbonn A26 Build/JRO03C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A26
   os_family: Android
   browser_family: Android Browser
@@ -6777,19 +6101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Karbonn A27+ Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A27+
   os_family: Android
   browser_family: Android Browser
@@ -6797,19 +6119,17 @@
   user_agent: Karbonn A35/V1 Linux/3.4.5 Android/4.2.2 Release/03.26.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A35
   os_family: Android
   browser_family: Android Browser
@@ -6817,19 +6137,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; Karbonn A4  Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A4
   os_family: Android
   browser_family: Android Browser
@@ -6837,19 +6155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us ; Karbonn A50 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.5.3.246/145/33756
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.5.3.246"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A50
   os_family: Android
   browser_family: Unknown
@@ -6857,19 +6173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Karbonn A5i Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A5i
   os_family: Android
   browser_family: Android Browser
@@ -6877,19 +6191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; Karbonn A6 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A6
   os_family: Android
   browser_family: Android Browser
@@ -6897,19 +6209,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Karbonn_A91) U2/1.0.0 UCBrowser/9.1.1.420 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.1.1.420"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: A91
   os_family: Android
   browser_family: Unknown
@@ -6917,19 +6227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Aura Note Play Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Aura Note Play
   os_family: Android
   browser_family: Chrome
@@ -6937,19 +6245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Aura Sleek Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Aura Sleek Plus
   os_family: Android
   browser_family: Chrome
@@ -6957,19 +6263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K9 Kavach 4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Kavach 4G
   os_family: Android
   browser_family: Chrome
@@ -6977,19 +6281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K9 Music 4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Music 4G
   os_family: Android
   browser_family: Chrome
@@ -6997,19 +6299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K9 Smart Build/K9 Smart) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart
   os_family: Android
   browser_family: Chrome
@@ -7017,19 +6317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; K9 Smart 1GB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart
   os_family: Android
   browser_family: Chrome
@@ -7037,19 +6335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; K9 Smart 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart 4G
   os_family: Android
   browser_family: Chrome
@@ -7057,19 +6353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; K9 Smart 4G. Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart 4G
   os_family: Android
   browser_family: Chrome
@@ -7077,19 +6371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K9 Smart Grand Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart Grand
   os_family: Android
   browser_family: Chrome
@@ -7097,19 +6389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K9 Smart Yuva Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Smart Yuva
   os_family: Android
   browser_family: Chrome
@@ -7117,19 +6407,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; karbonnK9 Viraat 4G Build/KOT49H)  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Viraat 4G
   os_family: Android
   browser_family: Chrome
@@ -7137,19 +6425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; K9 VIRAAT 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: K9 Viraat 4G
   os_family: Android
   browser_family: Chrome
@@ -7157,7 +6443,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Karbonn S2 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.2.17.1009776.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -7166,7 +6451,7 @@
     version: "3.2.17.1009776"
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: S2
   os_family: Android
   browser_family: Unknown
@@ -7174,19 +6459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Titanium Jumbo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium Jumbo
   os_family: Android
   browser_family: Chrome
@@ -7194,19 +6477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Titanium Jumbo 2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium Jumbo 2
   os_family: Android
   browser_family: Chrome
@@ -7214,19 +6495,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; Titanium S2 Plus Build/Karbonn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium S2 Plus
   os_family: Android
   browser_family: Chrome
@@ -7234,19 +6513,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; Titanium_S2_Plus Build/Karbonn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium S2 Plus
   os_family: Android
   browser_family: Chrome
@@ -7254,19 +6531,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; Titanium_S99 Build/Karbonn) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium S99
   os_family: Android
   browser_family: Chrome
@@ -7274,19 +6549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Titanium Vista 4G Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.3
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KA
+    brand: Karbonn
     model: Titanium Vista 4G
   os_family: Android
   browser_family: Chrome
@@ -7294,7 +6567,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; koobee M2 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -7303,7 +6575,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: KB
+    brand: Koobee
     model: M2
   os_family: Android
   browser_family: Unknown
@@ -7311,19 +6583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; koobee M3 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KB
+    brand: Koobee
     model: M3
   os_family: Android
   browser_family: Android Browser
@@ -7331,19 +6601,17 @@
   user_agent: koobee-T550/1.0 Linux/2.6.35.7 Android/2.3.5 Release/01.17.2013 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KB
+    brand: Koobee
     model: T550
   os_family: Android
   browser_family: Android Browser
@@ -7351,19 +6619,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1.1; Kruger&Matz DRIVE 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: DRIVE 4
   os_family: Android
   browser_family: Chrome
@@ -7371,19 +6637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Kruger Matz DRIVE 4 mini LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: DRIVE 4 mini LTE
   os_family: Android
   browser_family: Chrome
@@ -7391,19 +6655,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0.1; Kruger&Matz Drive 4S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: DRIVE 4S
   os_family: Android
   browser_family: Chrome
@@ -7411,19 +6673,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Kruger&Matz Drive 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: DRIVE 5
   os_family: Android
   browser_family: Chrome
@@ -7431,19 +6691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Kruger_Matz FLOW 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: FLOW 4
   os_family: Android
   browser_family: Chrome
@@ -7451,19 +6709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Kruger_Matz FLOW 4S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: FLOW 4S
   os_family: Android
   browser_family: Chrome
@@ -7471,19 +6727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KrugerMatz_LIVE4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: LIVE 4
   os_family: Android
   browser_family: Chrome
@@ -7491,19 +6745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LIVE4_KM0438 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: LIVE 4 KM0438
   os_family: Android
   browser_family: Chrome
@@ -7511,19 +6763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LIVE4_KM0439) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: LIVE 4 KM0439
   os_family: Android
   browser_family: Chrome
@@ -7531,19 +6781,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Kruger&Matz _LIVE5_KM0450) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: LIVE 5 KM0450
   os_family: Android
   browser_family: Chrome
@@ -7551,19 +6799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MOVE_6_mini Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: MOVE 6 Mini
   os_family: Android
   browser_family: Chrome
@@ -7571,19 +6817,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; Kruger&Matz MOVE 6S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: MOVE 6S
   os_family: Android
   browser_family: Chrome
@@ -7591,19 +6835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MOVE_7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: MOVE 7
   os_family: Android
   browser_family: Chrome
@@ -7611,19 +6853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MOVE_8 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KE
+    brand: 'Krüger&Matz'
     model: MOVE 8
   os_family: Android
   browser_family: Chrome
@@ -7631,19 +6871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Kogan Agora 6Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KG
+    brand: Kogan
     model: Agora 6Plus
   os_family: Android
   browser_family: Chrome
@@ -7651,19 +6889,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ko-kr; KM-E100 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KH
+    brand: KT-Tech
     model: KM-E100
   os_family: Android
   browser_family: Android Browser
@@ -7671,19 +6907,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; kingsun Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KI
+    brand: Kingsun
     model: ""
   os_family: Android
   browser_family: Unknown
@@ -7691,19 +6925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KINGSUN-F1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.36 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.36"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KI
+    brand: Kingsun
     model: F1
   os_family: Android
   browser_family: Chrome
@@ -7711,7 +6943,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; KINGSUN-S5Q Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/4.9 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -7720,7 +6951,7 @@
     version: "4.9"
   device:
     type: smartphone
-    brand: KI
+    brand: Kingsun
     model: S5Q
   os_family: Android
   browser_family: Unknown
@@ -7728,7 +6959,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; KINGSUN S6 Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/4.9 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -7737,7 +6967,7 @@
     version: "4.9"
   device:
     type: smartphone
-    brand: KI
+    brand: Kingsun
     model: S6
   os_family: Android
   browser_family: Unknown
@@ -7745,19 +6975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KINGSUN-S8 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KI
+    brand: Kingsun
     model: S8
   os_family: Android
   browser_family: Chrome
@@ -7765,19 +6993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ektra) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KK
+    brand: Kodak
     model: Ektra
   os_family: Android
   browser_family: Chrome
@@ -7785,19 +7011,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; IM5 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KK
+    brand: Kodak
     model: IM5
   os_family: Android
   browser_family: Chrome
@@ -7805,19 +7029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; KODAK_SMARTWAY_M1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KK
+    brand: Kodak
     model: Smartway M1
   os_family: Android
   browser_family: Chrome
@@ -7825,19 +7047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KODAK_SMARTWAY_T1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KK
+    brand: Kodak
     model: Smartway T1
   os_family: Android
   browser_family: Chrome
@@ -7845,19 +7065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KODAK SMARTWAY X1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KK
+    brand: Kodak
     model: Smartway X1
   os_family: Android
   browser_family: Chrome
@@ -7865,19 +7083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ELEMENT Q Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KL
+    brand: Kalley
     model: Element Q
   os_family: Android
   browser_family: Chrome
@@ -7885,19 +7101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Komu Color Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KM
+    brand: Komu
     model: Color
   os_family: Android
   browser_family: Chrome
@@ -7905,19 +7119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KOMU ENERGY Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KM
+    brand: Komu
     model: ENERGY
   os_family: Android
   browser_family: Chrome
@@ -7925,19 +7137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; KOMU-MINI Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KM
+    brand: Komu
     model: MINI
   os_family: Android
   browser_family: Android Browser
@@ -7945,19 +7155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SD4930UR Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.173 Mobile Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "25.0.1364.173"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: smartphone
-    brand: KN
+    brand: Amazon
     model: Fire Phone
   os_family: Android
   browser_family: Chrome
@@ -7965,19 +7173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; zh-cn; KOPO L128 Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: KP
+    brand: KOPO
     model: L128
   os_family: Android
   browser_family: Unknown
@@ -7985,19 +7191,17 @@
   user_agent: KOPO L8_TD/Linux/3.4.39 Android/4.3 Release/08.15.2013 Browser/AppleWebkit534.30 Mobile Safari/534.30 SohuNews/5.2.3 BuildCode/95
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KP
+    brand: KOPO
     model: L8
   os_family: Android
   browser_family: Android Browser
@@ -8005,19 +7209,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; zh-cn; KOPO L8 Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: KP
+    brand: KOPO
     model: L8
   os_family: Android
   browser_family: Unknown
@@ -8025,19 +7227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; KORIDY H15 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KR
+    brand: Koridy
     model: H15
   os_family: Android
   browser_family: Android Browser
@@ -8045,19 +7245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; KORIDY H16 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KR
+    brand: Koridy
     model: H16
   os_family: Android
   browser_family: Android Browser
@@ -8065,19 +7263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; KORIDY H20 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KR
+    brand: Koridy
     model: H20
   os_family: Android
   browser_family: Android Browser
@@ -8085,7 +7281,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; ALUMINI 2 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.106 Mobile Safari/537.36[FBAN/EMA;FBLC/es_LA;FBAV/90.0.0.10.180;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -8094,7 +7289,7 @@
     version: "90.0.0.10.180"
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: Alumini 2
   os_family: Android
   browser_family: Unknown
@@ -8102,19 +7297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Alumini3 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: Alumini 3
   os_family: Android
   browser_family: Chrome
@@ -8122,19 +7315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Alumini_3_Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: Alumini 3 Plus
   os_family: Android
   browser_family: Chrome
@@ -8142,19 +7333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Alumini3Plus Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: Alumini 3 Plus
   os_family: Android
   browser_family: Chrome
@@ -8162,19 +7351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; KEMPLER_TV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: TV
   os_family: Android
   browser_family: Chrome
@@ -8182,19 +7369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KEMPLER_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KS
+    brand: 'Kempler & Strauss'
     model: X
   os_family: Android
   browser_family: Chrome
@@ -8202,19 +7387,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; Ktouch_A11 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: A11
   os_family: Android
   browser_family: Android Browser
@@ -8222,19 +7405,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; K-Touch E780 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: E780
   os_family: Android
   browser_family: Android Browser
@@ -8242,19 +7423,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; K-Touch E780 Build/IMM76I) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.0.282 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.0.282"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: E780
   os_family: Android
   browser_family: Unknown
@@ -8262,19 +7441,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; zh-CN; K-Touch E806) U2/1.0.0 UCBrowser/9.6.0.378 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: E806
   os_family: Android
   browser_family: Unknown
@@ -8282,19 +7459,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; K-Touch S757/K-TOUCH_S757_V2.0; 480*854;  CTC/2.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 hao123/5.1_0.5.6.4_diordna_287_084/uynaiT_51_4.0.4_757S+hcuoT-K/381b/9745f72a301c90ab899829c9071c0ed7/1'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: S757
   os_family: Android
   browser_family: Android Browser
@@ -8302,19 +7477,17 @@
   user_agent: K-Touch_T60/TBT972010_8900_V0701 Linux/3.4.5 Android/4.2.2 Release/03.26.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30 MBBMS/2.2 System/Android 4.2.2;
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: T60
   os_family: Android
   browser_family: Android Browser
@@ -8322,19 +7495,17 @@
   user_agent: K-Touch_T619+/960226_8514_V0101 Mozilla/5.0 (Linux; U; Android 2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: T619
   os_family: Android
   browser_family: Android Browser
@@ -8342,7 +7513,6 @@
   user_agent: K-Touch_T619+/960226_8514_V0101 Mozilla/5.0 (Linux; U; Android 2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 baiduboxapp/5.1 (Baidu; P1 2.3.5)
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
@@ -8351,7 +7521,7 @@
     version: "5.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: T619
   os_family: Android
   browser_family: Unknown
@@ -8359,19 +7529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; K-Touch T621 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/4.5 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "4.5"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: T621
   os_family: Android
   browser_family: Unknown
@@ -8379,19 +7547,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.3; K-Touch T780/TBT960313_8660_V0101) Linux/3.0.8 Release/12.26.2012  AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: T780
   os_family: Android
   browser_family: Android Browser
@@ -8399,19 +7565,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; K-Touch Tou ch3 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.2.394 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.2.394"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: Tou ch3
   os_family: Android
   browser_family: Unknown
@@ -8419,7 +7583,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1; zh-cn; K-Touch U86 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 baiduboxapp/042_0.4_diordna_069_045/hcuoT-K_61_2.1.4_68U+hcuoT-K/1000154c/6F7FA236825AEB575DD75F1E9DA5858A%7C106199110809368/1'
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
@@ -8428,7 +7591,7 @@
     version: "042"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: U86
   os_family: Android
   browser_family: Unknown
@@ -8436,19 +7599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; K-Touch_W619 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: W619
   os_family: Android
   browser_family: Android Browser
@@ -8456,19 +7617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; YunOs 1.0.0.3; en-; K-Touch W619 Build/AliyunOs-2012) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: YunOs
-    short_name: YNS
     version: "1.0.0.3"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "4.0"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: W619
   os_family: Android
   browser_family: Safari
@@ -8476,19 +7635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3 YunOs 1.0.0.3; zh-cn; K-Touch W658 Build/AliyunOs-2012) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: YunOs
-    short_name: YNS
     version: "1.0.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: W658
   os_family: Android
   browser_family: Android Browser
@@ -8496,19 +7653,17 @@
   user_agent: Mozilla/5.0 (Linux; U;AliyunOS 1.5.1.18-RT-20120724.182153; zh-cn; K-Touch W688 Build/AliyunOs-2012;Android 2.3 Compatible) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: YunOs
-    short_name: YNS
     version: "1.5.1.18"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: W688
   os_family: Android
   browser_family: Android Browser
@@ -8516,19 +7671,17 @@
   user_agent: K-Touch W98/java_c_5609c Linux/3.4.5+ Android/4.2.2 Release/JDQ39 Browser/AppleWebKit534.30 Profile/ Configuration/ Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KT
+    brand: K-Touch
     model: W98
   os_family: Android
   browser_family: Android Browser
@@ -8536,19 +7689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; Kumai 260 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KU
+    brand: Kumai
     model: "260"
   os_family: Android
   browser_family: Android Browser
@@ -8556,7 +7707,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.5; zh-cn; KM-Kumai 290/Kumai_290_V1.4; 320*480;  CTC/2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 baiduboxapp/5.0 (Baidu; P1 2.3.5)'
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
@@ -8565,7 +7715,7 @@
     version: "5.0"
   device:
     type: smartphone
-    brand: KU
+    brand: Kumai
     model: "290"
   os_family: Android
   browser_family: Unknown
@@ -8573,19 +7723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; Kumai 290S-A Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KU
+    brand: Kumai
     model: 290S-A
   os_family: Android
   browser_family: Android Browser
@@ -8593,19 +7741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Kumai 918 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.36 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.36"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KU
+    brand: Kumai
     model: "918"
   os_family: Android
   browser_family: Chrome
@@ -8613,19 +7759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; BIGCOOL Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KW
+    brand: Konrow
     model: BigCool
   os_family: Android
   browser_family: Chrome
@@ -8633,19 +7777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; COOLFIVE Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KW
+    brand: Konrow
     model: Cool Five
   os_family: Android
   browser_family: Chrome
@@ -8653,19 +7795,17 @@
   user_agent: COOL-K/V1 Linux/3.10.72 Android/5.1 Release/03.10.2015 Browser/AppleWebKit537.36 Chrome/39.0.0.0 Mobile Safari/537.36 System/Android 5.1;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KW
+    brand: Konrow
     model: Cool-K
   os_family: Android
   browser_family: Chrome
@@ -8673,19 +7813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Just5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KW
+    brand: Konrow
     model: Just 5
   os_family: Android
   browser_family: Chrome
@@ -8693,19 +7831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LINK5 Build/MOST28F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KW
+    brand: Konrow
     model: Link 5
   os_family: Android
   browser_family: Chrome
@@ -8713,19 +7849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Three_Proofings_W5 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KX
+    brand: Kenxinda
     model: Three Proofings W5
   os_family: Android
   browser_family: Chrome
@@ -8733,19 +7867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Three Proofings W6 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KX
+    brand: Kenxinda
     model: Three Proofings W6
   os_family: Android
   browser_family: Chrome
@@ -8753,19 +7885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Three_Proofings_W7 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KX
+    brand: Kenxinda
     model: Three Proofings W7
   os_family: Android
   browser_family: Chrome
@@ -8773,19 +7903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Three_Proofings_W8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KX
+    brand: Kenxinda
     model: Three Proofings W8
   os_family: Android
   browser_family: Chrome
@@ -8793,19 +7921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Three_Proofings_W9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KX
+    brand: Kenxinda
     model: Three Proofings W9
   os_family: Android
   browser_family: Chrome
@@ -8813,19 +7939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; KYV43) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Basio 3
   os_family: Android
   browser_family: Chrome
@@ -8833,19 +7957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; KYV47-u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Basio 4
   os_family: Android
   browser_family: Chrome
@@ -8853,19 +7975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6782) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Brigadier
   os_family: Android
   browser_family: Chrome
@@ -8873,19 +7993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; NP501KC Build/104.0.4120; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno
   os_family: Android
   browser_family: Chrome
@@ -8893,19 +8011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 503KC Build/101.2.2b10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno E
   os_family: Android
   browser_family: Chrome
@@ -8913,19 +8029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 602KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno G
   os_family: Android
   browser_family: Chrome
@@ -8933,19 +8047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYV36 Build/101.6.2870; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno Rafre
   os_family: Android
   browser_family: Chrome
@@ -8953,7 +8065,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; KYL21 Build/022.0.3e02) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YJApp-ANDROID jp.co.yahoo.android.yjtop/3.0.18
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
@@ -8962,7 +8073,7 @@
     version: "3.0.18"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Digno S
   os_family: Android
   browser_family: Unknown
@@ -8970,19 +8081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6560C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce
   os_family: Android
   browser_family: Chrome
@@ -8990,19 +8099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6560T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce
   os_family: Android
   browser_family: Chrome
@@ -9010,19 +8117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; E6810) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce Pro
   os_family: Android
   browser_family: Chrome
@@ -9030,19 +8135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; E6910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce Pro 2
   os_family: Android
   browser_family: Chrome
@@ -9050,19 +8153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYOCERA-E6790) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce XD
   os_family: Android
   browser_family: Chrome
@@ -9070,19 +8171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6790TM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraForce XD
   os_family: Android
   browser_family: Chrome
@@ -9090,19 +8189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; E6782L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: DuraScout
   os_family: Android
   browser_family: Chrome
@@ -9110,19 +8207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYF31 Build/112.0.5800; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Gratina 4G
   os_family: Android
   browser_family: Chrome
@@ -9130,19 +8225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYF37 Build/105.0.2700; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Gratina 4G
   os_family: Android
   browser_family: Chrome
@@ -9150,19 +8243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYF39 Build/102.0.2041; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Gratina 4G
   os_family: Android
   browser_family: Chrome
@@ -9170,19 +8261,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; C5170 Build/IML77) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro
   os_family: Android
   browser_family: Android Browser
@@ -9190,19 +8279,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; C5215 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro EDGE
   os_family: Android
   browser_family: Android Browser
@@ -9210,19 +8297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; C6750 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro ELITE
   os_family: Android
   browser_family: Chrome
@@ -9230,19 +8315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C6730 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro ICON
   os_family: Android
   browser_family: Chrome
@@ -9250,19 +8333,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; en-us; C6530N Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro LIFE
   os_family: Android
   browser_family: Android Browser
@@ -9270,19 +8351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; C6743 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro Reach
   os_family: Android
   browser_family: Chrome
@@ -9290,19 +8369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; C6740) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro WAVE
   os_family: Android
   browser_family: Chrome
@@ -9310,19 +8387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; C6740N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro WAVE
   os_family: Android
   browser_family: Chrome
@@ -9330,19 +8405,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; C6522N Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Hydro XTRM
   os_family: Android
   browser_family: Android Browser
@@ -9350,19 +8423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KYV33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Infobar A03
   os_family: Android
   browser_family: Chrome
@@ -9370,19 +8441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 705KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Kantan Sumaho
   os_family: Android
   browser_family: Chrome
@@ -9390,19 +8459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KC-S301AE Build/101.0.1910) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: KC-S301AE
   os_family: Android
   browser_family: Chrome
@@ -9410,19 +8477,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-us; C5120 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Milano
   os_family: Android
   browser_family: Android Browser
@@ -9430,19 +8495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KYL23 Build/100.1.2150) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Miraie
   os_family: Android
   browser_family: Chrome
@@ -9450,19 +8513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.0; KYV39 Build/39.0.C.0.282) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Miraie F
   os_family: Android
   browser_family: Chrome
@@ -9470,19 +8531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; S4-KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: One S4
   os_family: Android
   browser_family: Chrome
@@ -9490,19 +8549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; S6-KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: One S6
   os_family: Android
   browser_family: Chrome
@@ -9510,19 +8567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; X3-KC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: One X3
   os_family: Android
   browser_family: Chrome
@@ -9530,19 +8585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KYV37) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Qua Phone
   os_family: Android
   browser_family: Chrome
@@ -9550,19 +8603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; KYV42 Build/1.000AL.27.a) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Qua Phone QX
   os_family: Android
   browser_family: Chrome
@@ -9570,19 +8621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KYV44) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Qua Phone QZ
   os_family: Android
   browser_family: Chrome
@@ -9590,19 +8639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KYV40U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Rafre
   os_family: Android
   browser_family: Chrome
@@ -9610,19 +8657,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; C5155 Build/IML77) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Rise
   os_family: Android
   browser_family: Android Browser
@@ -9630,7 +8675,6 @@
   user_agent: 'PodcastAddict/v2 - Dalvik/1.6.0 (Linux; U; Android 4.4.2; KC-S701 Build/102.0.1920)'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -9639,7 +8683,7 @@
     version: "2"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Torque
   os_family: Android
   browser_family: Unknown
@@ -9647,19 +8691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KYY24 Build/108.1.2110) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Torque G01
   os_family: Android
   browser_family: Chrome
@@ -9667,19 +8709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; KYV41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Torque G03
   os_family: Android
   browser_family: Chrome
@@ -9687,19 +8727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KYV46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Torque G04
   os_family: Android
   browser_family: Chrome
@@ -9707,19 +8745,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; KYY21 Build/206.0.1100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano L01
   os_family: Android
   browser_family: Android Browser
@@ -9727,19 +8763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KYY22 Build/100.2.0a30)AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano L02
   os_family: Android
   browser_family: Chrome
@@ -9747,19 +8781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KYY23 Build/106.0.2a00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano L03
   os_family: Android
   browser_family: Chrome
@@ -9767,19 +8799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; KYV31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano V01
   os_family: Android
   browser_family: Chrome
@@ -9787,19 +8817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; KYV34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano V02
   os_family: Android
   browser_family: Chrome
@@ -9807,19 +8835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KYV38) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano V03
   os_family: Android
   browser_family: Chrome
@@ -9827,19 +8853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KYV45) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KY
+    brand: Kyocera
     model: Urbano V03
   os_family: Android
   browser_family: Chrome
@@ -9847,19 +8871,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; KAZAM; Thunder 450W) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Thunder 450W
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9867,19 +8889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KAZAM Thunder Q45 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Thunder Q45
   os_family: Android
   browser_family: Chrome
@@ -9887,7 +8907,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; KAZAM Thunder Q45 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.10.1064617.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -9896,7 +8915,7 @@
     version: "3.3.10.1064617"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Thunder Q45
   os_family: Android
   browser_family: Unknown
@@ -9904,19 +8923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tornado 348 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Tornado 348
   os_family: Android
   browser_family: Chrome
@@ -9924,19 +8941,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KAZAM Trooper 551) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper 551
   os_family: Android
   browser_family: Chrome
@@ -9944,19 +8959,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Trooper_X35 Build/Trooper_X35) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X3.5
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-8.yml
+++ b/Tests/fixtures/smartphone-8.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Trooper_X40 Build/Trooper_X40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X4.0
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; KAZAM Trooper X45 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X45
   os_family: Android
   browser_family: Android Browser
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KAZAM Trooper X45 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X45
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Trooper_X55 Build/Trooper_X55) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X5.5
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KAZAM Trooper X50 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper X50
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; KAZAM Trooper2 50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: Trooper2 50
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KAZAM TV 45) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: KZ
+    brand: Kazam
     model: TV 45
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; Le 1 Pro Build/BGXNAOP5501103071S)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 1 Pro
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; X800+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 1 Pro
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Letv X500 Build/DBXCNOP5801608051S; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 1S
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Letv X501 Build/DBXCNOP5902303111S; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 1S
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Le X526 Build/IIXOSOP5801910121S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 2
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; LeEco Le 2 Build/NMF26V)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le 2
   os_family: Android
   browser_family: Android Browser
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Le Max Build/CHXOSOP5501405221S) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le Max
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Le X527 Build/IMXOSOP5801809091S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le X527
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1;zh_cn; LEX720 Build/WAXCNFN5902012312S) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/49.0.0.0 Mobile Safari/537.36 EUI Browser/5.9.020S
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: EUI Browser
-    short_name: EU
     version: "5.9.020"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le X720
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LEX722) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le X722
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; Le X820 Build/MOB31S)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le X820
   os_family: Android
   browser_family: Android Browser
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.0.2; zh-cn; X900 Build/CBXCNOP5500912251S) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025489 Mobile Safari/533.1 V1_AND_SQ_6.0.0_300_YYB_D QQ/6.0.0.2605 NetType/WIFI WebP/0.3.0 Pixel/1440
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "5.4"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Le X900
   os_family: Android
   browser_family: Unknown
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; X900+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: Max X900+
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Letv X910 Build/EEXCNFN5601304291S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L1
+    brand: LeEco
     model: X910
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; S6 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: S6
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; IVA S6 Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: S6
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XM100 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: XM100
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XM100 Plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: XM100 Plus
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XM100S Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: XM100S
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XM300 Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L2
+    brand: Landvo
     model: XM300 Pro
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; S5A4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: Argon
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; S4A2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: Irida
   os_family: Android
   browser_family: Android Browser
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-; S4A5 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: Oxygen
   os_family: Android
   browser_family: Android Browser
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; LEXAND S4A4 NEON Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 ACHEETAHI/2100502004
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: S4A4 Neon
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SC7 PRO HD Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.137 YaBrowser/17.4.0.544.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.4.0.544.01"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: SC7 PRO HD
   os_family: Android
   browser_family: Unknown
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru; S4A1 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.5.0.360 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: L3
+    brand: Lexand
     model: Vega
   os_family: Android
   browser_family: Unknown
@@ -663,19 +597,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.2.2; LEMHOOV  L15 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L4
+    brand: Lemhoov
     model: L15
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Elite 1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Elite 1
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KIICAA MIX Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 com.yandex.zen/4.4.0.2189
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: KICCAA Mix
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KIICAA POWER Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: KICCAA Power
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LEAGOO_Lead5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Lead 5
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LEAGOO Lead7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Lead 7
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LEAGOO M5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M5 EDGE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M5 Edge
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; LEAGOO M8 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M8
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; Leagoo M8Pro Build/MRA58K AppleWebKit/537.36 KHTML, like Gecko Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M8 Pro
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Leagoo-M8-Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M8 Pro
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; leagoo M8_pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: M8 Pro
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Leagoo T1 Build/NJH47F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: T1
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venture 1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Venture 1
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; Leagoo Z1 Build/LMY47I; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Z1
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; LEAGOO Z5 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.102 YaBrowser/18.11.1.979.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.1.979.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Z5
   os_family: Android
   browser_family: Unknown
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; Leagoo Z6 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L5
+    brand: Leagoo
     model: Z6
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; Land Rover Explore AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: Explore
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; LAND ROVER L15+ Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: L15+
   os_family: Android
   browser_family: Android Browser
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0.99; Land Rover T878 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0.99"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: T878
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; (Landrover-V1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: V1
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; (LANDROVER V18 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: V18
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; Landrover V6 Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: V6
   os_family: Android
   browser_family: Android Browser
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; LANDROVER V8 Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: V8
   os_family: Android
   browser_family: Android Browser
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Land Rover X Build/Land_Rover_X AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: X
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Land Rover X17 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: X17
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Land Roverd X18 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L6
+    brand: Land Rover
     model: X18
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Dalvik/v3.3.127 Compatible (TVM xx; YunOS 3.0; Linux; U; Android 4.4.4 Compatible; lephone T2 Build/KTU84P)
   os:
     name: YunOs
-    short_name: YNS
     version: "3.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: T2
   os_family: Android
   browser_family: Android Browser
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W10 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.8.976 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.8.976"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W10
   os_family: Android
   browser_family: Unknown
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W11 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/12.11.3.1204 (SpeedMode) U4/1.0 UCWEB/2.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.3.1204"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W11
   os_family: Android
   browser_family: Unknown
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W12 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.5.850 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.5.850"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W12
   os_family: Android
   browser_family: Unknown
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; lephone_W15) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W15
   os_family: Android
   browser_family: Chrome
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W2 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.1.0.882 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.1.0.882"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W2
   os_family: Android
   browser_family: Unknown
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W7 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1155"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W7
   os_family: Android
   browser_family: Unknown
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; lephone_W7_plus Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.0.5.850 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.5.850"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W7 Plus
   os_family: Android
   browser_family: Unknown
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-IN; lephone_W9 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Mobile Safari/537.36 UCBrowser/12.10.0.1163 UCTurbo/1.4.9.900
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser Turbo
-    short_name: UT
     version: "1.4.9.900"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: L7
+    brand: Lephone
     model: W9
   os_family: Android
   browser_family: Unknown
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Clarmin_B6 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L8
+    brand: Clarmin
     model: B6
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LUNA G50) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: G50
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; LUNA G60 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: G60
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TG-L800S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: TG-L800S
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LUNA V55 Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: L9
+    brand: Luna
     model: V55
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Ilium Alpha 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium Alpha 3
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Alpha 950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium Alpha 950
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ILIUM L1000 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1000
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ILIUM L1000) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1000
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ilium L1050) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1050
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ILIUM L1100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1100
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium L1120) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1120
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ilium L1200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1200
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Ilium L1400) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L1400
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ILIUM L200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L200
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Ilium L610) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L610
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium L620) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L620
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium L910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L910
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium L920) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L920
   os_family: Android
   browser_family: Chrome
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Ilium L950) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium L950
   os_family: Android
   browser_family: Chrome
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ilium LT500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium LT500
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; es-us; Ilium_LT500 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium LT500
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium LT510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium LT510
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium LT520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium LT520
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium M1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium M1
   os_family: Android
   browser_family: Chrome
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium M3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium M3
   os_family: Android
   browser_family: Chrome
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Ilium M5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium M5
   os_family: Android
   browser_family: Chrome
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Ilium M7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium M7
   os_family: Android
   browser_family: Chrome
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Ilium M9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium M9
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM S106 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium S106
   os_family: Android
   browser_family: Chrome
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM S106) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium S106
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM S520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium S520
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ILIUM S620) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium S620
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM S670) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium S670
   os_family: Android
   browser_family: Chrome
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM X110 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X110
   os_family: Android
   browser_family: Chrome
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Ilium X110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X110
   os_family: Android
   browser_family: Chrome
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium X120) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X120
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X120C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X120C
   os_family: Android
   browser_family: Chrome
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ILIUM X200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X200
   os_family: Android
   browser_family: Chrome
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ilium X210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X210
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium X220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X220
   os_family: Android
   browser_family: Chrome
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium X260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X260
   os_family: Android
   browser_family: Chrome
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ilium X500B Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X500B
   os_family: Android
   browser_family: Chrome
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ilium X500B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X500B
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium X510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X510
   os_family: Android
   browser_family: Chrome
@@ -2283,19 +2055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ilium X520) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X520
   os_family: Android
   browser_family: Chrome
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ilium X710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LA
+    brand: Lanix
     model: Ilium X710
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.1; Ledstar_Novus_Premium_6.0 Build/JOP40D)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LD
+    brand: Ledstar
     model: Novus Premium 6.0"
   os_family: Android
   browser_family: Android Browser
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Trendy 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LD
+    brand: Ledstar
     model: Trendy 5.0
   os_family: Android
   browser_family: Chrome
@@ -2363,19 +2127,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Lenovo A1010a20 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A Plus
   os_family: Android
   browser_family: Android Browser
@@ -2383,19 +2145,17 @@
   user_agent: LENOVO-Lenovo-A288t/1.0 Linux/2.6.35.7 Android/2.3.5 Release/12.28.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A288t
   os_family: Android
   browser_family: Android Browser
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; zh-CN; Lenovo A288t Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.6.428 U3/0.8.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.6.428"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A288t
   os_family: Android
   browser_family: Unknown
@@ -2423,19 +2181,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Lenovo L18021 Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A3
   os_family: Android
   browser_family: Android Browser
@@ -2443,19 +2199,17 @@
   user_agent: Lenovo A369 Linux/3.4.5 Android/2.3.6 Release/07.26.2013 Browser/AppleWebKit533.1 Profile/MIDP-2.0 Configuration/CLDC-1.1 Mobile Safari/533.1 Android 2.3.6
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A369
   os_family: Android
   browser_family: Android Browser
@@ -2463,19 +2217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Lenovo A390_ROW Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A390 ROW
   os_family: Android
   browser_family: Chrome
@@ -2483,19 +2235,17 @@
   user_agent: Lenovo-A390t_TD/S100 Release/11.2012 Mozilla/5.0 (Linux; U; Android 4.0.3) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A390t
   os_family: Android
   browser_family: Android Browser
@@ -2503,19 +2253,17 @@
   user_agent: Lenovo-A398t+_TD/S100 Linux/3.4.5 Android/4.1.2 Release/09.10.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A398t+
   os_family: Android
   browser_family: Android Browser
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; L18011 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Lenovo A5000 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A5000
   os_family: Android
   browser_family: Chrome
@@ -2563,19 +2307,17 @@
   user_agent: Lenovo-A516/S111 Linux/3.4.0 Android/4.2 Release/05.16.2013 Browser/AppleWebKit534.30 Profile/ Configuration/ Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A516
   os_family: Android
   browser_family: Android Browser
@@ -2583,19 +2325,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; zh-CN; Lenovo A530) U2/1.0.0 UCBrowser/9.5.0.360 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.360"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A530
   os_family: Android
   browser_family: Unknown
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; LNV-Lenovo_A560e Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A560e
   os_family: Android
   browser_family: Android Browser
@@ -2623,19 +2361,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.3; zh-CN; Lenovo A60) U2/1.0.0 UCBrowser/9.3.2.349 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.2.349"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A60
   os_family: Android
   browser_family: Unknown
@@ -2643,19 +2379,17 @@
   user_agent: MQQBrowser/3.1/Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; Lenovo A60+ Build/LenovoLePhone) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "3.1"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A60+
   os_family: Android
   browser_family: Unknown
@@ -2663,19 +2397,17 @@
   user_agent: Lenovo-A656_TD/S100 Linux/3.4.5 Android/4.2 Release/03.07.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A656
   os_family: Android
   browser_family: Android Browser
@@ -2683,19 +2415,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; Lenovo A690/S001) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A690
   os_family: Android
   browser_family: Android Browser
@@ -2703,19 +2433,17 @@
   user_agent: Lenovo-A820t_TD/S100 Linux/3.4.0 Android/4.1 Release/1.4.2013 Browser/AppleWebKit534.30 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: A820t
   os_family: Android
   browser_family: Android Browser
@@ -2723,19 +2451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo K10a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -2743,19 +2469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo K10a40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -2763,19 +2487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo K50a40 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K3 Note
   os_family: Android
   browser_family: Chrome
@@ -2783,19 +2505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; K31-t3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K31
   os_family: Android
   browser_family: Chrome
@@ -2803,19 +2523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo A7010a48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K4 Note
   os_family: Android
   browser_family: Chrome
@@ -2823,19 +2541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K350t) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K5
   os_family: Android
   browser_family: Chrome
@@ -2843,19 +2559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo A7020a48 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K5 Note
   os_family: Android
   browser_family: Chrome
@@ -2863,19 +2577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo A7020a40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K5 Note
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo K33a48 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6
   os_family: Android
   browser_family: Chrome
@@ -2903,19 +2613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo K33a48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo K53a48 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6 Note
   os_family: Android
   browser_family: Chrome
@@ -2943,19 +2649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenovo K53a48) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6 Note
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenovo K33a42 Build/NRD90N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6 Power
   os_family: Android
   browser_family: Chrome
@@ -2983,19 +2685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenovo K33a42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: K6 Power
   os_family: Android
   browser_family: Chrome
@@ -3003,19 +2703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenovo P2a42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P2
   os_family: Android
   browser_family: Chrome
@@ -3023,19 +2721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Lenovo P2a42 Build/NRD90N; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P2
   os_family: Android
   browser_family: Chrome
@@ -3043,19 +2739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; P2a42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P2
   os_family: Android
   browser_family: Chrome
@@ -3063,19 +2757,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1; zh-cn; Lenovo-P770/S100) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P770
   os_family: Android
   browser_family: Android Browser
@@ -3083,19 +2775,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; Lenovo P770 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P770
   os_family: Android
   browser_family: Android Browser
@@ -3103,19 +2793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Lenovo P780_ROW Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: P780 ROW
   os_family: Android
   browser_family: Chrome
@@ -3123,19 +2811,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Lenovo PB2-670M Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Phab 2
   os_family: Android
   browser_family: Android Browser
@@ -3143,19 +2829,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Lenovo L58041 Build/OPM1.171019.026)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: S5 Pro
   os_family: Android
   browser_family: Android Browser
@@ -3163,19 +2847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LenovoS668T Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: S668T
   os_family: Android
   browser_family: Chrome
@@ -3183,19 +2865,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; Lenovo S880 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: S880
   os_family: Android
   browser_family: Android Browser
@@ -3203,19 +2883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Lenovo S880 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: S880
   os_family: Android
   browser_family: Chrome
@@ -3223,19 +2901,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1;en-us; Lenovo_S920_ROW/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2.1 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: S920 ROW
   os_family: Android
   browser_family: Android Browser
@@ -3243,19 +2919,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Lenovo A2016a40 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe B
   os_family: Android
   browser_family: Android Browser
@@ -3263,19 +2937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo-A6020l36 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5
   os_family: Android
   browser_family: Chrome
@@ -3283,19 +2955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo A6020a40 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5
   os_family: Android
   browser_family: Chrome
@@ -3303,19 +2973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo A6020a40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5
   os_family: Android
   browser_family: Chrome
@@ -3323,19 +2991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Vibe K5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5
   os_family: Android
   browser_family: Chrome
@@ -3343,19 +3009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo A6020a46 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5 Plus
   os_family: Android
   browser_family: Chrome
@@ -3363,19 +3027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo A6020a46) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5 Plus
   os_family: Android
   browser_family: Chrome
@@ -3383,19 +3045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Vibe K5 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe K5 Plus
   os_family: Android
   browser_family: Chrome
@@ -3403,19 +3063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo P1c72) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.127 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "85.0.4183.127"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe P1
   os_family: Android
   browser_family: Chrome
@@ -3423,19 +3081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo P1a42 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe P1
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo P1a42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe P1
   os_family: Android
   browser_family: Chrome
@@ -3463,19 +3117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo P1ma40 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe P1m
   os_family: Android
   browser_family: Chrome
@@ -3483,19 +3135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Lenovo S1a40 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.5.972 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.5.972"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe S1
   os_family: Android
   browser_family: Unknown
@@ -3503,19 +3153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo Z90a40 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe Shot
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3171,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.0; VIBE X2 (X2) Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/47.0.2526.76 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe X2
   os_family: Android
   browser_family: Chrome
@@ -3543,19 +3189,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 5.0.2; VIBE Z2 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/45.0.2454.94  Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Vibe Z2
   os_family: Android
   browser_family: Chrome
@@ -3563,19 +3207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Z2 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Z2 Plus
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3225,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Lenovo L78071 Build/PKQ1.181030.001)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: Z5s
   os_family: Android
   browser_family: Android Browser
@@ -3603,19 +3243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZUK Z2151) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Edge
   os_family: Android
   browser_family: Chrome
@@ -3623,19 +3261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ZUK Z1 Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z1
   os_family: Android
   browser_family: Chrome
@@ -3643,19 +3279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZUK Z1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z1
   os_family: Android
   browser_family: Chrome
@@ -3663,19 +3297,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; Z2131 Build/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2
   os_family: Android
   browser_family: Android Browser
@@ -3683,19 +3315,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; en-US; ZUK Z2132 Build/MMB29M) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.2.0.915 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.2.0.915"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2
   os_family: Android
   browser_family: Unknown
@@ -3703,19 +3333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZUK Z2132) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2
   os_family: Android
   browser_family: Chrome
@@ -3723,19 +3351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ZUK Z2131) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2
   os_family: Android
   browser_family: Chrome
@@ -3743,19 +3369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZUK Z2121) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2 Pro
   os_family: Android
   browser_family: Chrome
@@ -3763,19 +3387,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; ZUK Z2121 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LE
+    brand: Lenovo
     model: ZUK Z2 Pro
   os_family: Android
   browser_family: Android Browser
@@ -3783,13 +3405,11 @@
   user_agent: NetFront/4.2 (BMP 1.0.4; U; en-us; LG; NetFront/4.2/AMB) Boost LG272 MMP/2.0 Profile/MIDP-2.1 Configuration/CLDC-1.1
   os:
     name: Brew
-    short_name: BMP
     version: "1.0.4"
     platform: ""
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.2"
     engine: NetFront
     engine_version: "4.2"
@@ -3803,13 +3423,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-LG730 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3823,7 +3441,6 @@
   user_agent: '[FBAN/FB4A;FBAV/263.0.0.46.121;FBBV/205281663;FBDM/{density=2.0,width=720,height=1187};FBLC/en_US;FBRV/206347851;FBCR/Metro by T-Mobile;FBMF/LGE;FBBD/MetroPCS;FBPN/com.facebook.katana;FBDV/LGMS210;FBSV/7.0;FBOP/19;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ARM
   client:
@@ -3840,13 +3457,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X210(G) Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -3860,13 +3475,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X210G Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -3880,13 +3493,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
@@ -3900,13 +3511,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; LG-D802 Build/JDQ39B) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3920,13 +3529,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; LG-D802 Build/JDQ39B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
@@ -3940,13 +3547,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-in; LG-E400 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.2
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -3960,13 +3565,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; sr-rs; LG-E400 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -3980,13 +3583,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-tw; LG-E400 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -4000,13 +3601,11 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; LG-E405) U2/1.0.0 UCBrowser/8.8.1.359 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
@@ -4020,13 +3619,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fa-ir; LG-E510 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -4040,13 +3637,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; el-gr; LG-E610v/V10d Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4060,13 +3655,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; LG-E610v Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4080,13 +3673,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ro-ro; LG-E610v/V10f Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4100,13 +3691,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-hn; LG-E612g Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4120,13 +3709,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; LG-E615 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4140,13 +3727,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-ca; LG-E617G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4160,13 +3745,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-es; LG-E730/V10b Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.2
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -4180,13 +3763,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; LG; LG-E900; Orange)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -4200,13 +3781,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; LG-E970 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
@@ -4220,13 +3799,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; LG-E973 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4240,13 +3817,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-E980/E98010p Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4260,13 +3835,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; LG-E988 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
@@ -4280,13 +3853,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; LG-F120K Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4300,13 +3871,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-F160S Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4320,13 +3889,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ko-kr; LG-F240K Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 Swing(And)/1.6.1.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4340,13 +3907,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ko-kr; LG-F240K/10z Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4360,13 +3925,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ko-kr; LG-F240L Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 NAVER(inapp; search; 260; 5.2.7)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -4380,13 +3943,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X210CM Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
@@ -4400,13 +3961,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VS880 Build/KOT49I.VS88012A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
@@ -4420,13 +3979,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VS880PP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
@@ -4440,13 +3997,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VS980 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
@@ -4460,13 +4015,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; LG-D618 Build/LRX22G)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -4480,13 +4033,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; LG-D620 Build/LRX22G)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -4500,13 +4051,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VS985 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
@@ -4520,13 +4069,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-gb; LG-D855 Build/KVT49L.A1401987978) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.1599.103 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.1599.103"
     engine: Blink
     engine_version: ""
@@ -4540,13 +4087,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-D852 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4560,13 +4105,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LG-D724 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -4580,13 +4123,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H811 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -4600,13 +4141,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H815 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4620,13 +4159,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H818 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4640,13 +4177,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H735 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4660,13 +4195,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LG-H542 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4680,13 +4213,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H630) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
@@ -4700,13 +4231,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H540 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -4720,13 +4249,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H525n Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -4740,13 +4267,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; LG-H736 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -4760,13 +4285,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-H850 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -4780,13 +4303,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LG-H860 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -4800,13 +4321,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VS987 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
@@ -4820,13 +4339,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; RS988) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
@@ -4840,13 +4357,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-H840 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
@@ -4860,13 +4375,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; LG-H870DS Build/NRD90U)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -4880,13 +4393,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VS988 Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
@@ -4900,13 +4411,11 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; LM-Q850 Build/OPM1.171019.026 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
@@ -4920,13 +4429,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-Q910) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
@@ -4940,13 +4447,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LM-G710N Build/OPR1.170623.032) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -4960,13 +4465,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LM-G710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -4980,13 +4483,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; LM-G710VM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
@@ -5000,13 +4501,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-G820) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
@@ -5020,7 +4519,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-G820N Build/PKQ1.181203.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.128 Whale/1.0.0.0 Crosswalk/23.69.590.22 Mobile Safari/537.36 NAVER(inapp; search; 650; 10.3.2)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
@@ -5037,13 +4535,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-G810) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -5057,13 +4553,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 901LG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
@@ -5077,13 +4571,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; LG-GT540 ; Build/Donut) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1 Java/Jbed/7.0 Profile/MIDP-2.1 Configuration/CLDC-1.1 MMS/LG-Android-MMS-V1.0/1.2
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
@@ -5097,7 +4589,6 @@
   user_agent: AndroidDownloadManager/5.1.1 (Linux; U; Android 5.1.1; LG-K420 Build/LMY47V)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
@@ -5114,13 +4605,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-F670L Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
@@ -5134,13 +4623,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-K430 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
@@ -5154,13 +4641,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LG-M250 Build/NRD90U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -5174,13 +4659,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X410.FN Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
@@ -5194,13 +4677,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VS501 Build/NRD90U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -5214,13 +4695,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LG-M255) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -5234,13 +4713,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LG-TP260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
@@ -5254,13 +4731,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LGMP260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -5274,13 +4749,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-K100 Build/MXB48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -5294,13 +4767,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X410UM Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
@@ -5314,13 +4785,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X320) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -5334,13 +4803,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-X230 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
@@ -5354,13 +4821,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X420) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -5374,13 +4839,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LG-X220) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.111"
     engine: Blink
     engine_version: ""
@@ -5394,13 +4857,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X540) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
@@ -5414,13 +4875,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LGMS330 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
@@ -5434,13 +4893,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-K330 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -5454,13 +4911,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-K332 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -5474,13 +4929,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-K350 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -5494,13 +4947,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; LG-X240 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -5514,13 +4965,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X212(G)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
@@ -5534,13 +4983,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; RS500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
@@ -5554,13 +5001,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VS500PP Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
@@ -5574,13 +5019,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VS500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
@@ -5594,13 +5037,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LG-KU5400 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
@@ -5614,13 +5055,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; LGL35G/V100) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -5634,13 +5073,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; LG-L40G Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -5654,13 +5091,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4; xx-xx; LG-D325 Build/KOT49I.A1392225267) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.1599.103 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.1599.103"
     engine: Blink
     engine_version: ""
@@ -5674,13 +5109,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LG-D340f8 Build/KOT49I.A1398387929) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
@@ -5694,13 +5127,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; LGL85C Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -5714,13 +5145,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LGL86C Build/IMM76L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -5734,13 +5163,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; LG-H324 Build/LRX21Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3313.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3313.67"
     engine: Blink
     engine_version: ""
@@ -5754,13 +5181,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H340n Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -5774,7 +5199,6 @@
   user_agent: '[FBAN/FB4A;FBAV/80.0.0.21.65;FBBV/31390006;FBDM/{density=1.5,width=480,height=786};FBLC/pt_BR;FBCR/VIVO;FBMF/LGE;FBBD/lge;FBPN/com.facebook.katana;FBDV/LG-H342;FBSV/5.0.1;FBOP/19;FBCA/armeabi-v7a:armeabi;]'
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ARM
   client:
@@ -5791,13 +5215,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X410(FG) Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -5811,13 +5233,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X410.FGN Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -5831,13 +5251,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-LS860 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -5851,13 +5269,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VS876) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
@@ -5871,13 +5287,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H502 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
@@ -5891,13 +5305,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; es-us; LG-MS690 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -5911,13 +5323,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; LGMS769 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -5931,13 +5341,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-MS770 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -5951,13 +5359,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LG-MS770 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
@@ -5971,13 +5377,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; LG-P880 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -5991,13 +5395,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; LG-P880 Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
@@ -6011,13 +5413,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-CN; LG-P880 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.1.550 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.1.550"
     engine: WebKit
     engine_version: "534.30"
@@ -6031,13 +5431,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ja-jp; L-07C Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6051,13 +5449,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; LG Optimus G Build/KRT16M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -6071,13 +5467,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ja-jp; L-05D Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6091,13 +5485,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; P713 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6111,13 +5503,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ja-jp; L-01D Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6131,13 +5521,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; iw-il; LG-P500h Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6151,13 +5539,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; zh-cn; LGC660 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 MMS/LG-Android-MMS-V1.0/1.2
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6171,13 +5557,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; xx-xx; LG-F100L Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6191,13 +5575,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LG-F100S Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
@@ -6211,13 +5593,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; LG-VS410PP Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6231,13 +5611,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VS415PP Build/KOT49I.VS415PP2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -6251,13 +5629,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VS425PP Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -6271,13 +5647,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; es-es; LG-P350 Build/GRJ90; CyanogenMod-7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6291,13 +5665,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-P500 Build/IMM76L; CyanogenMod-ICySnap) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6311,13 +5683,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-P659 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6331,13 +5701,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; bs-; LG-P700 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6351,13 +5719,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; bs-ba; LG-P700 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6371,13 +5737,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; LG-P700 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -6391,13 +5755,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-hk; LG-P705 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6411,13 +5773,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-gt; LG-P705g Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6431,13 +5791,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; LG-P713 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6451,13 +5809,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; ru-ru; LG-P725 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6471,13 +5827,11 @@
   user_agent: LG-P760/P76010b Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-P760 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6491,13 +5845,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; sr-; LG-P760 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6511,13 +5863,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-P769 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6531,13 +5881,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; LG-P895 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6551,13 +5899,11 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; en-US; LG-P895) U2/1.0.0 UCBrowser/8.6.0.276 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.0.276"
     engine: ""
     engine_version: ""
@@ -6571,13 +5917,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-pa; LG-P920h Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6591,13 +5935,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LG-P936 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "29.0.1547.72"
     engine: Blink
     engine_version: ""
@@ -6611,13 +5953,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fa-ir; LG-P940 Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6631,13 +5971,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; LG-P990 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6651,13 +5989,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; LG-P990 Build/IMM76L; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6671,13 +6007,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; LG-P999 Build/IMM76L; CyanogenMod-9.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6691,13 +6025,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; LG-P999 Build/GRI40; CyanogenMod-9.9.9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9.9.9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -6711,13 +6043,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; en-ca; LG-P505R Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6731,13 +6061,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-K371 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -6751,13 +6079,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-M150 Build/MXB48T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -6771,13 +6097,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X210APM Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
@@ -6791,13 +6115,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; xx; L-02D Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -6811,13 +6133,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X410.F Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
@@ -6831,13 +6151,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LML414DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
@@ -6851,13 +6169,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LML413DL Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
@@ -6871,13 +6187,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710(FGN) Build/OPM1.171019.019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
@@ -6891,13 +6205,11 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; LM-Q710FGN AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
@@ -6911,13 +6223,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710.FGN Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -6931,13 +6241,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; LG-M700 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
@@ -6951,13 +6259,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X525) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
@@ -6971,13 +6277,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-Q610.FG Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -6991,13 +6295,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-Q710.FG Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -7011,13 +6313,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-Q610.FGN Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7031,13 +6331,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-Q725K Build/OPM1.171019.019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7051,13 +6349,11 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; LM-Q725L AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
@@ -7071,13 +6367,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-Q815S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
@@ -7091,13 +6385,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-Q925L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
@@ -7111,13 +6403,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LGV33) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
@@ -7131,13 +6421,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LML211BL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
@@ -7151,13 +6439,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LML212VL Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -7171,13 +6457,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H343 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
@@ -7191,13 +6475,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-H422 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
@@ -7211,13 +6493,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; L-03K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
@@ -7231,13 +6511,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; L-01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
@@ -7251,13 +6529,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VS835) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
@@ -7271,13 +6547,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LML713DL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
@@ -7291,13 +6565,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-Q720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
@@ -7311,13 +6583,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; LG-SU870 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -7331,13 +6601,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X220PM Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
@@ -7351,13 +6619,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-H961N Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -7371,13 +6637,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-H901 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -7391,13 +6655,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; RS987 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
@@ -7411,13 +6673,11 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; VS990 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7431,7 +6691,6 @@
   user_agent: AndroidDownloadManager/7.0 (Linux; U; Android 7.0; LG-F800S Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -7448,13 +6707,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VS995 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
@@ -7468,13 +6725,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; VS996 Build/OPR1.170623.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
@@ -7488,13 +6743,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; L-01K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
@@ -7508,13 +6761,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.0.0; LM-V350 Build/OPR1.170623.032
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7528,13 +6779,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-V350N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -7548,13 +6797,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-V405 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
@@ -7568,13 +6815,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-V409N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
@@ -7588,13 +6833,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; L-51A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36 OPR/59.0.2925.53812
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "59.0.2925.53812"
     engine: Blink
     engine_version: ""
@@ -7608,13 +6851,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X440IM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -7628,13 +6869,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LG-K580) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
@@ -7648,13 +6887,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-K220 Build/MXB48T; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
@@ -7668,13 +6905,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LG-M320 Build/NRD90U) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
@@ -7688,13 +6923,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X510WM Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7708,13 +6941,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X210K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
@@ -7730,7 +6961,6 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.0.326"
     engine: ""
     engine_version: ""
@@ -7744,13 +6974,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X410K Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7764,13 +6992,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X415K Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7784,13 +7010,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X410S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
@@ -7804,13 +7028,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LM-X420N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
@@ -7824,13 +7046,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X410L Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7844,13 +7064,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X415L Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7864,13 +7082,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; LM-X415S Build/OPM1.171019.026
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7884,13 +7100,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; X5-LG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
@@ -7904,13 +7118,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.0.0; LM-X510K Build/O00623
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7924,13 +7136,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.0.0; LM-X510L Build/O00623
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7944,13 +7154,11 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.0.0; LM-X510S Build/O00623
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -7964,13 +7172,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X625N1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
@@ -7984,13 +7190,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; LM-X625N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -8004,13 +7208,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-H650 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
@@ -8024,13 +7226,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; LM-X210VPP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
@@ -8044,19 +7244,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; Lingwin Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: ""
   os_family: Android
   browser_family: Unknown
@@ -8064,19 +7262,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; Lingwin K1 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.0.552 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.0.552"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: K1
   os_family: Android
   browser_family: Unknown
@@ -8084,19 +7280,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-CN; Lingwin K5 Build/JLS36C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.2.559 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.2.559"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: K5
   os_family: Android
   browser_family: Unknown
@@ -8104,19 +7298,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Lingwin T620 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: T620
   os_family: Android
   browser_family: Android Browser
@@ -8124,19 +7316,17 @@
   user_agent: sprd-lingwin-U820S/1.0 Linux/2.6.35.7 Android/2.3.5 Release/10.15.2012 Browser/AppleWebKit533.1 (KHTML, like Gecko) Mozilla/5.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: U820S
   os_family: Android
   browser_family: Android Browser
@@ -8144,19 +7334,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; Lingwin U880 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: LI
+    brand: Lingwin
     model: U880
   os_family: Android
   browser_family: Android Browser
@@ -8164,19 +7352,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Bjorn_SP-500 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Bjorn SP-500
   os_family: Android
   browser_family: Chrome
@@ -8184,19 +7370,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; Lark Cirrus 4 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cirrus 4
   os_family: Android
   browser_family: Android Browser
@@ -8204,19 +7388,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lark Cirrus 4.5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 OPR/51.2.2461.137690
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "51.2.2461.137690"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cirrus 4.5
   os_family: Android
   browser_family: Opera
@@ -8224,19 +7406,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lark Cirrus 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cirrus 5
   os_family: Android
   browser_family: Chrome
@@ -8244,19 +7424,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cumulus 5 HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cumulus 5 HD
   os_family: Android
   browser_family: Chrome
@@ -8264,19 +7442,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cumulus 5.5 HD Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cumulus 5.5 HD
   os_family: Android
   browser_family: Chrome
@@ -8284,19 +7460,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cumulus 6 HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Cumulus 6 HD
   os_family: Android
   browser_family: Chrome
@@ -8304,19 +7478,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lark Phablet 6.0 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Phablet 6.0
   os_family: Android
   browser_family: Android Browser
@@ -8324,19 +7496,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lark_Stratus_5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LK
+    brand: Lark
     model: Stratus 5
   os_family: Android
   browser_family: Chrome
@@ -8344,19 +7514,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Fit FR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Fit FR
   os_family: Android
   browser_family: Chrome
@@ -8364,19 +7532,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le_Hola) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Hola
   os_family: Android
   browser_family: Chrome
@@ -8384,19 +7550,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Hola FR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Hola FR
   os_family: Android
   browser_family: Chrome
@@ -8404,19 +7568,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Hop Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Hop
   os_family: Android
   browser_family: Chrome
@@ -8424,19 +7586,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Lift Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Lift
   os_family: Android
   browser_family: Chrome
@@ -8444,19 +7604,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LeMoov Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Moov
   os_family: Android
   browser_family: Chrome
@@ -8464,19 +7622,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LeMoov2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Moov 2
   os_family: Android
   browser_family: Chrome
@@ -8484,19 +7640,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Smooth) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Smooth
   os_family: Android
   browser_family: Chrome
@@ -8504,19 +7658,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Le Smooth FR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LM
+    brand: Logicom
     model: Le Smooth FR
   os_family: Android
   browser_family: Chrome
@@ -8524,19 +7676,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LAIQ Glam Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LQ
+    brand: LAIQ
     model: Glam
   os_family: Android
   browser_family: Chrome
@@ -8544,19 +7694,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LAIQ New York Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LQ
+    brand: LAIQ
     model: New York
   os_family: Android
   browser_family: Chrome
@@ -8564,19 +7712,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; iQW553 Build/MRA58K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.4.2.995 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.4.2.995"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Alu 5.5"
   os_family: Android
   browser_family: Unknown
@@ -8584,19 +7730,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQW553N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Alu 5.5"
   os_family: Android
   browser_family: Chrome
@@ -8604,19 +7748,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1553 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Color 3 4G
   os_family: Android
   browser_family: Chrome
@@ -8624,19 +7766,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQD700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Color Fingerprint 4G
   os_family: Android
   browser_family: Chrome
@@ -8644,19 +7784,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQ1436 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Color mini 4G
   os_family: Android
   browser_family: Chrome
@@ -8664,19 +7802,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1850 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Diamond 5.2 4G
   os_family: Android
   browser_family: Chrome
@@ -8684,19 +7820,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQS300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: DX 4G
   os_family: Android
   browser_family: Chrome
@@ -8704,7 +7838,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQS300 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 Instagram 111.1.0.25.152 Android (24/7.0; 272dpi; 720x1198; MLS; iQS300; iQS300; mt6735; el_GR; 173238729)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -8713,7 +7846,7 @@
     version: "111.1.0.25.152"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: DX 4G
   os_family: Android
   browser_family: Unknown
@@ -8721,19 +7854,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQE100 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Energy 4G
   os_family: Android
   browser_family: Chrome
@@ -8741,19 +7872,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQGW516 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: F5
   os_family: Android
   browser_family: Chrome
@@ -8761,19 +7890,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQEL41) AppleWebKit/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Fab 4G
   os_family: Android
   browser_family: Android Browser
@@ -8781,19 +7908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQW503) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Flame 4G (2018)
   os_family: Android
   browser_family: Chrome
@@ -8801,19 +7926,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; iQN700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Inspire 4G
   os_family: Android
   browser_family: Chrome
@@ -8821,7 +7944,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; iQ1890 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 Instagram 10.29.0 Android (19/4.4.2; 320dpi; 720x1280; MLS; iQ1890; iQ1890; mt6592; el_GR)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -8830,7 +7952,7 @@
     version: "10.29.0"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Aura
   os_family: Android
   browser_family: Unknown
@@ -8838,19 +7960,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1570 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Color 5.5 4G
   os_family: Android
   browser_family: Chrome
@@ -8858,19 +7978,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1502a Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Flame
   os_family: Android
   browser_family: Chrome
@@ -8878,19 +7996,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; iQ1470 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Mobile Safari/537.36,1
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Onyx
   os_family: Android
   browser_family: Chrome
@@ -8898,19 +8014,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1511 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Spicy
   os_family: Android
   browser_family: Chrome
@@ -8918,19 +8032,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; iQ1552 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/11.3.2.960 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.3.2.960"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Titan 4G
   os_family: Android
   browser_family: Unknown
@@ -8938,19 +8050,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ0705 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Twist
   os_family: Android
   browser_family: Chrome
@@ -8958,19 +8068,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1401 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: iQTalk Verse 4G
   os_family: Android
   browser_family: Chrome
@@ -8978,19 +8086,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; iQW511T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Liberal
   os_family: Android
   browser_family: Chrome
@@ -8998,19 +8104,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; el-gr; iQL50 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: More 4G
   os_family: Android
   browser_family: Android Browser
@@ -9018,19 +8122,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQE200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: MX 4G
   os_family: Android
   browser_family: Chrome
@@ -9038,19 +8140,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; iQL550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Notch Lite
   os_family: Android
   browser_family: Chrome
@@ -9058,19 +8158,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQR300 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: R3 4G
   os_family: Android
   browser_family: Chrome
@@ -9078,19 +8176,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; iQ1568 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/81.0.40
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "81.0.40"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Range 4G
   os_family: Android
   browser_family: Chrome
@@ -9098,19 +8194,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; iQW608) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Regal
   os_family: Android
   browser_family: Chrome
@@ -9118,19 +8212,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQP50 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Ruby 4G
   os_family: Android
   browser_family: Chrome
@@ -9138,19 +8230,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQ5017 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Slice 4G
   os_family: Android
   browser_family: Chrome
@@ -9158,19 +8248,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQL30 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Status 4G
   os_family: Android
   browser_family: Chrome
@@ -9178,19 +8266,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQ1452a Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.40 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.40"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: TOP-S 4G
   os_family: Android
   browser_family: Chrome
@@ -9198,19 +8284,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQ1453 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Trend 4G
   os_family: Android
   browser_family: Chrome
@@ -9218,19 +8302,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQL51 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LS
+    brand: MLS
     model: Wave 4G
   os_family: Android
   browser_family: Chrome
@@ -9238,19 +8320,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LESPH5003B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LT
+    brand: Leotec
     model: Argon A250B
   os_family: Android
   browser_family: Chrome
@@ -9258,19 +8338,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LESPH5011 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LT
+    brand: Leotec
     model: Argon e250
   os_family: Android
   browser_family: Chrome
@@ -9278,19 +8356,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LESPH5014 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LT
+    brand: Leotec
     model: Krypton K150
   os_family: Android
   browser_family: Chrome
@@ -9298,19 +8374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lumus_Ion) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LU
+    brand: Lumus
     model: Ion
   os_family: Android
   browser_family: Chrome
@@ -9318,19 +8392,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NEOSC600) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LU
+    brand: Lumus
     model: Neo SC600
   os_family: Android
   browser_family: Chrome
@@ -9338,19 +8410,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; NEOSR620) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LU
+    brand: Lumus
     model: Neo SR620
   os_family: Android
   browser_family: Chrome
@@ -9358,19 +8428,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LAVA_A3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: A3
   os_family: Android
   browser_family: Chrome
@@ -9378,19 +8446,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A67 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: A67
   os_family: Android
   browser_family: Chrome
@@ -9398,19 +8464,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A76 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: A76
   os_family: Android
   browser_family: Chrome
@@ -9418,19 +8482,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A97 IPS Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: A97 IPS
   os_family: Android
   browser_family: Chrome
@@ -9438,19 +8500,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Flair Z1 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Flair Z1
   os_family: Android
   browser_family: Chrome
@@ -9458,19 +8518,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.6; en-US; Iris_349+) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 349+
   os_family: Android
   browser_family: Unknown
@@ -9478,19 +8536,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.6; en-US; Iris349i) U2/1.0.0 UCBrowser/9.2.0.419 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.419"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 349i
   os_family: Android
   browser_family: Unknown
@@ -9498,19 +8554,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; iris356 Build/irisIRIS356) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 356
   os_family: Android
   browser_family: Android Browser
@@ -9518,19 +8572,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; iris356) U2/1.0.0 UCBrowser/9.5.0.480 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.0.480"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 356
   os_family: Android
   browser_family: Unknown
@@ -9538,19 +8590,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; iris402+ Build/iris402+) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 402+
   os_family: Android
   browser_family: Android Browser
@@ -9558,19 +8608,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; iris402e Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 402e
   os_family: Android
   browser_family: Android Browser
@@ -9578,19 +8626,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; iris405+) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.460"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 405+
   os_family: Android
   browser_family: Unknown
@@ -9598,19 +8644,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; IRIS_501 Build/LAVAIRIS501) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 501
   os_family: Android
   browser_family: Chrome
@@ -9618,19 +8662,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; iris504Q Build/iris504Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 504Q
   os_family: Android
   browser_family: Chrome
@@ -9638,19 +8680,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Iris78W Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 78W
   os_family: Android
   browser_family: Chrome
@@ -9658,19 +8698,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Iris78W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris 78W
   os_family: Android
   browser_family: Chrome
@@ -9678,19 +8716,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X1 Selfie Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Iris X1 Selfie
   os_family: Android
   browser_family: Chrome
@@ -9700,7 +8736,7 @@
   client: null
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: KKT Pearl
   os_family: Unknown
   browser_family: Unknown
@@ -9708,19 +8744,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PixelV1 Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Pixel V1
   os_family: Android
   browser_family: Chrome
@@ -9728,19 +8762,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LAVA_R1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: R1
   os_family: Android
   browser_family: Chrome
@@ -9750,7 +8782,7 @@
   client: null
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Spark i7
   os_family: Unknown
   browser_family: Unknown
@@ -9758,19 +8790,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X41 Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: X41 Plus
   os_family: Android
   browser_family: Chrome
@@ -9778,19 +8808,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Z61_2GB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LV
+    brand: Lava
     model: Z61
   os_family: Android
   browser_family: Chrome
@@ -9798,19 +8826,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5501 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Earth 1
   os_family: Android
   browser_family: Chrome
@@ -9818,19 +8844,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5021 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Earth 2
   os_family: Android
   browser_family: Chrome
@@ -9838,19 +8862,17 @@
   user_agent: Mozilla/5.0 (Mobile; LYF/F30C/LYF_F30C-000-09-10-140318; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.0
   os:
     name: KaiOS
-    short_name: KOS
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "48.0"
     engine: Gecko
     engine_version: "48.0"
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: F30C
   os_family: Firefox OS
   browser_family: Firefox
@@ -9858,19 +8880,17 @@
   user_agent: Mozilla/5.0 (Mobile; LYF/F90M/LYF-F90M-000-02-28-130318; Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.0
   os:
     name: KaiOS
-    short_name: KOS
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "48.0"
     engine: Gecko
     engine_version: "48.0"
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: F90M
   os_family: Firefox OS
   browser_family: Firefox
@@ -9878,19 +8898,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4004 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 2
   os_family: Android
   browser_family: Chrome
@@ -9898,19 +8916,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4001 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 3
   os_family: Android
   browser_family: Chrome
@@ -9918,19 +8934,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4003 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 4
   os_family: Android
   browser_family: Chrome
@@ -9938,19 +8952,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4002 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 5
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone-9.yml
+++ b/Tests/fixtures/smartphone-9.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4005 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 6
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LYF_LS-4006) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 7
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-4008 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 7S
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; LS-4508 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame 8
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-4503 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Flame LS-4503
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Mobile; LYF/LF-2403N/LYF-LF2403N-000-01-38-151217;Android; rv:48.0) Gecko/48.0 Firefox/48.0 KAIOS/2.0
   os:
     name: KaiOS
-    short_name: KOS
     version: "2.0"
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "48.0"
     engine: Gecko
     engine_version: "48.0"
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: LF-2403N
   os_family: Firefox OS
   browser_family: Firefox
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5002 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 1
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-5020 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 10
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LS-5017 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 11
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LS-5008 Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 2
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LS-5503 Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 3
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5005 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 4
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5006 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 6
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5504 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 7
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LS-5507 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 7S
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LS-5015 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 8
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-5506 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water 9
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LS-5505 Build/LYF_LS-5505_01_07) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water F1
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LS-5201 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Water F1S
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5010 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 1
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-6001 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 2
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5502 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 3
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5014 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 4
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5018 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 4S
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LS-5013 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 5
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LS-5009 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 6
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LS-5016 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LY
+    brand: LYF
     model: Wind 7
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ANOVA A5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: LZ
+    brand: Lesia
     model: Anova A5
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Alpha_X Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M0
+    brand: Maze
     model: Alpha X
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; SSB504R Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M0
+    brand: Maze
     model: Speed
   os_family: Android
   browser_family: Opera
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SSB-500 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M0
+    brand: Maze
     model: SSB-500
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; zh-CN; MZ-15 Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 MZBrowser/8.1.210-2020031819 UWS/2.15.0.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.1.210"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 15 Lite
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; zh-CN; MZ-15 Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 MZBrowser/8.11.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.11.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 15 Plus
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; MZ-16s Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 MZBrowser/7.12.0 UWS/2.15.0.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "7.12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 16s
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; MZ-16T Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 MZBrowser/8.11.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.11.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 16T
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; MZ-16th Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 MZBrowser/8.12.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.12.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 16th
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; MZ-16th Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 MZBrowser/8.12.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.12.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 16th Plus
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; MZ-16 X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 MZBrowser/8.11.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "8.11.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: 16X
   os_family: Android
   browser_family: Chrome
@@ -763,7 +687,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; m1 metal Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043906 Mobile Safari/537.36 MicroMessenger/6.5.23.1180 NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -772,7 +695,7 @@
     version: "6.5.23.1180"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M1 Metal
   os_family: Android
   browser_family: Unknown
@@ -780,7 +703,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M1 E Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.49 Mobile MQQBrowser/6.2 TBS/043632 Safari/537.36 MicroMessenger/6.6.1.1220(0x26060133) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -789,7 +711,7 @@
     version: "6.6.1.1220(0x26060133)"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M1E
   os_family: Android
   browser_family: Unknown
@@ -797,19 +719,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; M578CA Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M2
   os_family: Android
   browser_family: Android Browser
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; MZ-M578C Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "40.0.2214.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M2
   os_family: Android
   browser_family: Chrome
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-cn; M578C Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M2
   os_family: Android
   browser_family: Unknown
@@ -857,7 +773,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; m2 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043805 Mobile Safari/537.36 MicroMessenger/6.6.1.1220(0x26060171) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -866,7 +781,7 @@
     version: "6.6.1.1220(0x26060171)"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M2
   os_family: Android
   browser_family: Unknown
@@ -874,7 +789,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; M2 E Build/MMB29U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/44088 Mobile Safari/537.36 MicroMessenger/6.6.7.1321(0x26060737) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -883,7 +797,7 @@
     version: "6.6.7.1321(0x26060737)"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M2E
   os_family: Android
   browser_family: Unknown
@@ -891,19 +805,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; M3E Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M3E
   os_family: Android
   browser_family: Android Browser
@@ -911,19 +823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; M3s Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.2.1487.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.10.2.1487.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M3S
   os_family: Android
   browser_family: Unknown
@@ -931,19 +841,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-CN; MZ-M3s Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 MZBrowser/6.9.410-2017122215 UWS/2.11.0.33 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "6.9.410"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M3s
   os_family: Android
   browser_family: Chrome
@@ -951,7 +859,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; M3X Build/MMB29U; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043909 Mobile Safari/537.36 MicroMessenger/6.6.5.1280(0x26060536) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
@@ -960,7 +867,7 @@
     version: "6.6.5.1280(0x26060536)"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M3X
   os_family: Android
   browser_family: Unknown
@@ -968,19 +875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MEIZU_M5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -988,19 +893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MZ-MEIZU_M5 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/45.0.2454.94 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "45.0.2454.94"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M5
   os_family: Android
   browser_family: Chrome
@@ -1008,19 +911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M5s Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.131 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.131"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M5S
   os_family: Android
   browser_family: Chrome
@@ -1028,19 +929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M612C Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M5S
   os_family: Android
   browser_family: Chrome
@@ -1048,19 +947,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; zh-cn; M711C Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M6
   os_family: Android
   browser_family: Unknown
@@ -1068,19 +965,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; M6T AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.27 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.27"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M6T
   os_family: Android
   browser_family: Chrome
@@ -1088,19 +983,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-CN; M1813 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M8
   os_family: Android
   browser_family: Unknown
@@ -1108,19 +1001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; M1816 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: M8 Lite
   os_family: Android
   browser_family: Chrome
@@ -1128,19 +1019,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; M031 Build/JRO03H) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/8.8.3.278 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.3.278"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX Dual Core
   os_family: Android
   browser_family: Unknown
@@ -1148,19 +1037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; M045 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX2
   os_family: Android
   browser_family: Unknown
@@ -1168,19 +1055,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; M040 Build/KTU84P) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX2
   os_family: Android
   browser_family: Unknown
@@ -1188,19 +1073,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.0; en-za; MX2 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX2
   os_family: Android
   browser_family: Android Browser
@@ -1208,19 +1091,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; M351 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30; 360 Aphone Browser (6.9.0)
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.9.0"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX3
   os_family: Android
   browser_family: Unknown
@@ -1228,19 +1109,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; M356 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX3
   os_family: Android
   browser_family: Android Browser
@@ -1248,19 +1127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; M355 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.0.0.488 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.0.0.488"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX3
   os_family: Android
   browser_family: Unknown
@@ -1268,19 +1145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-CN; M353 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX3
   os_family: Android
   browser_family: Unknown
@@ -1288,19 +1163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MX4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX4
   os_family: Android
   browser_family: Chrome
@@ -1308,19 +1181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MX4 Pro Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36; 360 Aphone Browser (6.9.7)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.9.7"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX4 Pro
   os_family: Android
   browser_family: Unknown
@@ -1328,19 +1199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; MX5 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: MX5
   os_family: Android
   browser_family: Chrome
@@ -1348,19 +1217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; M1822 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: Note 8
   os_family: Android
   browser_family: Chrome
@@ -1368,19 +1235,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; zh-cn; PRO 6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/7.6 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "7.6"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: PRO 6
   os_family: Android
   browser_family: Unknown
@@ -1388,19 +1253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; MZ-PRO 6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/40.0.2214.89 MZBrowser/6.7.3 UWS/2.11.0.22 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Meizu Browser
-    short_name: MZ
     version: "6.7.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: PRO 6
   os_family: Android
   browser_family: Chrome
@@ -1408,7 +1271,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRO 7-H Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/044033 Mobile Safari/537.36 MicroMessenger/6.6.7.1300(0x26060733) NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -1417,7 +1279,7 @@
     version: "6.6.7.1300(0x26060733)"
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: PRO 7
   os_family: Android
   browser_family: Unknown
@@ -1425,19 +1287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; M1852 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M1
+    brand: Meizu
     model: X8
   os_family: Android
   browser_family: Chrome
@@ -1445,19 +1305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MEEG_101M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M2
+    brand: MEEG
     model: 101M
   os_family: Android
   browser_family: Unknown
@@ -1465,7 +1323,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MEEG 103M Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.6.1 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -1474,7 +1331,7 @@
     version: "6.6.1"
   device:
     type: smartphone
-    brand: M2
+    brand: MEEG
     model: 103M
   os_family: Android
   browser_family: Unknown
@@ -1482,19 +1339,17 @@
   user_agent: Thunder.Mozilla/5.0 (Linux; Android 4.4.2; MEEG 210R Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M2
+    brand: MEEG
     model: 210R
   os_family: Android
   browser_family: Chrome
@@ -1502,19 +1357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Xino Z46 X4 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M4
+    brand: Modecom
     model: Xino Z46 X4
   os_family: Android
   browser_family: Chrome
@@ -1522,19 +1375,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; G7106 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: G7106
   os_family: Android
   browser_family: Android Browser
@@ -1542,19 +1393,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; G7106) U2/1.0.0 UCBrowser/10.4.2.659 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.2.659"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: G7106
   os_family: Android
   browser_family: Unknown
@@ -1562,19 +1411,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; G7108 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: G7108
   os_family: Android
   browser_family: Android Browser
@@ -1582,19 +1429,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-us; M20 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: M20
   os_family: Android
   browser_family: Android Browser
@@ -1602,19 +1447,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; M20 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: M20
   os_family: Android
   browser_family: Android Browser
@@ -1622,19 +1465,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; M35 Build/GRK39F
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: M5
+    brand: MIXC
     model: M35
   os_family: Android
   browser_family: Android Browser
@@ -1642,19 +1483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; E1 Selfie Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: E1 Selfie
   os_family: Android
   browser_family: Chrome
@@ -1662,19 +1501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; mobiistar KAT 452 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Kat 452
   os_family: Android
   browser_family: Chrome
@@ -1682,19 +1519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2 mobiistar_KOOL_Lite; Build/KOT49H)  AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.131 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.131"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Kool Lite
   os_family: Android
   browser_family: Chrome
@@ -1702,19 +1537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; mobiistar LAI 504c Build/mobiistar) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai 504c
   os_family: Android
   browser_family: Chrome
@@ -1722,19 +1555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; mobiistar LAI 504K Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai 504K
   os_family: Android
   browser_family: Chrome
@@ -1742,19 +1573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; mobiistar LAI Y Build/mobiistar) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Y
   os_family: Android
   browser_family: Chrome
@@ -1762,19 +1591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; mobiistar_LAI_YOLLO Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yollo
   os_family: Android
   browser_family: Chrome
@@ -1782,19 +1609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; mobiistar LAI Yuki Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yuki
   os_family: Android
   browser_family: Chrome
@@ -1802,19 +1627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; mobiistar LAI YUNA 1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yuna 1
   os_family: Android
   browser_family: Chrome
@@ -1822,7 +1645,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; Mobiistar_LAI_Yuna_C Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/166.0.0.26.91;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -1831,7 +1653,7 @@
     version: "166.0.0.26.91"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yuna C
   os_family: Android
   browser_family: Unknown
@@ -1839,7 +1661,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; mobiistar_LAI_Yuna_S Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/116.0.0.18.70;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -1848,7 +1669,7 @@
     version: "116.0.0.18.70"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yuna S
   os_family: Android
   browser_family: Unknown
@@ -1856,7 +1677,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; Mobiistar_LAI_Yuna_X Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/173.0.0.62.99;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -1865,7 +1685,7 @@
     version: "173.0.0.62.99"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Yuna X
   os_family: Android
   browser_family: Unknown
@@ -1873,7 +1693,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; Mobiistar_LAI_Z Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36[FBAN/EMA;FBLC/vi_VN;FBAV/94.0.0.8.182;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1882,7 +1701,7 @@
     version: "94.0.0.8.182"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Z
   os_family: Android
   browser_family: Unknown
@@ -1890,7 +1709,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; mobiistar LAI Z1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36[FBAN/EMA;FBLC/vi_VN;FBAV/96.0.0.7.216;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -1899,7 +1717,7 @@
     version: "96.0.0.7.216"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Z1
   os_family: Android
   browser_family: Unknown
@@ -1907,19 +1725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mobiistar_LAI_Z2 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Z2
   os_family: Android
   browser_family: Chrome
@@ -1927,19 +1743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Mobiistar_LAI_Zena Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zena
   os_family: Android
   browser_family: Chrome
@@ -1947,19 +1761,17 @@
   user_agent: Mozilla/6.0 (Linux; U; Android 6.0; mobiistar_LAI_ZORO_2 Build/ AppleWebKit/534.30 (KHTML, like Gecko) Version/6.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zoro 2
   os_family: Android
   browser_family: Android Browser
@@ -1967,19 +1779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; mobiistar LAI ZORO 2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zoro 2
   os_family: Android
   browser_family: Chrome
@@ -1987,19 +1797,17 @@
   user_agent: Mozilla/6.0 (Linux; U; Android 6.0; mobiistar_LAI_ZORO_3 Build/ AppleWebKit/534.30 (KHTML, like Gecko) Version/6.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zoro 3
   os_family: Android
   browser_family: Android Browser
@@ -2007,7 +1815,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; mobiistar_LAI_Zumbo_J Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/163.0.0.43.91;]'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
@@ -2016,7 +1823,7 @@
     version: "163.0.0.43.91"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zumbo J
   os_family: Android
   browser_family: Unknown
@@ -2024,19 +1831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Mobiistar_LAI_Zumbo_J_2017 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zumbo J (2017)
   os_family: Android
   browser_family: Chrome
@@ -2044,7 +1849,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; Mobiistar_Zumbo_J2 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Mobile Safari/537.36 [FB_IAB/Orca-Android;FBAV/167.0.0.28.94;]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -2053,7 +1857,7 @@
     version: "167.0.0.28.94"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zumbo J2
   os_family: Android
   browser_family: Unknown
@@ -2061,19 +1865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Zumbo_S_2017 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zumbo S (2017)
   os_family: Android
   browser_family: Chrome
@@ -2081,19 +1883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Zumbo_S_2017_Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Lai Zumbo S Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -2101,19 +1901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; mobiistar_PRIME_558 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime 558
   os_family: Android
   browser_family: Chrome
@@ -2121,19 +1919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; mobiistar PRIME X 2017 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime X
   os_family: Android
   browser_family: Chrome
@@ -2141,7 +1937,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.1; mobiistar PRIME X Grand Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36 [FB_IAB/MESSENGER;FBAV/118.0.0.19.82;]'
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
@@ -2150,7 +1945,7 @@
     version: "118.0.0.19.82"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime X Grand
   os_family: Android
   browser_family: Unknown
@@ -2158,19 +1953,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PRIME X MAX 2018 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime X Max
   os_family: Android
   browser_family: Chrome
@@ -2178,19 +1971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; mobiistar_PRIME_X_Plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime X Plus
   os_family: Android
   browser_family: Chrome
@@ -2198,19 +1989,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; mobiistar PRIME X1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Prime X1
   os_family: Android
   browser_family: Chrome
@@ -2218,19 +2007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; mobiistar touch LAI 512 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Touch Lai 512
   os_family: Android
   browser_family: Chrome
@@ -2238,19 +2025,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; vi-vn; Mobiistar Touch S03 Build/VENUS_00.03.142.H1091) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Touch S03
   os_family: Android
   browser_family: Android Browser
@@ -2258,19 +2043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X1 Notch Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: X1 Notch
   os_family: Android
   browser_family: Chrome
@@ -2278,19 +2061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mobiistar_ZORO_4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Zoro 4G
   os_family: Android
   browser_family: Chrome
@@ -2298,19 +2079,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; mobiistar_LAI_Zumbo Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Zumbo
   os_family: Android
   browser_family: Chrome
@@ -2318,19 +2097,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mobiistar ZUMBO Power Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Zumbo Power
   os_family: Android
   browser_family: Chrome
@@ -2338,19 +2115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mobiistar ZUMBO S2 Dual Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Zumbo S2
   os_family: Android
   browser_family: Chrome
@@ -2358,19 +2133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mobiistar Zumbo S2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M6
+    brand: Mobiistar
     model: Zumbo S2
   os_family: Android
   browser_family: Chrome
@@ -2378,19 +2151,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.6; es-es; MPM_AVA758 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: M7
+    brand: Miray
     model: MPM AVA758
   os_family: Android
   browser_family: Android Browser
@@ -2398,19 +2169,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us ; MPM-i616 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.6.1.262/145/444
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.1.262"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: M7
+    brand: Miray
     model: MPM i616
   os_family: Android
   browser_family: Unknown
@@ -2418,19 +2187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 502M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: 502M
   os_family: Android
   browser_family: Chrome
@@ -2438,19 +2205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_FIVE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Five
   os_family: Android
   browser_family: Chrome
@@ -2458,19 +2223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Grand Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Grand
   os_family: Android
   browser_family: Chrome
@@ -2478,19 +2241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Grand_4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Grand 4G
   os_family: Android
   browser_family: Chrome
@@ -2498,19 +2259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Grand_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Grand 4G
   os_family: Android
   browser_family: Chrome
@@ -2518,19 +2277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Myria_Quad Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Quad
   os_family: Android
   browser_family: Chrome
@@ -2538,19 +2295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Wide_2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Wide 2
   os_family: Android
   browser_family: Chrome
@@ -2558,19 +2313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Wide_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Wide 2
   os_family: Android
   browser_family: Chrome
@@ -2578,19 +2331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Wide_4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Wide 4G
   os_family: Android
   browser_family: Chrome
@@ -2598,19 +2349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Myria_Wide_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M8
+    brand: Myria
     model: Wide 4G
   os_family: Android
   browser_family: Chrome
@@ -2618,19 +2367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MTC_968 Build/ICECREAM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "968"
   os_family: Android
   browser_family: Chrome
@@ -2638,19 +2385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MTC 970 Build/JRO03C) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "970"
   os_family: Android
   browser_family: Chrome
@@ -2658,19 +2403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MTC 970H Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: 970H
   os_family: Android
   browser_family: Chrome
@@ -2678,19 +2421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MTC 972 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "972"
   os_family: Android
   browser_family: Chrome
@@ -2698,19 +2439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MTC975 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "975"
   os_family: Android
   browser_family: Chrome
@@ -2718,19 +2457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MTC 978 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "978"
   os_family: Android
   browser_family: Chrome
@@ -2738,19 +2475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MTC 982 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: "982"
   os_family: Android
   browser_family: Chrome
@@ -2758,19 +2493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MTC 982O Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: 982O
   os_family: Android
   browser_family: Chrome
@@ -2778,19 +2511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MTC 982T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: 982T
   os_family: Android
   browser_family: Chrome
@@ -2798,19 +2529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_Race2_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 YaBrowser/19.1.3.198.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.1.3.198.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Race 2 4G
   os_family: Android
   browser_family: Unknown
@@ -2818,19 +2547,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; SMART Race 4G Build/LMY47D; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36 YandexSearch/7.63 YandexSearchBrowser/7.63
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Race 4G
   os_family: Android
   browser_family: Chrome
@@ -2838,19 +2565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MTC SMART Run Build/ARK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3435.52 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3435.52"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Run 4G
   os_family: Android
   browser_family: Chrome
@@ -2858,19 +2583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MTC SMART Run 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Run 4G
   os_family: Android
   browser_family: Chrome
@@ -2878,19 +2601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MTC SmartRun 4G Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Run 4G
   os_family: Android
   browser_family: Chrome
@@ -2898,19 +2619,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; MTC SMART Sprint 4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.9.1193 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.9.1193"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Sprint 4G
   os_family: Android
   browser_family: Unknown
@@ -2918,19 +2637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MTC_SMART_Sprint_4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Sprint 4G
   os_family: Android
   browser_family: Chrome
@@ -2938,19 +2655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MTC_SMART_Start_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Start 2
   os_family: Android
   browser_family: Chrome
@@ -2958,19 +2673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SMART Surf2 4G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.186 YaBrowser/18.3.1.651.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.3.1.651.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Surf 2 4G
   os_family: Android
   browser_family: Unknown
@@ -2978,19 +2691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SMART_Surf_4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: M9
+    brand: MTC
     model: Smart Surf 4G
   os_family: Android
   browser_family: Chrome
@@ -2998,19 +2709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MSP96017) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MA
+    brand: Manta Multimedia
     model: Forto 2
   os_family: Android
   browser_family: Chrome
@@ -3018,19 +2727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MSP95015 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MA
+    brand: Manta Multimedia
     model: Mezo 2
   os_family: Android
   browser_family: Chrome
@@ -3038,19 +2745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MSP95020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MA
+    brand: Manta Multimedia
     model: Rocky 2
   os_family: Android
   browser_family: Chrome
@@ -3058,19 +2763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MSP95021) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MA
+    brand: Manta Multimedia
     model: Rocky 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -3078,19 +2781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MSP95014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MA
+    brand: Manta Multimedia
     model: Titano 3
   os_family: Android
   browser_family: Chrome
@@ -3098,19 +2799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Cynus_F10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus F10
   os_family: Android
   browser_family: Chrome
@@ -3118,19 +2817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Cynus F3 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus F3
   os_family: Android
   browser_family: Android Browser
@@ -3138,19 +2835,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Cynus F4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus F4
   os_family: Android
   browser_family: Android Browser
@@ -3158,19 +2853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Cynus_F8 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus F8
   os_family: Android
   browser_family: Chrome
@@ -3178,19 +2871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Cynus T1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus T1
   os_family: Android
   browser_family: Android Browser
@@ -3198,19 +2889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Cynus T2 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus T2
   os_family: Android
   browser_family: Chrome
@@ -3218,19 +2907,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; Cynus T5 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MB
+    brand: Mobistel
     model: Cynus T5
   os_family: Android
   browser_family: Android Browser
@@ -3238,19 +2925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxG400 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G400
   os_family: Android
   browser_family: Chrome
@@ -3258,19 +2943,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PPBG500 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G500
   os_family: Android
   browser_family: Android Browser
@@ -3278,19 +2961,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PPCG500 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G500
   os_family: Android
   browser_family: Android Browser
@@ -3298,19 +2979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; M-PPAG500 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G500
   os_family: Android
   browser_family: Chrome
@@ -3318,19 +2997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxG501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo G501
   os_family: Android
   browser_family: Chrome
@@ -3338,19 +3015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxS470 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S470
   os_family: Android
   browser_family: Chrome
@@ -3358,19 +3033,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S500 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S500
   os_family: Android
   browser_family: Android Browser
@@ -3378,19 +3051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PP2S500C Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S500
   os_family: Android
   browser_family: Android Browser
@@ -3398,19 +3069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-PPxS501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Mobile Safari/537.36 OPR/29.0.1809.92697
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "29.0.1809.92697"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo S501
   os_family: Android
   browser_family: Opera
@@ -3418,19 +3087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; M-PPAX470U Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo X470U
   os_family: Android
   browser_family: Android Browser
@@ -3438,19 +3105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; M_PPAX510U Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo X510U
   os_family: Android
   browser_family: Chrome
@@ -3458,19 +3123,17 @@
   user_agent: Android 4.4.2;AppleWebKit/537.36;Build/KOT49H;M-PPxX520U Build/KOT49H
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MC
+    brand: Mediacom
     model: PhonePad Duo X520U
   os_family: Android
   browser_family: Android Browser
@@ -3478,19 +3141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MEDION B5530) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: B5530
   os_family: Android
   browser_family: Chrome
@@ -3498,19 +3159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MEDION E4002 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: E4002
   os_family: Android
   browser_family: Chrome
@@ -3518,19 +3177,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; MEDION Smartphone LIFE E3501 Build/GRJ34) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: LIFE E3501
   os_family: Android
   browser_family: Android Browser
@@ -3538,19 +3195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MEDION E4504) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life E4504
   os_family: Android
   browser_family: Chrome
@@ -3558,19 +3213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MEDION E5004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life E5004
   os_family: Android
   browser_family: Chrome
@@ -3578,19 +3231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MEDION E5020) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life E5020
   os_family: Android
   browser_family: Chrome
@@ -3598,19 +3249,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MEDION LIFE P4012 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: LIFE P4012
   os_family: Android
   browser_family: Android Browser
@@ -3618,19 +3267,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; de-de; MEDION LIFE P4310 Build/GRJ29) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: LIFE P4310
   os_family: Android
   browser_family: Android Browser
@@ -3638,19 +3285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MEDION P5015) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life P5015
   os_family: Android
   browser_family: Chrome
@@ -3658,19 +3303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MEDION S5004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life S5004
   os_family: Android
   browser_family: Chrome
@@ -3678,19 +3321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X5001 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: Life X5001
   os_family: Android
   browser_family: Chrome
@@ -3698,19 +3339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MEDION P4013 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: P4013
   os_family: Android
   browser_family: Chrome
@@ -3718,19 +3357,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MEDION X4701 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MD
+    brand: Medion
     model: X4701
   os_family: Android
   browser_family: Android Browser
@@ -3738,7 +3375,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; MOFUT Build/JLS36C) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.3)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -3747,7 +3383,7 @@
     version: "6.7"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: ""
   os_family: Android
   browser_family: Unknown
@@ -3755,7 +3391,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MOFUT F1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
@@ -3764,7 +3399,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: F1
   os_family: Android
   browser_family: Unknown
@@ -3772,19 +3407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; F6 Build/MOFUTF6) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: F6
   os_family: Android
   browser_family: Chrome
@@ -3792,19 +3425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; MOFUT Build/MOFUTF6) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: F6
   os_family: Android
   browser_family: Chrome
@@ -3812,19 +3443,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MOFUT_F88RZTD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: F88RZTD
   os_family: Android
   browser_family: Android Browser
@@ -3832,19 +3461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-CN; MOFUT_KX Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.0.558 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.0.558"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: KX
   os_family: Android
   browser_family: Unknown
@@ -3852,19 +3479,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; zh-CN; MOFUT_N5 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.2.626 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.2.626"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: N5
   os_family: Android
   browser_family: Unknown
@@ -3872,19 +3497,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MOFUT T2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MF
+    brand: Mofut
     model: T2
   os_family: Android
   browser_family: Android Browser
@@ -3892,19 +3515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MyWigo City3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MG
+    brand: MyWigo
     model: City 3
   os_family: Android
   browser_family: Chrome
@@ -3912,19 +3533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MS50X6 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Atmos II
   os_family: Android
   browser_family: Chrome
@@ -3932,19 +3551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MS55X5 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Atmos Pro
   os_family: Android
   browser_family: Chrome
@@ -3952,19 +3569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MS55X6 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Atmos Pro II
   os_family: Android
   browser_family: Chrome
@@ -3972,19 +3587,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MS45A4000 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: eOn 45
   os_family: Android
   browser_family: Android Browser
@@ -3992,19 +3605,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ro-ro; MS50A4000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: eOn 50
   os_family: Android
   browser_family: Android Browser
@@ -4012,19 +3623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MS50A4500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: eOn 50 Elegance
   os_family: Android
   browser_family: Chrome
@@ -4032,19 +3641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MS50A6000 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: eOn 50 Quad 16
   os_family: Android
   browser_family: Chrome
@@ -4052,19 +3659,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MS50A5000 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: eOn 50 Quad 8
   os_family: Android
   browser_family: Android Browser
@@ -4072,19 +3677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS55L1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: GAIA
   os_family: Android
   browser_family: Chrome
@@ -4092,19 +3695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS50L1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Inti
   os_family: Android
   browser_family: Chrome
@@ -4112,19 +3713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MB-2900 QUATTRO Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Mobile Safari/537.36 OPR/37.0.2192.105088
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "37.0.2192.105088"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: MB-2900 Quattro
   os_family: Android
   browser_family: Opera
@@ -4132,19 +3731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; tr-tr; MS43A3000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: MS43A3000
   os_family: Android
   browser_family: Android Browser
@@ -4152,19 +3749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MS50B11000 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: MS50B11000
   os_family: Android
   browser_family: Chrome
@@ -4172,19 +3767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; POLYS_MS45L1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Polys MS45L1
   os_family: Android
   browser_family: Chrome
@@ -4192,19 +3785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Wave5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MH
+    brand: Mobiola
     model: Wave 5
   os_family: Android
   browser_family: Chrome
@@ -4212,19 +3803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4560MMX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: 4560MMX
   os_family: Android
   browser_family: Chrome
@@ -4232,19 +3821,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Micromax_A101 Build/MicromaxMicromax_A101) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A101
   os_family: Android
   browser_family: Android Browser
@@ -4252,19 +3839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Micromax A110Q Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A110Q
   os_family: Android
   browser_family: Chrome
@@ -4272,19 +3857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-in; Micromax A116 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A116
   os_family: Android
   browser_family: Android Browser
@@ -4292,19 +3875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Micromax A116i Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A116i
   os_family: Android
   browser_family: Chrome
@@ -4312,7 +3893,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-in; Micromax A210 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.2.17.1009776.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ARM
   client:
@@ -4321,7 +3901,7 @@
     version: "3.2.17.1009776"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A210
   os_family: Android
   browser_family: Unknown
@@ -4329,19 +3909,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-in; Micromax A24 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A24
   os_family: Android
   browser_family: Android Browser
@@ -4349,19 +3927,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.5; en-US; Micromax_A26) U2/1.0.0 UCBrowser/8.9.2.373 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.9.2.373"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A26
   os_family: Android
   browser_family: Unknown
@@ -4369,19 +3945,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; Micromax_A27) U2/1.0.0 UCBrowser/8.9.2.373 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A27
   os_family: GNU/Linux
   browser_family: Opera
@@ -4389,19 +3963,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; Micromax_A36) U2/1.0.0 UCBrowser/8.2.0.242 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.2.0.242"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A36
   os_family: Android
   browser_family: Unknown
@@ -4409,19 +3981,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-in; Micromax A58 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A58
   os_family: Android
   browser_family: Android Browser
@@ -4429,19 +3999,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Micromax A61 Build/JZO57K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A61
   os_family: Android
   browser_family: Android Browser
@@ -4449,19 +4017,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 2.3.5; en-US; Micromax_A62) U2/1.0.0 UCBrowser/8.7.0.315 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.7.0.315"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A62
   os_family: Android
   browser_family: Unknown
@@ -4469,19 +4035,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Opera Mini/7.1.32052/30.3697; en-US; Micromax_A62) U2/1.0.0 UCBrowser/9.1.1.420 Mobile
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.1.32052"
     engine: Presto
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A62
   os_family: GNU/Linux
   browser_family: Opera
@@ -4489,19 +4053,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; Micromax_A74) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A74
   os_family: Android
   browser_family: Unknown
@@ -4509,19 +4071,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-in; Micromax A92 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: A92
   os_family: Android
   browser_family: Android Browser
@@ -4529,19 +4089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Q327 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Bolt
   os_family: Android
   browser_family: Chrome
@@ -4549,19 +4107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Micromax Q402+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Bolt Pace
   os_family: Android
   browser_family: Chrome
@@ -4569,19 +4125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Micromax Q424 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Bolt Selfie
   os_family: Android
   browser_family: Chrome
@@ -4589,19 +4143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Micromax E481 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Canvas 5
   os_family: Android
   browser_family: Chrome
@@ -4609,19 +4161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Micromax AQ5001 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Canvas Juice 2
   os_family: Android
   browser_family: Chrome
@@ -4629,19 +4179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Micromax Q417 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Canvas Mega
   os_family: Android
   browser_family: Chrome
@@ -4649,19 +4197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AQ5001 Canvas Power Build/LMY49J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: Canvas Power
   os_family: Android
   browser_family: Chrome
@@ -4669,19 +4215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; YU5530 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: YU Yureka S YU5530
   os_family: Android
   browser_family: Chrome
@@ -4689,19 +4233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; YU5040) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MI
+    brand: MicroMax
     model: YU Yureka YU5040
   os_family: Android
   browser_family: Chrome
@@ -4709,19 +4251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CRONO 22 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.131 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.131"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MJ
+    brand: Majestic
     model: Crono 22
   os_family: Android
   browser_family: Chrome
@@ -4729,19 +4269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CRONO 44 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MJ
+    brand: Majestic
     model: Crono 44
   os_family: Android
   browser_family: Chrome
@@ -4749,19 +4287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; URANO 77LTE Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MJ
+    brand: Majestic
     model: Urano 77 LTE
   os_family: Android
   browser_family: Chrome
@@ -4769,19 +4305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; it-it; MAJESTIC Zeus21 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 MxBrowser/4.4.0.2000
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.4.0.2000"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MJ
+    brand: Majestic
     model: Zeus21
   os_family: Android
   browser_family: Unknown
@@ -4789,19 +4323,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MLLED M1B Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M1B
   os_family: Android
   browser_family: Unknown
@@ -4809,7 +4341,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MLLED M2+ Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 BaiduBoxApp/3.6_7300050a
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -4818,7 +4349,7 @@
     version: "3.6"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M2+
   os_family: Android
   browser_family: Unknown
@@ -4826,7 +4357,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MLLED_M3 MINI Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.2.54_rec1912d.581 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -4835,7 +4365,7 @@
     version: "6.2.2.54.rec1912d.581"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M3 MINI
   os_family: Android
   browser_family: Unknown
@@ -4843,19 +4373,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; MLLED M7S Build/KOT49H) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baidubrowser/6.0.21.0 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "6.0.21.0"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M7S
   os_family: Android
   browser_family: Baidu
@@ -4863,19 +4391,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MLLED M8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M8
   os_family: Android
   browser_family: Unknown
@@ -4883,19 +4409,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-CN; MLLED_M8S Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.1.549 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.1.549"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: M8S
   os_family: Android
   browser_family: Unknown
@@ -4903,7 +4427,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; MLLED X3S Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025440 Mobile Safari/533.1 MicroMessenger/6.2.4.54_r266a9ba.601 NetType/WIFI Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -4912,7 +4435,7 @@
     version: "6.2.4.54.r266a9ba.601"
   device:
     type: smartphone
-    brand: ML
+    brand: MLLED
     model: X3S
   os_family: Android
   browser_family: Unknown
@@ -4920,19 +4443,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.0.4; PH350B Build/IMM76D)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MM
+    brand: Mpman
     model: PH350
   os_family: Android
   browser_family: Android Browser
@@ -4940,19 +4461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-ch; PH350 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MM
+    brand: Mpman
     model: PH350
   os_family: Android
   browser_family: Android Browser
@@ -4960,19 +4479,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PH520 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MM
+    brand: Mpman
     model: PH520
   os_family: Android
   browser_family: Android Browser
@@ -4980,19 +4497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; M4 SS4458) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Attitude
   os_family: Android
   browser_family: Chrome
@@ -5000,19 +4515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M4_B2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: B2
   os_family: Android
   browser_family: Chrome
@@ -5020,19 +4533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M4_B3 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: B3
   os_family: Android
   browser_family: Chrome
@@ -5040,19 +4551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; M4 SS4451 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Believe
   os_family: Android
   browser_family: Chrome
@@ -5060,19 +4569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; M4 SS4452 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Dream
   os_family: Android
   browser_family: Chrome
@@ -5080,19 +4587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M4 SS4457) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Elegance
   os_family: Android
   browser_family: Chrome
@@ -5100,19 +4605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M4 SS4457-R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Ever
   os_family: Android
   browser_family: Chrome
@@ -5120,19 +4623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; M4 SS4456) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Evolution
   os_family: Android
   browser_family: Chrome
@@ -5140,19 +4641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; M4 SS4455 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Excite
   os_family: Android
   browser_family: Chrome
@@ -5160,19 +4659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M4 SS4458-R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Feel Plus
   os_family: Android
   browser_family: Chrome
@@ -5180,19 +4677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; M4 SS4040 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: In Touch
   os_family: Android
   browser_family: Chrome
@@ -5200,19 +4695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; M4 SS4453) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Inspiration
   os_family: Android
   browser_family: Chrome
@@ -5220,19 +4713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; M4 SS1050 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Joy
   os_family: Android
   browser_family: Chrome
@@ -5240,19 +4731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; M4 SS1060 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Live
   os_family: Android
   browser_family: Chrome
@@ -5260,19 +4749,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; M4 SS1080 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Max One
   os_family: Android
   browser_family: Chrome
@@ -5280,19 +4767,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; M4 SS1090 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Max Ultra
   os_family: Android
   browser_family: Chrome
@@ -5300,19 +4785,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; M4 SS4020 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Play
   os_family: Android
   browser_family: Chrome
@@ -5320,19 +4803,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; M4 SS1070 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Sense
   os_family: Android
   browser_family: Chrome
@@ -5340,19 +4821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M4 SS4450 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Share
   os_family: Android
   browser_family: Chrome
@@ -5360,19 +4839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M4 SS4350 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Soul
   os_family: Android
   browser_family: Chrome
@@ -5380,19 +4857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M4 SS4345 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -5400,19 +4875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M4 SS4045 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Style
   os_family: Android
   browser_family: Chrome
@@ -5420,19 +4893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; M4 SS4445 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MN
+    brand: M4tel
     model: Style Access
   os_family: Android
   browser_family: Chrome
@@ -5440,19 +4911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MOBIX M6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MO
+    brand: Mio
     model: Mobix M6
   os_family: Android
   browser_family: Chrome
@@ -5460,19 +4929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MFLogin4 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Login 4 LTE
   os_family: Android
   browser_family: Chrome
@@ -5480,19 +4947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MegLogPh) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Login+
   os_family: Android
   browser_family: Chrome
@@ -5500,19 +4965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MFLoginPh Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.100 YaBrowser/17.10.2.145.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.10.2.145.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Login+
   os_family: Android
   browser_family: Unknown
@@ -5520,19 +4983,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; ru-ru; SP-A20i Build/MF_GB_01.02) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Mint
   os_family: Android
   browser_family: Android Browser
@@ -5540,19 +5001,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MS3B Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Optima
   os_family: Android
   browser_family: Android Browser
@@ -5560,19 +5019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Megafon Optima Build/LolliFox_Final) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: Optima
   os_family: Android
   browser_family: Chrome
@@ -5580,19 +5037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; ru-ru; MegaFon SP-A5 Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MP
+    brand: MegaFon
     model: SP-A5
   os_family: Android
   browser_family: Android Browser
@@ -5600,19 +5055,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; M.T.T. Smart Multimedia Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MQ
+    brand: M.T.T.
     model: Smart Multimedia
   os_family: Android
   browser_family: Android Browser
@@ -5620,19 +5073,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; M.T.T. SmartFun Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MQ
+    brand: M.T.T.
     model: SmartFun
   os_family: Android
   browser_family: Android Browser
@@ -5640,19 +5091,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-fr; M.T.T.SmartMax Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MQ
+    brand: M.T.T.
     model: SmartMax
   os_family: Android
   browser_family: Android Browser
@@ -5660,19 +5109,17 @@
   user_agent: Mozilla/5.0 (MotorolaWebKit; U; /Windows CE 7.0) AppleWebKit/534.51 (KHTML, like Gecko) Version/2.3.0 Mobile Safari/534.51
   os:
     name: Windows CE
-    short_name: WCE
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "2.3.0"
     engine: WebKit
     engine_version: "534.51"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: ""
   os_family: Windows Mobile
   browser_family: Safari
@@ -5680,19 +5127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; MotoA953 Build/MILS2_U6_2.3.4) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: A953
   os_family: Android
   browser_family: Android Browser
@@ -5700,19 +5145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; XT603 Build/5.5.1Q-117_PAX-79) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Admiral
   os_family: Android
   browser_family: Android Browser
@@ -5720,19 +5163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; pt-br; XT682 Build/V1.51D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Atrix
   os_family: Android
   browser_family: Android Browser
@@ -5740,19 +5181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-br; XT687 Build/V2.27D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Atrix TV
   os_family: Android
   browser_family: Android Browser
@@ -5760,19 +5199,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; XT535 Build/V1.540) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy
   os_family: Android
   browser_family: Android Browser
@@ -5780,19 +5217,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-gb; MOT-XT320 Build/0A.1F.3A) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy Mini
   os_family: Android
   browser_family: Android Browser
@@ -5800,19 +5235,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; XT320 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy Mini
   os_family: Android
   browser_family: Android Browser
@@ -5820,19 +5253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; pt-br; XT321 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Versão/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy Mini
   os_family: Android
   browser_family: Android Browser
@@ -5840,19 +5271,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; XT555C Build/V1.67D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy XT
   os_family: Android
   browser_family: Android Browser
@@ -5860,19 +5289,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; XT556 Build/V1.70B) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy XT
   os_family: Android
   browser_family: Android Browser
@@ -5880,19 +5307,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; XT557 Build/V1.65K) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Defy XT
   os_family: Android
   browser_family: Android Browser
@@ -5900,19 +5325,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.0.1; en-us; Droid Build/ESD56) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID
   os_family: Android
   browser_family: Android Browser
@@ -5920,19 +5343,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; it-it; Momodesign MD Droid Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID
   os_family: Android
   browser_family: Android Browser
@@ -5940,19 +5361,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Droid Build/GRH78C; 10800) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID
   os_family: Android
   browser_family: Android Browser
@@ -5960,19 +5379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID2 Build/4.5.1_57_DR4-51) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID 2
   os_family: Android
   browser_family: Android Browser
@@ -5980,19 +5397,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; en-us; DROID2 GLOBAL Build/S273) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID 2 GLOBAL
   os_family: Android
   browser_family: Android Browser
@@ -6000,19 +5415,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROID3 Build/5.5.1_84_D3G-66_M2-10) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID 3
   os_family: Android
   browser_family: Android Browser
@@ -6020,19 +5433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; DROID4 Build/9.8.2O-72_VZW-18-9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID 4
   os_family: Android
   browser_family: Chrome
@@ -6040,19 +5451,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; XT894 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 CyanogenMod/10.1.2/maserati
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid 4
   os_family: Android
   browser_family: Android Browser
@@ -6060,19 +5469,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; DROID4 4G Build/6.7.2-180_DR4-16_M2-37) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID 4 4G
   os_family: Android
   browser_family: Android Browser
@@ -6080,19 +5487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; DROID BIONIC Build/9.8.2O-72_VZW-22) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID BIONIC
   os_family: Android
   browser_family: Chrome
@@ -6100,19 +5505,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; DROID BIONIC 4G Build/6.7.2-223_DBN_M4-23) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID BIONIC 4G
   os_family: Android
   browser_family: Android Browser
@@ -6120,19 +5523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; XT1030 Build/12.9.0Q2.X-160-OBK_TA-14-7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid Mini
   os_family: Android
   browser_family: Chrome
@@ -6140,19 +5541,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; XT610 Build/V2U_3.4.2-179) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid Pro
   os_family: Android
   browser_family: Android Browser
@@ -6160,19 +5559,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; DROID Pro Build/VZW; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID Pro
   os_family: Android
   browser_family: Android Browser
@@ -6180,19 +5577,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-ca; MOT-XT910 Build/6.5.1_73_SLC-24) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR
   os_family: Android
   browser_family: Android Browser
@@ -6200,19 +5595,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-sg; XT910 Build/6.5.1-167-SPD-IRD-40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR
   os_family: Android
   browser_family: Android Browser
@@ -6220,19 +5613,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-; DROID RAZR Build/6.7.2-180_DHD-16_M4-31) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID RAZR
   os_family: Android
   browser_family: Android Browser
@@ -6240,19 +5631,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; XT910 Build/6.7.2-180_SLC-35_R01) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR
   os_family: Android
   browser_family: Android Browser
@@ -6260,19 +5649,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MOT-XT910S Build/6.7.4-27_SA-51) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR
   os_family: Android
   browser_family: Android Browser
@@ -6280,19 +5667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; DROID RAZR Build/6.7.2-180_DHD-16_M4-31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1631.1 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1631.1"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID RAZR
   os_family: Android
   browser_family: Chrome
@@ -6300,19 +5685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT915 Build/2_32A_2013) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D1
   os_family: Android
   browser_family: Chrome
@@ -6320,19 +5703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT914 Build/2_28B_2012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D1
   os_family: Android
   browser_family: Chrome
@@ -6340,19 +5721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT916 Build/2_32D_2014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D1
   os_family: Android
   browser_family: Chrome
@@ -6360,19 +5739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT918 Build/2_330_2009) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D1
   os_family: Android
   browser_family: Chrome
@@ -6380,19 +5757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT919 Build/2_290_2012) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D3
   os_family: Android
   browser_family: Chrome
@@ -6400,19 +5775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT920 Build/2_32D_2030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR D3
   os_family: Android
   browser_family: Chrome
@@ -6420,19 +5793,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-us; DROID RAZR HD Build/9.8.1Q_39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID RAZR HD
   os_family: Android
   browser_family: Android Browser
@@ -6440,19 +5811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT925 Build/9.8.2Q-8-XT925_VQL-12.2) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR HD
   os_family: Android
   browser_family: Chrome
@@ -6460,19 +5829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT925 Build/9.8.2Q-8-XT925_VQUL-1601) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR HD
   os_family: Android
   browser_family: Chrome
@@ -6480,19 +5847,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; XT890 Build/8.7.1I-110_IFW-31) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR i
   os_family: Android
   browser_family: Android Browser
@@ -6500,19 +5865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; XT890 Build/8.7.1I-110_IFW-DE-32) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR i
   os_family: Android
   browser_family: Chrome
@@ -6520,19 +5883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT907 Build/9.8.1Q-94-1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR M
   os_family: Android
   browser_family: Chrome
@@ -6540,19 +5901,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; XT885 Build/6.7.3-135_YIC-8) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR V
   os_family: Android
   browser_family: Android Browser
@@ -6560,19 +5919,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; XT886 Build/6.7.3-179_YIC-11) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid RAZR V
   os_family: Android
   browser_family: Android Browser
@@ -6580,19 +5937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; XT1254 Build/MCG24.251-5-5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid Turbo
   os_family: Android
   browser_family: Chrome
@@ -6600,19 +5955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; XT1080 Build/SU2-3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Droid Ultra
   os_family: Android
   browser_family: Chrome
@@ -6620,19 +5973,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; DROIDX Build/4.5.1_57_DX9-10) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID X
   os_family: Android
   browser_family: Android Browser
@@ -6640,19 +5991,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; DROID X2 Build/4.5.1A-DTN-200-18) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: DROID X2
   os_family: Android
   browser_family: Android Browser
@@ -6660,19 +6009,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; XT881 Build/6.7.3-130_YUS-11) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Electrify 2
   os_family: Android
   browser_family: Android Browser
@@ -6680,19 +6027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; XT901 Build/9.8.2Q-50_SLS-13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Electrify M
   os_family: Android
   browser_family: Chrome
@@ -6700,19 +6045,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.1; Motorola_ES405B_312; Windows Phone 6.5.3.5)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "6.5.3.5"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "6.0"
     engine: Trident
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: ES405B
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6720,19 +6063,17 @@
   user_agent: MOT-XT311/Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; XT311 Build/V4.36M) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Fire
   os_family: Android
   browser_family: Android Browser
@@ -6740,19 +6081,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; XT316 Build/V4.26H) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Fire
   os_family: Android
   browser_family: Android Browser
@@ -6760,19 +6099,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; fr-ca; XT531 Build/V4.540) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Fire XT
   os_family: Android
   browser_family: Android Browser
@@ -6780,19 +6117,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; XT800W Build/TTSKT_U_80.33.41R) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Glam
   os_family: Android
   browser_family: Android Browser
@@ -6800,19 +6135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; XT626 Build/5.5.1Q-391_IR_TA-82) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: IronRock
   os_family: Android
   browser_family: Android Browser
@@ -6820,19 +6153,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.5; en-us; MB300 Build/Blur_Version.0.13.37.MB300.ATT.en.US Flex/P014) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB300
   os_family: Android
   browser_family: Android Browser
@@ -6840,19 +6171,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; MotoMB511 Build/ERE27) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB511
   os_family: Android
   browser_family: Android Browser
@@ -6860,19 +6189,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MB526 Build/IMM76L; CyanogenMod-CM9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB526
   os_family: Android
   browser_family: Android Browser
@@ -6880,19 +6207,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; hu-hu; MB526 Build/JRO03L; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB526
   os_family: Android
   browser_family: Android Browser
@@ -6900,19 +6225,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; MB860 Build/4.5.2A-51_OLL-17.8) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB860
   os_family: Android
   browser_family: Android Browser
@@ -6920,19 +6243,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.7; tr-tr; MB860 Build/4.5.141; CM7 20120812 [yyyymmdd]) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB860
   os_family: Android
   browser_family: Android Browser
@@ -6940,19 +6261,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; MB860 Build/IMM76L; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB860
   os_family: Android
   browser_family: Android Browser
@@ -6960,19 +6279,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MB886 Build/9.8.0Q-97_MB886_FFW-20) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 airGClient/2.1.7
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB886
   os_family: Android
   browser_family: Android Browser
@@ -6980,7 +6297,6 @@
   user_agent: AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; MB886 Build/9.8.0Q-97_MB886_FFW-20)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -6989,7 +6305,7 @@
     version: "4.1.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB886
   os_family: Android
   browser_family: Unknown
@@ -6997,19 +6313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MB886 Build/9.8.0Q-97_MB886_FFW-20) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MB886
   os_family: Android
   browser_family: Chrome
@@ -7017,19 +6331,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; ME525(Defy) Build/MIUI) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: ME525(Defy)
   os_family: Android
   browser_family: Android Browser
@@ -7037,19 +6349,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-ca; Motorola XT720 Build/STR_U2_05.1F.1) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Milestone
   os_family: Android
   browser_family: Android Browser
@@ -7057,19 +6367,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; Milestone XT720 Build/STR_U2_01.1E.0) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Milestone
   os_family: Android
   browser_family: Android Browser
@@ -7077,19 +6385,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; XT860 Build/5.5.1-112_SLU-57M) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Milestone 3
   os_family: Android
   browser_family: Android Browser
@@ -7097,19 +6403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Moto C Plus Build/NRD90M.03.038) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto C Plus
   os_family: Android
   browser_family: Chrome
@@ -7117,19 +6421,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; XT1021 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto E
   os_family: Android
   browser_family: Chrome
@@ -7137,19 +6439,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.4; en-US; XT1022) U2/1.0.0 UCBrowser/9.5.1.494 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.5.1.494"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto E
   os_family: Android
   browser_family: Unknown
@@ -7157,19 +6457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XT1706 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto E3 Power
   os_family: Android
   browser_family: Chrome
@@ -7177,19 +6475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Moto E (4) Plus Build/NMA26.42-142) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto E4 Plus
   os_family: Android
   browser_family: Chrome
@@ -7197,19 +6493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; XT1924-9 Build/OCP27.91-38-31-22; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto E5 Plus
   os_family: Android
   browser_family: Chrome
@@ -7217,19 +6511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; XT1028 Build/14.10.0Q3.X-84-14) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7237,19 +6529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1032 Build/KLB20.9-1.10-1.24-1.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7257,19 +6547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1033 Build/KXB20.25-1.31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7277,19 +6565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1031 Build/KXB20.9-1.10-1.18) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7297,19 +6583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1034 Build/KXB20.9-1.10-1.36) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7317,19 +6601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XT1068 Build/MPB24.65-34-3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7337,19 +6619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XT1069) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7357,19 +6637,17 @@
   user_agent: Browse/0.6.mini (Linux 3.4.0+; RemixOS 6.0; Motorola Moto G 2014; en_us) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.119 Desktop
   os:
     name: Remix OS
-    short_name: REM
     version: "2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G
   os_family: Android
   browser_family: Chrome
@@ -7377,19 +6655,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; moto g power Build/QPMS30.80-51-5)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G Power
   os_family: Android
   browser_family: Android Browser
@@ -7397,19 +6673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; MotoG3 Build/MPIS24.107-55-2-17) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G3
   os_family: Android
   browser_family: Chrome
@@ -7417,19 +6691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Moto G (4) Build/MPJ24.139-49) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G4
   os_family: Android
   browser_family: Chrome
@@ -7437,19 +6709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XT1670) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5
   os_family: Android
   browser_family: Chrome
@@ -7457,19 +6727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XT1687) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5 Plus
   os_family: Android
   browser_family: Chrome
@@ -7477,19 +6745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XT1685) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5 Plus
   os_family: Android
   browser_family: Chrome
@@ -7497,19 +6763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; XT1799-2 Build/NZS26.86-108) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5s
   os_family: Android
   browser_family: Unknown
@@ -7517,19 +6781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Moto G (5S) Plus Build/NPSS26.116-61-5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5S Plus
   os_family: Android
   browser_family: Chrome
@@ -7537,19 +6799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; XT1805 Build/OPM1.171019.013) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5s Plus
   os_family: Android
   browser_family: Chrome
@@ -7557,19 +6817,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; XT1804 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5s Plus
   os_family: Android
   browser_family: Chrome
@@ -7577,19 +6835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XT1803) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G5s Plus
   os_family: Android
   browser_family: Chrome
@@ -7597,19 +6853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; XT1925-10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G6
   os_family: Android
   browser_family: Chrome
@@ -7617,19 +6871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; moto g(6)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto g6
   os_family: Android
   browser_family: Chrome
@@ -7637,19 +6889,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; moto g(6) plus Build/PPWS29.116-11-23)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G6 Plus
   os_family: Android
   browser_family: Android Browser
@@ -7657,19 +6907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; moto g(6) plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G6 Plus
   os_family: Android
   browser_family: Chrome
@@ -7677,19 +6925,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-cn; XT1965-6 Build/PCW29.27-73) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G7 Plus
   os_family: Android
   browser_family: Unknown
@@ -7697,19 +6943,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; moto g(7) power Build/QPO30.85-18)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto G7 Power
   os_family: Android
   browser_family: Android Browser
@@ -7717,19 +6961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; XT1663 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto M
   os_family: Android
   browser_family: Chrome
@@ -7737,19 +6979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; XT1049 Build/13.9.0Q2.X-178-RW-17) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7757,19 +6997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; XT1056 Build/13.11.3Q2.X-69-3-8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7777,19 +7015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; XT1060 Build/13.11.1Q2.X-69-3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.135"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7797,19 +7033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; XT1058 Build/13.11.1Q2.X-69-3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7817,19 +7051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1053 Build/KXA20.16-1.25) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7837,19 +7069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1055 Build/KXA20.16-1.27) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7857,19 +7087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XT1052 Build/KLA20.16-2.16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7877,19 +7105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XT1092 Build/MPES24.49-18-7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7897,19 +7123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XT1097 Build/MPES24.49-18-7; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X
   os_family: Android
   browser_family: Chrome
@@ -7917,19 +7141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; XT1562 Build/MPDS24.107-70-1-5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X Play
   os_family: Android
   browser_family: Chrome
@@ -7937,19 +7159,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; XT1572 Build/NPHS25.200-15-8)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X Style
   os_family: Android
   browser_family: Android Browser
@@ -7957,19 +7177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; XT1096) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto X2
   os_family: Android
   browser_family: Chrome
@@ -7977,19 +7195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; moto x4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto x4
   os_family: Android
   browser_family: Chrome
@@ -7997,19 +7213,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-CN; XT882 Build/SWDFS_M7_4.97.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.2.404 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.2.404"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto XT882
   os_family: Android
   browser_family: Unknown
@@ -8017,7 +7231,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; XT1650-05 Build/NCC25.106-15; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/6.2 TBS/043909 Mobile Safari/537.36 MicroMessenger/6.6.5.1280(0x26060536) NetType/4G Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
@@ -8026,7 +7239,7 @@
     version: "6.6.5.1280(0x26060536)"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z
   os_family: Android
   browser_family: Unknown
@@ -8034,19 +7247,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; XT1635-02 Build/MPN24.104-44)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z Play
   os_family: Android
   browser_family: Android Browser
@@ -8054,19 +7265,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; XT1635-03 Build/MCN24.104-35.2)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z Play
   os_family: Android
   browser_family: Android Browser
@@ -8074,19 +7283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; XT1789-05; Build/OCX27.138-29; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.92 Mobile Safari/537.36 SogouMSE,SogouMobileBrowser/5.6.2
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z2 Force
   os_family: Android
   browser_family: Safari
@@ -8094,19 +7301,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; en-US; XT1710-02 Build/NDSS26.118-23-11) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.4.1214 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.4.1214"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z2 Play
   os_family: Android
   browser_family: Unknown
@@ -8114,19 +7319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; Moto Z2 Play Build/OPSS27.76-12-25-7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z2 Play
   os_family: Android
   browser_family: Chrome
@@ -8134,19 +7337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; XT1710-08; Build/OCN27.59-30-4; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.92 Mobile Safari/537.36 SogouMSE,SogouMobileBrowser/5.6.3
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.6.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z2 Play
   os_family: Android
   browser_family: Safari
@@ -8154,19 +7355,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-CN; XT1929-15 Build/PCX29.10-33) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1079 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1079"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Moto Z3
   os_family: Android
   browser_family: Unknown
@@ -8174,19 +7373,17 @@
   user_agent: MOT-XT615/Mozilla/5.0 (Linux; U; Android 2.3.7; fr-ca; XT615 Build/V1.62D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motoluxe
   os_family: Android
   browser_family: Android Browser
@@ -8194,19 +7391,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; MOT-XT615 Build/V1.48C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motoluxe
   os_family: Android
   browser_family: Android Browser
@@ -8214,19 +7409,17 @@
   user_agent: 'MOT-XT685/1.0 Android/4.0.4 Release/9.15.2011 Browser/AppleWebKit534.30  Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; XT685 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motoluxe Dual-SIM
   os_family: Android
   browser_family: Android Browser
@@ -8234,19 +7427,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; XT685 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 V1_AND_SQ_4.6.1_9_YYB_D QQ/4.6.1.2110
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motoluxe Dual-SIM
   os_family: Android
   browser_family: Android Browser
@@ -8254,19 +7445,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; es-us; MotoroiX Build/IUS) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 480X854 motorola MotoroiX
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: MotoroiX
   os_family: Android
   browser_family: Android Browser
@@ -8274,19 +7463,17 @@
   user_agent: MOT-XT390/1.0 Android/2.3.6 Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; MOT-XT390 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart
   os_family: Android
   browser_family: Android Browser
@@ -8294,19 +7481,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; MOT-XT389 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart
   os_family: Android
   browser_family: Android Browser
@@ -8314,19 +7499,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; fr-fr; XT389 Build/0C.03.05R_S) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart
   os_family: Android
   browser_family: Android Browser
@@ -8334,19 +7517,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; MOT-XT303 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart ME
   os_family: Android
   browser_family: Android Browser
@@ -8354,19 +7535,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; XT303 Build/07.1F.01R_S) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart ME
   os_family: Android
   browser_family: Android Browser
@@ -8374,19 +7553,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; pt-br; MOT-XT305 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Motosmart ME
   os_family: Android
   browser_family: Android Browser
@@ -8394,19 +7571,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 10; motorola one action Build/QSBS30.121-12-4)
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: One Action
   os_family: Android
   browser_family: Android Browser
@@ -8414,19 +7589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; XT1970-5 Build/PCA29.31-52; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: One Vision
   os_family: Android
   browser_family: Chrome
@@ -8434,19 +7607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; motorola one zoom) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: One Zoom
   os_family: Android
   browser_family: Chrome
@@ -8454,19 +7625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; XT1943-1 Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: P30
   os_family: Android
   browser_family: Chrome
@@ -8474,19 +7643,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; zh-cn; XT1942-1 Build/OCT28.67-54) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/10.3 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "10.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: P30 Note
   os_family: Android
   browser_family: Unknown
@@ -8494,19 +7661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; XT1941-2 Build/OCK28.47-32; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: P30 Play
   os_family: Android
   browser_family: Chrome
@@ -8514,7 +7679,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; XT897 Build/9.8.2Q-122_XT897_FFW-5) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ARM
   client:
@@ -8523,7 +7687,7 @@
     version: "3.3.11.1069658"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Photon Q
   os_family: Android
   browser_family: Unknown
@@ -8531,19 +7695,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; es-us; XT621 Build/5.5.1Q_PRIMUS_MR-217) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Primus
   os_family: Android
   browser_family: Android Browser
@@ -8551,19 +7713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; fr-fr; Motorola-XT502 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Quench
   os_family: Android
   browser_family: Android Browser
@@ -8571,19 +7731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; zh-cn; XT300 Build/SESGC_U3_00.35.0) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: smartphone
-    brand: MR
+    brand: Motorola
     model: Spice
   os_family: Android
   browser_family: Android Browser
@@ -8591,19 +7749,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 1320) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 1320
   os_family: Windows
   browser_family: Internet Explorer
@@ -8611,19 +7767,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; NOKIA; RM-994_eu_poland_1155) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 1320
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8631,19 +7785,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; NOKIA; Lumia 1320) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 1320
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8651,19 +7803,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; ARM; Touch; WPDesktop; Lumia 1530)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 1530
   os_family: Windows
   browser_family: Internet Explorer
@@ -8671,19 +7821,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 430 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 430
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8691,19 +7839,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; en-IN; Microsoft; RM-1099_1005) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 430
   os_family: Windows Mobile
   browser_family: Unknown
@@ -8711,13 +7857,12 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0.13333.0; U; pt-BR; Microsoft RM-1114_1000)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0.13333.0"
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 435
   os_family: Windows Mobile
   browser_family: Unknown
@@ -8725,19 +7870,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 7.0; Windows Phone OS 7.0; Trident/3.1; IEMobile/7.0; Microsoft; Lumia 435 Dual SIM)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "7.0"
     engine: Trident
     engine_version: "3.1"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 435
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8745,19 +7888,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; Lumia 435) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 435
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8765,19 +7906,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone OS 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; Microsoft; RM-1031_1010)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 532
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8785,19 +7924,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 535) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10512
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "12.10512"
     engine: Edge
     engine_version: "12.10512"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 535
   os_family: Windows
   browser_family: Internet Explorer
@@ -8805,19 +7942,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone 8.1; Trident/6.0; IEMobile/10.0; ARM; Touch; Microsoft; RM-1092_1002)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 535
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8825,19 +7960,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1089_1087) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 535
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8845,19 +7978,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1090) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 535
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8865,19 +7996,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; Lumia 535) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 535
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8885,19 +8014,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1141) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 540
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8905,19 +8032,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; Lumia 540 Dual SIM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Mobile Safari/537.36 Edge/14.14393
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "14.14393"
     engine: Edge
     engine_version: "14.14393"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 540
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8925,19 +8050,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 550) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 550
   os_family: Windows
   browser_family: Internet Explorer
@@ -8945,19 +8068,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows Phone OS 8.0; Trident/6.0; IEMobile/10.0; ARM; Touch; Microsoft; RM-1127_15119)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.0"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 550
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8965,19 +8086,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; NOKIA; RM-1010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Mobile Safari/537.36 Edge/14.14393
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "14.14393"
     engine: Edge
     engine_version: "14.14393"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 638
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -8985,19 +8104,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 640 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.135 Safari/537.36 Edge/12.10536
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "12.10536"
     engine: Edge
     engine_version: "12.10536"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows
   browser_family: Internet Explorer
@@ -9005,19 +8122,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 640 LTE Dual SIM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows
   browser_family: Internet Explorer
@@ -9025,19 +8140,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 640 Dual SIM) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9045,19 +8158,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; Lumia 640 LTE) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9065,19 +8176,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1072) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9085,19 +8194,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1073) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9105,19 +8212,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1074) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9125,19 +8230,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1076) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9145,19 +8248,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1077) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9165,19 +8266,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; Microsoft; RM-1113) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9185,19 +8284,17 @@
   user_agent: UCWEB/2.0 (Windows; U; wds 8.10; de-DE; Microsoft; RM-1077_1011) U2/1.0.0 UCBrowser/4.2.1.541 U2/1.0.0 Mobile
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "4.2.1.541"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Unknown
@@ -9205,19 +8302,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; Lumia 640 Dual SIM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9225,13 +8320,12 @@
   user_agent: Mozilla/5.0 (Windows Phone 8.10.15148.0; U; pt-BR; Microsoft RM-1109_1002)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.10.15148.0"
     platform: ""
   client: null
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Unknown
@@ -9239,19 +8333,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; Lumia 640 Dual SIM) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9259,19 +8351,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.2; ARM; Trident/7.0; Touch; rv:11.0; WPDesktop; Lumia 640 LTE) like Gecko
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 640
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9279,19 +8369,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; ARM; Lumia 650) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Safari/537.36 Edge/13.10586
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ARM
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 650
   os_family: Windows
   browser_family: Internet Explorer
@@ -9299,19 +8387,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 4.2.1; Microsoft; RM-1154) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2486.0 Mobile Safari/537.36 Edge/13.10586
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "13.10586"
     engine: Edge
     engine_version: "13.10586"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 650
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9319,19 +8405,17 @@
   user_agent: Mozilla/5.0 (Windows Phone 10.0; Android 6.0.1; Microsoft; RM-1152) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 Mobile Safari/537.36 Edge/15.15254
   os:
     name: Windows Phone
-    short_name: WPH
     version: "10.0"
     platform: ""
   client:
     type: browser
     name: Microsoft Edge
-    short_name: PS
     version: "15.15254"
     engine: Edge
     engine_version: "15.15254"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 650 SS
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9339,19 +8423,17 @@
   user_agent: Mozilla/5.0 (MSIE 9.0; Windows Phone OS 7.5; Trident/5.0; IEMobile/9.0; Nokia; Lumia 850)
   os:
     name: Windows Phone
-    short_name: WPH
     version: "7.5"
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
   device:
     type: smartphone
-    brand: MS
+    brand: Microsoft
     model: Lumia 850
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -9359,19 +8441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MOVIC W2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MV
+    brand: Movic
     model: W2
   os_family: Android
   browser_family: Chrome
@@ -9379,19 +8459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MOVIC-W3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MV
+    brand: Movic
     model: W3
   os_family: Android
   browser_family: Chrome
@@ -9399,19 +8477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MOVIC-W4 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MV
+    brand: Movic
     model: W4
   os_family: Android
   browser_family: Chrome
@@ -9419,19 +8495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MOVIC-W5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MV
+    brand: Movic
     model: W5
   os_family: Android
   browser_family: Chrome
@@ -9439,19 +8513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Astro_5N_LTE Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MW
+    brand: Maxwest
     model: Astro 5N LTE
   os_family: Android
   browser_family: Chrome
@@ -9459,19 +8531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Astro X55s) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MW
+    brand: Maxwest
     model: Astro X55s
   os_family: Android
   browser_family: Chrome
@@ -9479,19 +8549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Nitro_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MW
+    brand: Maxwest
     model: Nitro 4
   os_family: Android
   browser_family: Chrome
@@ -9499,19 +8567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Virtue Z5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MW
+    brand: Maxwest
     model: Virtue Z5
   os_family: Android
   browser_family: Chrome
@@ -9519,19 +8585,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MEU AN400 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: MX
+    brand: MEU
     model: AN400
   os_family: Android
   browser_family: Android Browser
@@ -9539,19 +8603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MEU AN500 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MX
+    brand: MEU
     model: AN500
   os_family: Android
   browser_family: Chrome
@@ -9559,19 +8621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MyPhone a888 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: a888
   os_family: Android
   browser_family: Chrome
@@ -9579,19 +8639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MyPhone A919 Duo Build/IMM76D) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Mobile Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "25.0.1364.169"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: A919 Duo
   os_family: Android
   browser_family: Chrome
@@ -9599,19 +8657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; myPhone_AXE_LTE Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: AXE LTE
   os_family: Android
   browser_family: Chrome
@@ -9619,19 +8675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; myPhone_C-Smart_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: C-Smart 4
   os_family: Android
   browser_family: Chrome
@@ -9639,19 +8693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; C-Smart_pix Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: C-Smart Pix
   os_family: Android
   browser_family: Chrome
@@ -9659,19 +8711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; myPhone CityXL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: CityXL
   os_family: Android
   browser_family: Chrome
@@ -9679,19 +8729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; myPhone Cube Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Cube
   os_family: Android
   browser_family: Chrome
@@ -9699,19 +8747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CUBE_LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Cube LTE
   os_family: Android
   browser_family: Chrome
@@ -9719,19 +8765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; myPhone_Fun_8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: FUN 8
   os_family: Android
   browser_family: Chrome
@@ -9739,19 +8783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; myPhone Fun LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Fun LTE
   os_family: Android
   browser_family: Chrome
@@ -9759,19 +8801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hammer Active) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Active
   os_family: Android
   browser_family: Chrome
@@ -9779,19 +8819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hammer_Active2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Active 2
   os_family: Android
   browser_family: Chrome
@@ -9799,19 +8837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hammer_Active2_LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Active 2 LTE
   os_family: Android
   browser_family: Chrome
@@ -9819,19 +8855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HAMMER_AXE_M_LTE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Axe M LTE
   os_family: Android
   browser_family: Chrome
@@ -9839,19 +8873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hammer AXE Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Axe Pro
   os_family: Android
   browser_family: Chrome
@@ -9859,19 +8891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hammer_Blade2_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Blade 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -9879,19 +8909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HAMMER ENERGY Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Energy
   os_family: Android
   browser_family: Chrome
@@ -9899,19 +8927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hammer Iron 2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Iron
-    short_name: IR
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: MY
+    brand: MyPhone
     model: Hammer Iron 2
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -3,13 +3,11 @@
   user_agent: Mozilla/5.0 (Android; Mobile; rv:22.0) Gecko/22.0 Firefox/22.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "22.0"
     engine: Gecko
     engine_version: "22.0"
@@ -23,13 +21,11 @@
   user_agent: Mozilla/5.0 (Android; Mobile; rv:26.0) Gecko/26.0 Firefox/26.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -43,13 +39,11 @@
   user_agent: Mozilla/5.0 (Android; Mobile; rv:37.0) Servo/1.0 Firefox/37.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "37.0"
     engine: Servo
     engine_version: "1.0"
@@ -63,13 +57,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 0.5; en-us) AppleWebKit/522+ (KHTML, like Gecko) Safari/419.3
   os:
     name: Android
-    short_name: AND
     version: "0.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "522"
@@ -83,13 +75,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; S57 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
@@ -103,13 +93,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; General Mobile 4G Build/LUZ59K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
@@ -123,13 +111,11 @@
   user_agent: QwantMobile/2.0 (Android 6.0; Mobile; rv:61.0) Gecko/61.0 Firefox/59.0 QwantBrowser/61.0
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "2.0"
     engine: Gecko
     engine_version: "61.0"
@@ -143,13 +129,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Web Explorer/2.6.1 Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Web Explorer
-    short_name: WP
     version: "2.6.1"
     engine: Webkit
     engine_version: "537.36"
@@ -163,13 +147,11 @@
   user_agent: Mozilla/5.0 (Android 7.0; Mobile; rv:52.0) Gecko/52.0 Mobicip/2.3.1_r747
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Mobicip
-    short_name: MO
     version: ""
     engine: Gecko
     engine_version: "52.0"
@@ -183,13 +165,11 @@
   user_agent: Mozilla/5.0 (Android 7.1.2; Mobile; rv:52.6.0) Gecko/52.6.0 IceCat/52.6.0
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: IceCat
-    short_name: I4
     version: "52.6.0"
     engine: Gecko
     engine_version: "52.6.0"
@@ -203,13 +183,11 @@
   user_agent: Qwant/2.5 (Android 8.1.0; Mobile; rv:63.0) Gecko/63.0 Firefox/59.0 QwantBrowser/63.0.1
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Qwant Mobile
-    short_name: QM
     version: "2.5"
     engine: Gecko
     engine_version: "63.0"
@@ -223,13 +201,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 9) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Mobile Safari/537.36 DuckDuckGo/5
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: DuckDuckGo Privacy Browser
-    short_name: DD
     version: "5"
     engine: Blink
     engine_version: ""
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ACCENT_NEON) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "00"
+    brand: Accent
     model: Neon
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; meanIT_C1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: C1
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; meanIT_C2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: C2
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; meanIT MG430) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: MG430
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; meanIT Q1 plus Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: Q1 Plus
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; meanIT Q4; Android/4.4.2; Release/08.06.2015) AppleWebKit/534.30 (KHTML, like Gecko) Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: Q4
   os_family: Android
   browser_family: Android Browser
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; meanIT Q5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: Q5
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; meanIT_X1 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: X1
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; meanIT_X2 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; meanIT_X6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: "09"
+    brand: meanIT
     model: X6
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; iris708 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0A
+    brand: AIS
     model: LAVA PRO 4.5
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Techno X595BT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0B
+    brand: BB Mobile
     model: Techno Spark 3G X595BT
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Maxvi_MS401) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0D
+    brand: MAXVI
     model: MS401
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MELROSE_2019 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0E
+    brand: Melrose
     model: 2019 Ultra Slim 3.4"
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MELROSE_S9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0E
+    brand: Melrose
     model: S9
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iTRUCK 7 3G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0I
+    brand: iTruck
     model: 7.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KL-V905 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0K
+    brand: Klipad
     model: KL-V905
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lumigon_T3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0L
+    brand: Lumigon
     model: T3
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Newman K1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0N
+    brand: Newman
     model: K1
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Newman P308 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0N
+    brand: Newman
     model: P308
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; POCO F2 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0P
+    brand: POCO
     model: F2 Pro
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; POCO X2 Build/QKQ1.190825.002; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0P
+    brand: POCO
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GO3C Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0S
+    brand: SEMP TCL
     model: GO! 3C
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; GO3C Plus Build/OPM2.171019.012)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 0S
+    brand: SEMP TCL
     model: GO! 3C Plus
   os_family: Android
   browser_family: Android Browser
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GO3E Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0S
+    brand: SEMP TCL
     model: GO3E
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; GO5E Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0S
+    brand: SEMP TCL
     model: GO5E
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; 5101J Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0S
+    brand: SEMP TCL
     model: L9 Plus
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TONE e19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0T
+    brand: Tone
     model: e19
   os_family: Android
   browser_family: Chrome
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TONE m15 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0T
+    brand: Tone
     model: m15
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIPRO PRO 1 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0V
+    brand: Vipro
     model: Pro 1
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIPRO PRO2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0V
+    brand: Vipro
     model: Pro 2
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIPRO PRO2X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0V
+    brand: Vipro
     model: Pro 2X
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VIPRO PRO 3 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0V
+    brand: Vipro
     model: Pro 3
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1;Elite Sense Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 0W
+    brand: Swipe
     model: Elite Sense
   os_family: Android
   browser_family: Chrome
@@ -923,39 +831,35 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Alba 57) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1A
-    model: 5.7
+    brand: Alba
+    model: "5.7"
   os_family: Android
   browser_family: Chrome
 - 
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Capture+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1B
+    brand: Billion
     model: Capture Plus
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ETL-S3520    Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 1E
+    brand: Etuline
     model: ETL-S3520
   os_family: Android
   browser_family: Android Browser
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ETL-S4521 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: smartphone
-    brand: 1E
+    brand: Etuline
     model: ETL-S4521
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ETL-S5042 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1E
+    brand: Etuline
     model: ETL-S5042
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ETL-S5084) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1E
+    brand: Etuline
     model: ETL-S5084
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ETL-S6022 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 OPR/36.2.2254.130496
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "36.2.2254.130496"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1E
+    brand: Etuline
     model: ETL-S6022
   os_family: Android
   browser_family: Opera
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; IMARS VEGA X7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1I
+    brand: iMars
     model: Vega X7
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ureki_U1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1K
+    brand: Kzen
     model: Ureki U1
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LOGIC_L5D Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: L5D
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; LOGIC X1 Build/JDQ39) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X1
   os_family: Android
   browser_family: Android Browser
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Logic X3 Build/Logic_X3-V1.0_2014.08.09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X3
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LOGIC X4M Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X4M
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LOGIC X4M LITE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X4M Lite
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; LOGIC_X5_LITE Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X5 Lite
   os_family: Android
   browser_family: Android Browser
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LOGIC X5 LITE2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X5 Lite 2
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LOGIC X5A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X5A
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; LOGIC X5F Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X5F
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; LOGIC_X5T Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X5T
   os_family: Android
   browser_family: Chrome
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; LOGIC_X60G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1L
+    brand: Logic
     model: X60G
   os_family: Android
   browser_family: Chrome
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Neo906) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1N
+    brand: Neomi
     model: Neo 906
   os_family: Android
   browser_family: Chrome
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Neo908) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1N
+    brand: Neomi
     model: Neo 908
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NEO 909) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1N
+    brand: Neomi
     model: Neo 909
   os_family: Android
   browser_family: Chrome
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHICOMM CLUE 2S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1P
+    brand: Phicomm
     model: Clue 2S
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PHICOMM C630 (CLUE L)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1P
+    brand: Phicomm
     model: Clue L
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; PHICOMM CLUE M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1P
+    brand: Phicomm
     model: Clue M
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHICOMM ENERGY 3+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1P
+    brand: Phicomm
     model: Energy 3+
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PHICOMM E653(ENERGY L)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3983.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3983.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1P
+    brand: Phicomm
     model: Energy L
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Multilaser_E Build/V7_20200305)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: E
   os_family: Android
   browser_family: Android Browser
@@ -1503,19 +1353,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Multilaser_E_Lite Build/V6_20200415)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: E Lite
   os_family: Android
   browser_family: Android Browser
@@ -1523,19 +1371,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Multilaser_F Build/V7_20191029)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: F
   os_family: Android
   browser_family: Android Browser
@@ -1543,19 +1389,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Multilaser_G Build/V8_20190904)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: G
   os_family: Android
   browser_family: Android Browser
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Multilaser_G_Max Build/V9_20191024; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: G Max
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Multilaser_G_Pro Build/V9_20200420; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: G Pro
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; Multilaser H Build/V16_20200107)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: H
   os_family: Android
   browser_family: Android Browser
@@ -1623,19 +1461,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; MS40G Build/V18_20200423)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS40G
   os_family: Android
   browser_family: Android Browser
@@ -1643,19 +1479,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; MS40S Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS40S
   os_family: Android
   browser_family: Android Browser
@@ -1663,19 +1497,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MS45S Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS45S
   os_family: Android
   browser_family: Android Browser
@@ -1683,19 +1515,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; MS45S_A6 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS45S A6
   os_family: Android
   browser_family: Android Browser
@@ -1703,19 +1533,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MS5.V2 Build/MS5.V2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS5.V2
   os_family: Android
   browser_family: Android Browser
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MS50G Build/V20_20200506; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS50G
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; MS50L Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS50L
   os_family: Android
   browser_family: Android Browser
@@ -1763,19 +1587,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; MS50S Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS50S
   os_family: Android
   browser_family: Android Browser
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MS50X Build/V11_20190306; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS50X
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; MS55M Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS55M
   os_family: Android
   browser_family: Android Browser
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MS60X Build/V7_20190117; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS60X
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MS60Z Build/V6_20190219; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS60Z
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; MS70 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS70
   os_family: Android
   browser_family: Android Browser
@@ -1883,19 +1695,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; MS80X Build/V6_20181109)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1R
+    brand: Multilaser
     model: MS80X
   os_family: Android
   browser_family: Android Browser
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; X-Style_S5501 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/44.1.2254.142553
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.142553"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Style S5501
   os_family: Android
   browser_family: Opera
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; X-Treme PQ11 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ11
   os_family: Android
   browser_family: Android Browser
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-tremePQ16 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ16
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ua; X-tremePQ22 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ22
   os_family: Android
   browser_family: Android Browser
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-Treme PQ23 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ23
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-treme_PQ24 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ24
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Sigma mobile Xtreme PQ25 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ25
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-treme_PQ26 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ26
   os_family: Android
   browser_family: Chrome
@@ -2063,19 +1857,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; X_treme_PQ27 Build/LMY47V
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ27
   os_family: Android
   browser_family: Android Browser
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; Sigma_Xtreme_PQ27 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36 OPR/44.1.2254.142088
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.142088"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ27
   os_family: Android
   browser_family: Opera
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X-treme_PQ28 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.86 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ28
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; X-treme_PQ29 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ29
   os_family: Android
   browser_family: Android Browser
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; X-treme-PQ30 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ30
   os_family: Android
   browser_family: Chrome
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-treme_PQ31 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ31
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X_treme_PQ34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ34
   os_family: Android
   browser_family: Chrome
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X-tremePQ35 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ35
   os_family: Android
   browser_family: Chrome
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; X-Treme PQ39 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.0.1187 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.0.1187"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ39
   os_family: Android
   browser_family: Unknown
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X_treme_PQ52) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ52
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; X-Treme PQ53 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ53
   os_family: Android
   browser_family: Android Browser
@@ -2283,19 +2055,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 8.1.0; X-treme_PQ54 Build/O11019
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 1S
+    brand: Sigma
     model: X-Treme PQ54
   os_family: Android
   browser_family: Android Browser
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TurboX_Ray) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X Ray
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Turbo_X5_Black Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X5 Black
   os_family: Android
   browser_family: Chrome
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TurboX5Black) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X5 Black
   os_family: Android
   browser_family: Chrome
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TurboX5Hero) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X5 Hero
   os_family: Android
   browser_family: Chrome
@@ -2383,19 +2145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Turbo_X5_Max Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X5 Max
   os_family: Android
   browser_family: Unknown
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TurboX5Space Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X5 Space
   os_family: Android
   browser_family: Chrome
@@ -2423,19 +2181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Turbo X6 Z Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X6 Z
   os_family: Android
   browser_family: Chrome
@@ -2443,19 +2199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Turbo_X8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 1T
+    brand: Turbo
     model: X8
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; GHONGV10 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2C
+    brand: Ghong
     model: V10
   os_family: Android
   browser_family: Chrome
@@ -2483,19 +2235,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Tele2_Maxi Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Maxi
   os_family: Android
   browser_family: Unknown
@@ -2503,19 +2253,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Tele2_Maxi_LTE Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Maxi LTE
   os_family: Android
   browser_family: Unknown
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Tele2_Maxi_Plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.0.1288 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.0.1288"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Maxi Plus
   os_family: Android
   browser_family: Unknown
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; en-US; Tele2 Midi Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.9.1201 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.9.1201"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Midi
   os_family: Android
   browser_family: Unknown
@@ -2563,19 +2307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Tele2 Midi 1.1 Build/MOB31K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Midi 1.1
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tele2_Midi_2_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Midi 2.0
   os_family: Android
   browser_family: Chrome
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tele2_Mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Mini
   os_family: Android
   browser_family: Chrome
@@ -2623,19 +2361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0 Tele2_Mini_1_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Mini 1.1
   os_family: Android
   browser_family: Chrome
@@ -2643,19 +2379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Tele2 Mini 1.1 Build/MOB31K; ru-ru) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36 Puffin/7.8.1.40497AP
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.1.40497"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2L
+    brand: Tele2
     model: Mini 1.1
   os_family: Android
   browser_family: Unknown
@@ -2663,19 +2397,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; Masstel_Juno_Q3 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: Juno Q3
   os_family: Android
   browser_family: Chrome
@@ -2683,19 +2415,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; vi-vn; Masstel M05 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M05
   os_family: Android
   browser_family: Android Browser
@@ -2703,19 +2433,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; vi; Masstel M11 Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.8.0.435 U3/0.8.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.0.435"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M11
   os_family: Android
   browser_family: Unknown
@@ -2723,19 +2451,17 @@
   user_agent: Dalvik/1.4.0 (Linux; U; Android 4.0; Masstel M12 Build/GRK39F)
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M12
   os_family: Android
   browser_family: Android Browser
@@ -2743,19 +2469,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 2.3.5; vi; Masstel_M120) U2/1.0.0 UCBrowser/9.8.0.534 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.0.534"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M120
   os_family: Android
   browser_family: Unknown
@@ -2763,19 +2487,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; vi-vn; Masstel M15 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M15
   os_family: Android
   browser_family: Android Browser
@@ -2783,19 +2505,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android MASSTEL 4.0; vi-vn; MASSTEL (M18) Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M18
   os_family: Android
   browser_family: Android Browser
@@ -2803,19 +2523,17 @@
   user_agent: Dalvik/1.4.0 (Linux; U; Android 2.3.5; Masstel M190 Build/MocorDroid2.3.5)
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M190
   os_family: Android
   browser_family: Android Browser
@@ -2823,19 +2541,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; vi-vn; Masstel M250 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: M250
   os_family: Android
   browser_family: Android Browser
@@ -2843,19 +2559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Masstel N450 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N450
   os_family: Android
   browser_family: Chrome
@@ -2863,19 +2577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Masstel_N460 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N460
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Masstel N520 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N520
   os_family: Android
   browser_family: Chrome
@@ -2903,19 +2613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Masstel N536 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N536
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Masstel N540 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.73 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N540
   os_family: Android
   browser_family: Chrome
@@ -2943,19 +2649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.3; Masstel N550 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N550
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2667,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; ru-ru; Masstel N580 Build/MRA58K) AppleWebkit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: N580
   os_family: Android
   browser_family: Android Browser
@@ -2983,19 +2685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Masstel_X9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2M
+    brand: Masstel
     model: X9
   os_family: Android
   browser_family: Chrome
@@ -3003,19 +2703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NOMU S30mini Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Mobile Safari/537.36 AlohaBrowser/2.9.0.2
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Aloha Browser
-    short_name: AL
     version: "2.9.0.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 2N
+    brand: Nomu
     model: S30 Mini
   os_family: Android
   browser_family: Unknown
@@ -3023,19 +2721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NOMU_T18) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2N
+    brand: Nomu
     model: T18
   os_family: Android
   browser_family: Chrome
@@ -3043,19 +2739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tinai K1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 2T
+    brand: Tinai
     model: K1
   os_family: Android
   browser_family: Chrome
@@ -3063,19 +2757,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; Tinai K2 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 2T
+    brand: Tinai
     model: K2
   os_family: Android
   browser_family: Android Browser
@@ -3083,19 +2775,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; iCherry C110 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C110
   os_family: Android
   browser_family: Android Browser
@@ -3103,19 +2793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iCherry C121 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C121
   os_family: Android
   browser_family: Chrome
@@ -3123,19 +2811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C211 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C211
   os_family: Android
   browser_family: Chrome
@@ -3143,19 +2829,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; iCherry C216 Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C216
   os_family: Android
   browser_family: Android Browser
@@ -3163,19 +2847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C220 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C220
   os_family: Android
   browser_family: Chrome
@@ -3183,19 +2865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry_C227 Build/iCherry_C227; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C227
   os_family: Android
   browser_family: Chrome
@@ -3203,19 +2883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C229 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C229
   os_family: Android
   browser_family: Chrome
@@ -3223,19 +2901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C230 Build/iCherry_C230) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C230
   os_family: Android
   browser_family: Chrome
@@ -3243,19 +2919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C233 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C233
   os_family: Android
   browser_family: Chrome
@@ -3263,19 +2937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C251) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C251
   os_family: Android
   browser_family: Chrome
@@ -3283,19 +2955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C252 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C252
   os_family: Android
   browser_family: Chrome
@@ -3303,19 +2973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iCherry C255 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3I
+    brand: i-Cherry
     model: C255
   os_family: Android
   browser_family: Chrome
@@ -3323,19 +2991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Meitu2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: "2"
   os_family: Android
   browser_family: Chrome
@@ -3343,19 +3009,17 @@
   user_agent: Android 4.2.1;Build/JOP40D;Meitu Kiss Build/JOP40D
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: Kiss
   os_family: Android
   browser_family: Android Browser
@@ -3363,19 +3027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Meitu M4 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 Browser
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M4
   os_family: Android
   browser_family: Chrome
@@ -3383,19 +3045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MP1503 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M6
   os_family: Android
   browser_family: Chrome
@@ -3403,19 +3063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MP1512 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36 OPR/48.0.2331.132663
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "48.0.2331.132663"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M6s
   os_family: Android
   browser_family: Opera
@@ -3423,19 +3081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MP1603 Build/NMF26O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M8
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MP1711 Build/NMF26O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M8s
   os_family: Android
   browser_family: Chrome
@@ -3463,19 +3117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MP1709 Build/NMF26O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.126 MQQBrowser/6.2 TBS/039308 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: M8s
   os_family: Android
   browser_family: Unknown
@@ -3483,19 +3135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MP1602 Build/NMF26O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: T8
   os_family: Android
   browser_family: Chrome
@@ -3503,19 +3153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; MP1713 Build/NMF26O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: T8s
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3171,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.1; zh-CN; MP1701 Build/NMF26O) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.6.1.1041 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.6.1.1041"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: T8s
   os_family: Android
   browser_family: Unknown
@@ -3543,19 +3189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MP1718 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: T9
   os_family: Android
   browser_family: Chrome
@@ -3563,19 +3207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Meitu V4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: V4
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MP1605 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3M
+    brand: Meitu
     model: V6
   os_family: Android
   browser_family: Chrome
@@ -3603,19 +3243,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; Positivo Mini I Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Mini I
   os_family: Android
   browser_family: Android Browser
@@ -3623,19 +3261,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0.2; S455 Build/LRX22G)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Selfie
   os_family: Android
   browser_family: Android Browser
@@ -3643,19 +3279,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; Twist (2018) Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist (2018)
   os_family: Android
   browser_family: Android Browser
@@ -3663,19 +3297,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Twist 2 Build/OPM2.171019.012)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist 2
   os_family: Android
   browser_family: Android Browser
@@ -3683,19 +3315,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Twist 2 Fit Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist 2 Fit
   os_family: Android
   browser_family: Android Browser
@@ -3703,19 +3333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Twist 2 Pro Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist 2 Pro
   os_family: Android
   browser_family: Chrome
@@ -3723,19 +3351,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Twist 3 Build/OPM2.171019.012
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist 3
   os_family: Android
   browser_family: Android Browser
@@ -3743,19 +3369,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Positivo Twist M Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist M
   os_family: Android
   browser_family: Android Browser
@@ -3763,19 +3387,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; Twist Max Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Max
   os_family: Android
   browser_family: Android Browser
@@ -3783,19 +3405,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; Twist Metal Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Metal
   os_family: Android
   browser_family: Android Browser
@@ -3803,19 +3423,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Twist Metal 32GB Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Metal 32GB
   os_family: Android
   browser_family: Android Browser
@@ -3823,19 +3441,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; Twist_Mini Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Mini
   os_family: Android
   browser_family: Android Browser
@@ -3843,19 +3459,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; Twist Mini Build/O11019)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Mini
   os_family: Android
   browser_family: Android Browser
@@ -3863,19 +3477,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U;Android 6.0; Positivo Twist S Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist S
   os_family: Android
   browser_family: Android Browser
@@ -3883,19 +3495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Twist SE Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist SE
   os_family: Android
   browser_family: Chrome
@@ -3903,19 +3513,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; Twist XL Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 3P
+    brand: Positivo BGH
     model: Twist XL
   os_family: Android
   browser_family: Android Browser
@@ -3923,19 +3531,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZYVV1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 3V
+    brand: VVETIME
     model: V1
   os_family: Android
   browser_family: Chrome
@@ -3943,19 +3549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ALIGATOR RX510) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: RX510
   os_family: Android
   browser_family: Chrome
@@ -3963,19 +3567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALIGATOR S4080) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S4080
   os_family: Android
   browser_family: Chrome
@@ -3983,19 +3585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALIGATOR S5060 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S5060
   os_family: Android
   browser_family: Chrome
@@ -4003,19 +3603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ALIGATOR S5065) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S5065
   os_family: Android
   browser_family: Chrome
@@ -4023,19 +3621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Aligator_S5066 Build/O11019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S5066
   os_family: Android
   browser_family: Chrome
@@ -4043,19 +3639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ALIGATOR S5070) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S5070
   os_family: Android
   browser_family: Chrome
@@ -4063,19 +3657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ALIGATOR S5080 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4A
+    brand: Aligator
     model: S5080
   os_family: Android
   browser_family: Chrome
@@ -4083,19 +3675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 4Good Light A103 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: Light A103
   os_family: Android
   browser_family: Chrome
@@ -4103,19 +3693,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; Light B100 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: Light B100
   os_family: Android
   browser_family: Opera
@@ -4123,19 +3711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4Good S555m 4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 YaBrowser/16.2.1.7529.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.2.1.7529.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: People
   os_family: Android
   browser_family: Unknown
@@ -4143,19 +3729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; People G410) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: People G410
   os_family: Android
   browser_family: Chrome
@@ -4163,19 +3747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; People G503) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: People G503
   os_family: Android
   browser_family: Chrome
@@ -4183,19 +3765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; 4Good S450m 4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: S450m 4G
   os_family: Android
   browser_family: Chrome
@@ -4203,19 +3783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; S501m 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4G
+    brand: 4Good
     model: S501m 3G
   os_family: Android
   browser_family: Chrome
@@ -4223,19 +3801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Matrix Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4M
+    brand: Mobicel
     model: Matrix
   os_family: Android
   browser_family: Chrome
@@ -4243,19 +3819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Mobicel_R1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4M
+    brand: Mobicel
     model: R1
   os_family: Android
   browser_family: Chrome
@@ -4263,19 +3837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PCS01 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 4P
+    brand: Philco
     model: PCS01
   os_family: Android
   browser_family: Chrome
@@ -4283,19 +3855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TSD Octa A0520P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5A
+    brand: ArmPhone
     model: TSD Octa A0520P
   os_family: Android
   browser_family: Chrome
@@ -4303,19 +3873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TSD Quadra A0509P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5A
+    brand: ArmPhone
     model: TSD Quadra A0509P
   os_family: Android
   browser_family: Chrome
@@ -4323,19 +3891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 2E E450 2018) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5E
+    brand: 2E
     model: E450 (2018)
   os_family: Android
   browser_family: Chrome
@@ -4343,19 +3909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; E500A_2019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4021.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4021.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5E
+    brand: 2E
     model: E500A (2019)
   os_family: Android
   browser_family: Chrome
@@ -4363,19 +3927,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.3; ZUG 3 Build/JLS36C)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 5M
+    brand: Mann
     model: ZUG 3
   os_family: Android
   browser_family: Android Browser
@@ -4383,19 +3945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZUG 5S Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.2.339.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.2.339.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5M
+    brand: Mann
     model: ZUG 5S
   os_family: Android
   browser_family: Unknown
@@ -4403,19 +3963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ZUG 5S Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5M
+    brand: Mann
     model: ZUG 5S Q
   os_family: Android
   browser_family: Chrome
@@ -4423,19 +3981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOS FIVE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Five
   os_family: Android
   browser_family: Chrome
@@ -4443,19 +3999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; NOS NEVA 80) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36 OPR/57.1.2830.52480
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "57.1.2830.52480"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Neva 80
   os_family: Android
   browser_family: Opera
@@ -4463,19 +4017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NOS NOVU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Novu
   os_family: Android
   browser_family: Chrome
@@ -4483,19 +4035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NOS NOVU II) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Novu II
   os_family: Android
   browser_family: Chrome
@@ -4503,19 +4053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NOS NOVU III) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Novu III
   os_family: Android
   browser_family: Chrome
@@ -4523,19 +4071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NOS Roya Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5N
+    brand: Nos
     model: Roya
   os_family: Android
   browser_family: Chrome
@@ -4543,19 +4089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHONEMAX_Mars) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5P
+    brand: Phonemax
     model: Mars
   os_family: Android
   browser_family: Chrome
@@ -4563,19 +4107,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; PHONEMAX_Saturn Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 5P
+    brand: Phonemax
     model: Saturn
   os_family: Android
   browser_family: Android Browser
@@ -4583,19 +4125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHONEMAX_Saturn_X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 5P
+    brand: Phonemax
     model: Saturn X
   os_family: Android
   browser_family: Chrome
@@ -4603,19 +4143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; QS5509A Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6A
+    brand: 'AT&T'
     model: Axia
   os_family: Android
   browser_family: Chrome
@@ -4623,19 +4161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; U304AA Build/P00610; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6A
+    brand: 'AT&T'
     model: Radiant Core
   os_family: Android
   browser_family: Chrome
@@ -4643,19 +4179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PrimuxDelta6 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.62 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6P
+    brand: Primux
     model: Delta 6
   os_family: Android
   browser_family: Chrome
@@ -4663,19 +4197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CARBONO_5 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6S
+    brand: Spectrum
     model: Carbono 5.0"
   os_family: Android
   browser_family: Chrome
@@ -4683,19 +4215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CUARZO_6 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6S
+    brand: Spectrum
     model: Cuarzo 6.0"
   os_family: Android
   browser_family: Chrome
@@ -4703,19 +4233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; DIAMANTE_5 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6S
+    brand: Spectrum
     model: Diamante 5.0"
   os_family: Android
   browser_family: Chrome
@@ -4723,19 +4251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VULCANO_55 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6S
+    brand: Spectrum
     model: Vulcano 5.5"
   os_family: Android
   browser_family: Chrome
@@ -4743,19 +4269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TWOE E450R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6T
+    brand: Twoe
     model: E450R
   os_family: Android
   browser_family: Chrome
@@ -4763,19 +4287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MAXTRON S8 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 6X
+    brand: Maxtron
     model: S8
   os_family: Android
   browser_family: Chrome
@@ -4783,19 +4305,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MAXTRON_V2 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 6X
+    brand: Maxtron
     model: V2
   os_family: Android
   browser_family: Android Browser
@@ -4803,19 +4323,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MAXTRON_V3 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 6X
+    brand: Maxtron
     model: V3
   os_family: Android
   browser_family: Android Browser
@@ -4823,19 +4341,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; id; MAXTRON-V7) U2/1.0.0 UCBrowser/10.6.8.732 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.8.732"
     engine: ""
     engine_version: ""
   device:
     type: smartphone
-    brand: 6X
+    brand: Maxtron
     model: V7
   os_family: Android
   browser_family: Unknown
@@ -4843,19 +4359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IBRIT_I5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: I5
   os_family: Android
   browser_family: Chrome
@@ -4863,19 +4377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IBRIT_I7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: I7
   os_family: Android
   browser_family: Chrome
@@ -4883,19 +4395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; iBRIT_POWER6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: Power 6
   os_family: Android
   browser_family: Chrome
@@ -4903,19 +4413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iBRIT_Speed Pro Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7I
+    brand: iBrit
     model: Speed Pro
   os_family: Android
   browser_family: Chrome
@@ -4923,19 +4431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MS450 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS450
   os_family: Android
   browser_family: Chrome
@@ -4943,19 +4449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MS453 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS453
   os_family: Android
   browser_family: Chrome
@@ -4963,19 +4467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MS456 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS456
   os_family: Android
   browser_family: Chrome
@@ -4983,19 +4485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS457) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS457
   os_family: Android
   browser_family: Chrome
@@ -5003,19 +4503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MS457PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS457 Plus
   os_family: Android
   browser_family: Chrome
@@ -5023,19 +4521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MS505 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS505
   os_family: Android
   browser_family: Chrome
@@ -5043,19 +4539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; MS514) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7M
+    brand: Maxcom
     model: MS514
   os_family: Android
   browser_family: Chrome
@@ -5063,19 +4557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHIFT6m) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 7S
+    brand: Shift Phones
     model: SHIFT6m
   os_family: Android
   browser_family: Chrome
@@ -5083,19 +4575,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 6.0; MITO-311 Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: "311"
   os_family: Android
   browser_family: Android Browser
@@ -5103,19 +4593,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; MITO_A10 Build/MOB31E)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A10
   os_family: Android
   browser_family: Android Browser
@@ -5123,19 +4611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MITO A16 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A16
   os_family: Android
   browser_family: Chrome
@@ -5143,19 +4629,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A18 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A18
   os_family: Android
   browser_family: Android Browser
@@ -5163,19 +4647,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A180 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A180
   os_family: Android
   browser_family: Android Browser
@@ -5183,19 +4665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MITO A230 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A230
   os_family: Android
   browser_family: Chrome
@@ -5203,19 +4683,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A260 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A260
   os_family: Android
   browser_family: Android Browser
@@ -5223,19 +4701,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A30 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A30
   os_family: Android
   browser_family: Android Browser
@@ -5243,19 +4719,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.3; MITO A310 Build/JLS36C)
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A310
   os_family: Android
   browser_family: Android Browser
@@ -5263,19 +4737,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A313 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A313
   os_family: Android
   browser_family: Android Browser
@@ -5283,19 +4755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; MITO A322 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A322
   os_family: Android
   browser_family: Android Browser
@@ -5303,19 +4773,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO A33 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A33
   os_family: Android
   browser_family: Android Browser
@@ -5323,19 +4791,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A330 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A330
   os_family: Android
   browser_family: Android Browser
@@ -5343,19 +4809,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MITO A350 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A350
   os_family: Android
   browser_family: Android Browser
@@ -5363,19 +4827,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO A360 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A360
   os_family: Android
   browser_family: Android Browser
@@ -5383,19 +4845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; mito A39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A39
   os_family: Android
   browser_family: Chrome
@@ -5403,19 +4863,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MITO A50 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A50
   os_family: Android
   browser_family: Android Browser
@@ -5423,19 +4881,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A55 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A55
   os_family: Android
   browser_family: Android Browser
@@ -5443,19 +4899,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO_A550 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A550
   os_family: Android
   browser_family: Android Browser
@@ -5463,19 +4917,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A60 Build/KVT49L)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A60
   os_family: Android
   browser_family: Android Browser
@@ -5483,19 +4935,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A68 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A68
   os_family: Android
   browser_family: Android Browser
@@ -5503,19 +4953,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO_A69 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A69
   os_family: Android
   browser_family: Android Browser
@@ -5523,19 +4971,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO_A72 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A72
   os_family: Android
   browser_family: Android Browser
@@ -5543,19 +4989,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO A73 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A73
   os_family: Android
   browser_family: Android Browser
@@ -5563,19 +5007,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO A75 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A75
   os_family: Android
   browser_family: Android Browser
@@ -5583,19 +5025,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MITO A810 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A810
   os_family: Android
   browser_family: Android Browser
@@ -5603,19 +5043,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; MITO_A82 Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A82
   os_family: Android
   browser_family: Android Browser
@@ -5623,19 +5061,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MITO_A950 Build/MITO_A950_20151017_T02)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: smartphone
-    brand: 8M
+    brand: Mito
     model: A950
   os_family: Android
   browser_family: Android Browser
@@ -5643,19 +5079,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; IQM newton Build/IQM_newton_V1.0_20160910) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8Q
+    brand: IQM
     model: Newton
   os_family: Android
   browser_family: Chrome
@@ -5663,19 +5097,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 6.0; IQM picasso) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 YaBrowser/19.9.2.117.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.9.2.117.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8Q
+    brand: IQM
     model: Picasso
   os_family: Android
   browser_family: Unknown
@@ -5683,19 +5115,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 6.0; IQM vivaldi) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 YaBrowser/19.10.1.81.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.10.1.81.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8Q
+    brand: IQM
     model: Vivaldi
   os_family: Android
   browser_family: Unknown
@@ -5703,19 +5133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SOYES 6S Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8S
+    brand: Soyes
     model: 6S
   os_family: Android
   browser_family: Chrome
@@ -5723,19 +5151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SOYES_7S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 8S
+    brand: Soyes
     model: 7S
   os_family: Android
   browser_family: Chrome
@@ -5743,19 +5169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AMIGOO M1 Max Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9A
+    brand: Amigoo
     model: M1 Max
   os_family: Android
   browser_family: Chrome
@@ -5763,19 +5187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AMIGOO R300 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9A
+    brand: Amigoo
     model: R300
   os_family: Android
   browser_family: Chrome
@@ -5783,19 +5205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AMIGOO R9 Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9A
+    brand: Amigoo
     model: R9 Max
   os_family: Android
   browser_family: Chrome
@@ -5803,19 +5223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AMIGOO X15 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9A
+    brand: Amigoo
     model: X15
   os_family: Android
   browser_family: Chrome
@@ -5823,19 +5241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; SUGAR C11 Build/N2G47H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: C11
   os_family: Android
   browser_family: Chrome
@@ -5843,19 +5259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SUGAR C21 Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: C21
   os_family: Android
   browser_family: Chrome
@@ -5863,19 +5277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-cn; SUGAR C6 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.2 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: C6
   os_family: Android
   browser_family: Unknown
@@ -5883,19 +5295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR F11; Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.92 Mobile Safari/537.36 SogouMSE,SogouMobileBrowser/5.6.0
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: F11
   os_family: Android
   browser_family: Safari
@@ -5903,19 +5313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR F7 mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: F7 Mini
   os_family: Android
   browser_family: Chrome
@@ -5923,19 +5331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR F9 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: F9
   os_family: Android
   browser_family: Chrome
@@ -5943,19 +5349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR S9 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML like Gecko) Version/4.0 Chrome/48.0.2564.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: S9
   os_family: Android
   browser_family: Chrome
@@ -5963,19 +5367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR Y11) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y11
   os_family: Android
   browser_family: Chrome
@@ -5983,19 +5385,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; en-US; SUGAR Y12 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.5.1146 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.5.1146"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y12
   os_family: Android
   browser_family: Unknown
@@ -6003,19 +5403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SUGAR Y15; Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.92 Mobile Safari/537.36 SogouMSE,SogouMobileBrowser/5.6.2
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y15
   os_family: Android
   browser_family: Safari
@@ -6023,19 +5421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-cn; SUGAR Y7 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko)Version/4.0 Chrome/37.0.0.0 MQQBrowser/6.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y7
   os_family: Android
   browser_family: Unknown
@@ -6043,19 +5439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUGAR Y7 MAX Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y7 Max
   os_family: Android
   browser_family: Chrome
@@ -6063,19 +5457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; SUGAR Y8 MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y8 Max
   os_family: Android
   browser_family: Chrome
@@ -6083,19 +5475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SUGAR Y9 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.0.0 MQQBrowser/6.6 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "6.6"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: 9S
+    brand: Sugar
     model: Y9
   os_family: Android
   browser_family: Unknown
@@ -6103,19 +5493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; UL40 Build/UL40_01.01.05; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A0
+    brand: ANS
     model: UL40
   os_family: Android
   browser_family: Chrome
@@ -6123,19 +5511,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Allview 2 Speed QUAD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: 2 Speed QUAD
   os_family: Android
   browser_family: Android Browser
@@ -6143,19 +5529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A10_Lite_2019 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A10 Lite (2019)
   os_family: Android
   browser_family: Chrome
@@ -6163,19 +5547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; A10_Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A10 Plus
   os_family: Android
   browser_family: Chrome
@@ -6183,19 +5565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A4You Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A4 You
   os_family: Android
   browser_family: Chrome
@@ -6203,19 +5583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; en-us; ALLVIEW A4ALL Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A4ALL
   os_family: Android
   browser_family: Android Browser
@@ -6223,19 +5601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A5_Easy Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Easy
   os_family: Android
   browser_family: Chrome
@@ -6243,19 +5619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A5_Easy_TM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Easy
   os_family: Android
   browser_family: Chrome
@@ -6263,19 +5637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; A5_Quad Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Quad
   os_family: Android
   browser_family: Chrome
@@ -6283,19 +5655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A5_Quad_Plus_TM Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Quad Plus
   os_family: Android
   browser_family: Chrome
@@ -6303,19 +5673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A5_Ready Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Ready
   os_family: Android
   browser_family: Chrome
@@ -6323,19 +5691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A5_Ready_TM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Ready
   os_family: Android
   browser_family: Chrome
@@ -6343,19 +5709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; A5Smiley Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A5 Smiley
   os_family: Android
   browser_family: Chrome
@@ -6363,19 +5727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A6_Duo Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A6 Duo
   os_family: Android
   browser_family: Chrome
@@ -6383,19 +5745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A6_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A6 Lite
   os_family: Android
   browser_family: Chrome
@@ -6403,19 +5763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; A7_Lite Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A7 Lite
   os_family: Android
   browser_family: Chrome
@@ -6423,19 +5781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; A8_Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A8 Lite
   os_family: Android
   browser_family: Chrome
@@ -6443,19 +5799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; A9_Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: A9 Lite
   os_family: Android
   browser_family: Chrome
@@ -6463,19 +5817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ALLVIEW P4i Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: AllDro P4
   os_family: Android
   browser_family: Android Browser
@@ -6483,19 +5835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX4Nano Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: AX4 Nano
   os_family: Android
   browser_family: Chrome
@@ -6503,19 +5853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; C6_Duo) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: C6 Duo
   os_family: Android
   browser_family: Chrome
@@ -6523,19 +5871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; E2_Living Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: E2 Living
   os_family: Android
   browser_family: Chrome
@@ -6543,19 +5889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; E3_Jump) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: E3 Jump
   os_family: Android
   browser_family: Chrome
@@ -6563,19 +5907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E3_Living Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: E3 Living
   os_family: Android
   browser_family: Chrome
@@ -6583,19 +5925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; E3_Sign Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: E3 Sign
   os_family: Android
   browser_family: Chrome
@@ -6603,19 +5943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; E4_Lite Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: E4 Lite
   os_family: Android
   browser_family: Chrome
@@ -6623,19 +5961,17 @@
   user_agent: Mozilla/5.0 (Mobile; Windows Phone 8.1; Android 4.0; ARM; Trident/7.0; Touch; rv:11.0; IEMobile/11.0; ALLVIEW; Impera S) like iPhone OS 7_0_3 Mac OS X AppleWebKit/537 (KHTML, like Gecko) Mobile Safari/537
   os:
     name: Windows Phone
-    short_name: WPH
     version: "8.1"
     platform: ARM
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: Impera S
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -6643,19 +5979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M9_Connect Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: M9 Connect
   os_family: Android
   browser_family: Chrome
@@ -6663,19 +5997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; P10_Life) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P10 Life
   os_family: Android
   browser_family: Chrome
@@ -6683,19 +6015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; P10_Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P10 Max
   os_family: Android
   browser_family: Chrome
@@ -6703,19 +6033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; P10_Style) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P10 Style
   os_family: Android
   browser_family: Chrome
@@ -6723,19 +6051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P4_eMagic Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P4 eMagic
   os_family: Android
   browser_family: Chrome
@@ -6743,19 +6069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P4_Pro Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P4 Pro
   os_family: Android
   browser_family: Chrome
@@ -6763,19 +6087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P4_Quad Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P4 Quad
   os_family: Android
   browser_family: Chrome
@@ -6783,19 +6105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P41_eMagic Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P41 eMagic
   os_family: Android
   browser_family: Chrome
@@ -6803,19 +6123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P41_eMagic_TM Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P41 eMagic
   os_family: Android
   browser_family: Chrome
@@ -6823,19 +6141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P43_Easy Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P43 Easy
   os_family: Android
   browser_family: Chrome
@@ -6843,19 +6159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P5_eMagic_TM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 eMagic
   os_family: Android
   browser_family: Chrome
@@ -6863,19 +6177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P5_eMagic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 eMagic
   os_family: Android
   browser_family: Chrome
@@ -6883,19 +6195,17 @@
   user_agent: MT6795_TD/V1 Linux/3.10.65+ Android/5.1 P5_Energy Release/04.24.2015 Browser/AppleWebKit537.36 Chrome/39.0.0.0 Mobile Safari/537.36 System/Android 5.1;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 Energy
   os_family: Android
   browser_family: Chrome
@@ -6903,19 +6213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P5Life_TM Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 Life
   os_family: Android
   browser_family: Chrome
@@ -6923,19 +6231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P5_Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 Lite
   os_family: Android
   browser_family: Chrome
@@ -6943,19 +6249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P5_Pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P5 Pro
   os_family: Android
   browser_family: Chrome
@@ -6963,19 +6267,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; ALLVIEW_P6 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6
   os_family: Android
   browser_family: Android Browser
@@ -6983,19 +6285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P6_Energy Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Energy
   os_family: Android
   browser_family: Chrome
@@ -7003,19 +6303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P6_Energy_TM Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Energy
   os_family: Android
   browser_family: Chrome
@@ -7023,19 +6321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P6_Energy_Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Energy Lite
   os_family: Android
   browser_family: Chrome
@@ -7043,19 +6339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P6_Energy_mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Energy Mini
   os_family: Android
   browser_family: Chrome
@@ -7063,19 +6357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P6_lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Lite
   os_family: Android
   browser_family: Chrome
@@ -7083,19 +6375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P6_lite_TM Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.107 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.107"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Lite
   os_family: Android
   browser_family: Chrome
@@ -7103,19 +6393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P6_plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Plus
   os_family: Android
   browser_family: Chrome
@@ -7123,19 +6411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P6_Pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Pro
   os_family: Android
   browser_family: Chrome
@@ -7143,19 +6429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P6_Qmax Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Qmax
   os_family: Android
   browser_family: Chrome
@@ -7163,19 +6447,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ro-ro; ALLVIEW_P6_Quad Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P6 Quad
   os_family: Android
   browser_family: Android Browser
@@ -7183,19 +6465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P7_PRO Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P7 Pro
   os_family: Android
   browser_family: Chrome
@@ -7203,19 +6483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P7_PRO_TM Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P7 Pro
   os_family: Android
   browser_family: Chrome
@@ -7223,19 +6501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P7_Seon Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P7 Seon
   os_family: Android
   browser_family: Chrome
@@ -7243,19 +6519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; P7_Xtreme Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P7 Xtreme
   os_family: Android
   browser_family: Chrome
@@ -7263,19 +6537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P8_eMagic_TM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 eMagic
   os_family: Android
   browser_family: Chrome
@@ -7283,19 +6555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P8_eMagic) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 eMagic
   os_family: Android
   browser_family: Chrome
@@ -7303,19 +6573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P8_Energy Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Energy
   os_family: Android
   browser_family: Chrome
@@ -7323,19 +6591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P8_Energy_mini_TM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Energy Mini
   os_family: Android
   browser_family: Chrome
@@ -7343,19 +6609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P8_Energy_mini Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Energy Mini
   os_family: Android
   browser_family: Chrome
@@ -7363,19 +6627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; P8_Energy_PRO Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Energy Pro
   os_family: Android
   browser_family: Chrome
@@ -7383,19 +6645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P8_Life Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Life
   os_family: Android
   browser_family: Chrome
@@ -7403,19 +6663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P8_PRO Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P8 Pro
   os_family: Android
   browser_family: Chrome
@@ -7423,19 +6681,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P9_Energy Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy
   os_family: Android
   browser_family: Chrome
@@ -7443,19 +6699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P9_Energy_Lite Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy Lite
   os_family: Android
   browser_family: Chrome
@@ -7463,19 +6717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P9_Energy_Lite_2017 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy Lite (2017)
   os_family: Android
   browser_family: Chrome
@@ -7483,19 +6735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P9_Energy_mini Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy Mini
   os_family: Android
   browser_family: Chrome
@@ -7503,19 +6753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; P9_Energy_mini_TM Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy Mini
   os_family: Android
   browser_family: Chrome
@@ -7523,19 +6771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P9_Energy_S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Energy S
   os_family: Android
   browser_family: Chrome
@@ -7543,19 +6789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P9_Life Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Life
   os_family: Android
   browser_family: Chrome
@@ -7563,19 +6807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P9_Life_TM Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: P9 Life
   os_family: Android
   browser_family: Chrome
@@ -7583,19 +6825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V1_Viper Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V1 Viper
   os_family: Android
   browser_family: Chrome
@@ -7603,19 +6843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V1_Viper_I Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V1 Viper I
   os_family: Android
   browser_family: Chrome
@@ -7623,19 +6861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V1_Viper_I4G_TM Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V1 Viper I 4G
   os_family: Android
   browser_family: Chrome
@@ -7643,19 +6879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; V1_Viper_I4G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V1 Viper I 4G
   os_family: Android
   browser_family: Chrome
@@ -7663,19 +6897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; V2_Viper_E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper E
   os_family: Android
   browser_family: Chrome
@@ -7683,19 +6915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; V2_Viper_I_TM Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper I
   os_family: Android
   browser_family: Chrome
@@ -7703,19 +6933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; V2_Viper_I Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper I
   os_family: Android
   browser_family: Chrome
@@ -7723,19 +6951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; V2_Viper_I4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper I 4G
   os_family: Android
   browser_family: Chrome
@@ -7743,19 +6969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V2_Viper_S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper S
   os_family: Android
   browser_family: Chrome
@@ -7763,19 +6987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V2_Viper_X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper X
   os_family: Android
   browser_family: Chrome
@@ -7783,19 +7005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V2_Viper_X_plus Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper X Plus
   os_family: Android
   browser_family: Chrome
@@ -7803,19 +7023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V2_Viper_Xe Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V2 Viper Xe
   os_family: Android
   browser_family: Chrome
@@ -7823,19 +7041,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; V3_Viper) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V3 Viper
   os_family: Android
   browser_family: Chrome
@@ -7843,19 +7059,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; V4_Viper) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: V4 Viper
   os_family: Android
   browser_family: Chrome
@@ -7863,19 +7077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; X1_Soul Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X1 Soul
   os_family: Android
   browser_family: Chrome
@@ -7883,19 +7095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X1_Soul_Xtreme) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X1 Soul Xtreme
   os_family: Android
   browser_family: Chrome
@@ -7903,19 +7113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X2_Soul Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul
   os_family: Android
   browser_family: Chrome
@@ -7923,19 +7131,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X2_Soul_Mini Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -7943,19 +7149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X2_Soul_Mini_TM Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -7963,19 +7167,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X2_Soul_Style_TM Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Style
   os_family: Android
   browser_family: Chrome
@@ -7983,19 +7185,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X2_Soul_Style) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Style
   os_family: Android
   browser_family: Chrome
@@ -8003,19 +7203,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X2_Soul_Style_Plus Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Style Plus
   os_family: Android
   browser_family: Chrome
@@ -8023,19 +7221,17 @@
   user_agent: MT6795_TD/V1 Linux/3.10.72+ Android/5.1 X2_Soul_Xtreme Release/04.24.2015 Browser/AppleWebKit537.36 Chrome/39.0.0.0 Mobile Safari/537.36 System/Android 5.1;
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Soul Xtreme
   os_family: Android
   browser_family: Chrome
@@ -8043,19 +7239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X2_Twin Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X2 Twin
   os_family: Android
   browser_family: Chrome
@@ -8063,19 +7257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X3_Soul Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul
   os_family: Android
   browser_family: Chrome
@@ -8083,19 +7275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X3_Soul_Lite_TM Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Lite
   os_family: Android
   browser_family: Chrome
@@ -8103,19 +7293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X3_Soul_Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Lite
   os_family: Android
   browser_family: Chrome
@@ -8123,19 +7311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X3_Soul_mini Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -8143,19 +7329,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X3_Soul_PLUS Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Plus
   os_family: Android
   browser_family: Chrome
@@ -8163,19 +7347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X3_Soul_PRO Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Pro
   os_family: Android
   browser_family: Chrome
@@ -8183,19 +7365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X3_Soul_Style) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X3 Soul Style
   os_family: Android
   browser_family: Chrome
@@ -8203,19 +7383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; X4_Soul Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul
   os_family: Android
   browser_family: Chrome
@@ -8223,19 +7401,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Infinity_L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Infinity L
   os_family: Android
   browser_family: Chrome
@@ -8243,19 +7419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Infinity_N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Infinity N
   os_family: Android
   browser_family: Chrome
@@ -8263,19 +7437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Infinity_S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Infinity S
   os_family: Android
   browser_family: Chrome
@@ -8283,19 +7455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Infinity_Z Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Infinity Z
   os_family: Android
   browser_family: Chrome
@@ -8303,19 +7473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Lite Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Lite
   os_family: Android
   browser_family: Chrome
@@ -8323,19 +7491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Mini Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -8343,19 +7509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -8363,19 +7527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Mini_S_TM Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Mini S
   os_family: Android
   browser_family: Chrome
@@ -8383,19 +7545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Mini_S Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Mini S
   os_family: Android
   browser_family: Chrome
@@ -8403,19 +7563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Mini_S_TM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Mini S
   os_family: Android
   browser_family: Chrome
@@ -8423,19 +7581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Style Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Style
   os_family: Android
   browser_family: Chrome
@@ -8443,19 +7599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Style) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Style
   os_family: Android
   browser_family: Chrome
@@ -8463,19 +7617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; X4_Soul_Xtreme Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X4 Soul Xtreme
   os_family: Android
   browser_family: Chrome
@@ -8483,19 +7635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X5_Soul) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X5 Soul
   os_family: Android
   browser_family: Chrome
@@ -8503,19 +7653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X5_Soul_Mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X5 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -8523,19 +7671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; X5_Soul_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X5 Soul Pro
   os_family: Android
   browser_family: Chrome
@@ -8543,19 +7689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; X6_Soul_mini) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A2
+    brand: Allview
     model: X6 Soul Mini
   os_family: Android
   browser_family: Chrome
@@ -8563,19 +7707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AGM A8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A3
+    brand: AGM
     model: A8
   os_family: Android
   browser_family: Chrome
@@ -8583,19 +7725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AGM A8 SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A3
+    brand: AGM
     model: A8 SE
   os_family: Android
   browser_family: Chrome
@@ -8603,19 +7743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AGM X1 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A3
+    brand: AGM
     model: X1
   os_family: Android
   browser_family: Chrome
@@ -8623,19 +7761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AGM X2 Build/N2G47H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A3
+    brand: AGM
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -8643,19 +7779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2; ASK_SP581_HD Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: A4
+    brand: Ask
     model: SP581 HD
   os_family: Android
   browser_family: Chrome
@@ -8663,19 +7797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASK SP618 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A4
+    brand: Ask
     model: SP618
   os_family: Android
   browser_family: Chrome
@@ -8683,19 +7815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ALTRON AL-555) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A5
+    brand: altron
     model: AL-555
   os_family: Android
   browser_family: Chrome
@@ -8703,19 +7833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ARK Benefit A1 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/38.0.2125.102 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit A1
   os_family: Android
   browser_family: Chrome
@@ -8723,19 +7851,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ARK Benefit A2 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit A2
   os_family: Android
   browser_family: Chrome
@@ -8743,19 +7869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ARK Benefit A3 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit A3
   os_family: Android
   browser_family: Chrome
@@ -8763,19 +7887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK-Benefit-I1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 YandexSearch/7.15
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit I1
   os_family: Android
   browser_family: Chrome
@@ -8783,19 +7905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK Benefit I2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit I2
   os_family: Android
   browser_family: Chrome
@@ -8803,19 +7923,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK-Benefit I2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.138 Mobile Safari/537.36 OPR/22.0.1485.78487
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "22.0.1485.78487"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit I2
   os_family: Android
   browser_family: Opera
@@ -8823,19 +7941,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ARK Benefit i3 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit i3
   os_family: Android
   browser_family: Chrome
@@ -8843,19 +7959,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; ARK_Benefit_M1 Build/ARK_Benefit_M1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M1
   os_family: Android
   browser_family: Android Browser
@@ -8863,19 +7977,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK Benefit M1 3G Build/Ark_Electronic_Technology) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M1 3G
   os_family: Android
   browser_family: Chrome
@@ -8883,19 +7995,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ARK_BENEFIT_M1S Build/ARK_BENEFIT_M1S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M1S
   os_family: Android
   browser_family: Android Browser
@@ -8903,19 +8013,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ARK Benefit M2 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/47.0.2526.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "47.0.2526.100"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M2
   os_family: Android
   browser_family: Chrome
@@ -8923,19 +8031,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK_Benefit_M2C Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M2C
   os_family: Android
   browser_family: Chrome
@@ -8943,19 +8049,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; ARK Benefit M3S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M3S
   os_family: Android
   browser_family: Unknown
@@ -8963,19 +8067,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK_Benefit_M4 Build/ARK_Benefit_M4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M4
   os_family: Android
   browser_family: Chrome
@@ -8983,19 +8085,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; ARK Benefit M5 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.8.0.718 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.8.0.718"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M5
   os_family: Android
   browser_family: Unknown
@@ -9003,19 +8103,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_M5_Plus Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M5 Plus
   os_family: Android
   browser_family: Chrome
@@ -9023,19 +8121,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ARK Benefit M501 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M501
   os_family: Android
   browser_family: Chrome
@@ -9043,19 +8139,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_M502 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.0.412.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.0.412.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M502
   os_family: Android
   browser_family: Unknown
@@ -9063,19 +8157,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_M503 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M503
   os_family: Android
   browser_family: Chrome
@@ -9083,19 +8175,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Benefit_M505 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M505
   os_family: Android
   browser_family: Chrome
@@ -9103,19 +8193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Benefit_M506 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M506
   os_family: Android
   browser_family: Chrome
@@ -9123,19 +8211,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Benefit_M6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M6
   os_family: Android
   browser_family: Chrome
@@ -9143,19 +8229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ARK Benefit M7 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M7
   os_family: Android
   browser_family: Chrome
@@ -9163,19 +8247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Benefit_M8 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.0.1326.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.10.0.1326.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit M8
   os_family: Android
   browser_family: Unknown
@@ -9183,19 +8265,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Benefit_Note_1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit Note 1
   os_family: Android
   browser_family: Chrome
@@ -9203,19 +8283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_S401 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S401
   os_family: Android
   browser_family: Chrome
@@ -9223,19 +8301,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; Benefit_S402 Build/LMY47D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.8.0.718 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.8.0.718"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S402
   os_family: Android
   browser_family: Unknown
@@ -9243,19 +8319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Benefit_S403 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.116 YaBrowser/16.9.0.1424.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.9.0.1424.00"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S403
   os_family: Android
   browser_family: Unknown
@@ -9263,19 +8337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_S404 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S404
   os_family: Android
   browser_family: Chrome
@@ -9283,19 +8355,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; ARK_Benefit_S451 Build/KOT49H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.9.0.731 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.0.731"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S451
   os_family: Android
   browser_family: Unknown
@@ -9303,19 +8373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Benefit_S453 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S453
   os_family: Android
   browser_family: Chrome
@@ -9323,19 +8391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK_Benefit_S501 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S501
   os_family: Android
   browser_family: Chrome
@@ -9343,19 +8409,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ARK_Benefit_S501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S501
   os_family: Android
   browser_family: Chrome
@@ -9363,19 +8427,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_S502_Plus Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S502 Plus
   os_family: Android
   browser_family: Chrome
@@ -9383,19 +8445,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Benefit_S503 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S503
   os_family: Android
   browser_family: Chrome
@@ -9403,19 +8463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Benefit_S503_Max Build/ARK80N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S503 Max
   os_family: Android
   browser_family: Chrome
@@ -9423,19 +8481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Benefit_S505 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Benefit S505
   os_family: Android
   browser_family: Chrome
@@ -9443,19 +8499,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; EDGE A5HD Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Edge A5HD
   os_family: Android
   browser_family: Chrome
@@ -9463,19 +8517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Elf_S8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Elf S8
   os_family: Android
   browser_family: Chrome
@@ -9483,19 +8535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ICON R40+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Icon R40+
   os_family: Android
   browser_family: Chrome
@@ -9503,19 +8553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ICON R45 Build/HDICON R45) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Icon R45
   os_family: Android
   browser_family: Chrome
@@ -9523,19 +8571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Impulse P1 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Impulse P1
   os_family: Android
   browser_family: Chrome
@@ -9543,19 +8589,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Impulse P1+ Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Impulse P1 Plus
   os_family: Android
   browser_family: Chrome
@@ -9563,19 +8607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Impulse_P2 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Impulse P2
   os_family: Android
   browser_family: Chrome
@@ -9583,19 +8625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Wizard_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A6
+    brand: Ark
     model: Wizard 1
   os_family: Android
   browser_family: Chrome
@@ -9603,19 +8643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5432 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Agio
   os_family: Android
   browser_family: Chrome
@@ -9623,19 +8661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5412 max Build/MDA89D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: AS-5412 Max
   os_family: Android
   browser_family: Chrome
@@ -9643,19 +8679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; AS_601L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: AS-601L
   os_family: Android
   browser_family: Chrome
@@ -9663,19 +8697,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; AS_401L Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.6.1205 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.6.1205"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Asper
   os_family: Android
   browser_family: Unknown
@@ -9683,19 +8715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AS_501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Club
   os_family: Android
   browser_family: Chrome
@@ -9703,19 +8733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AS-5434 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Club
   os_family: Android
   browser_family: Opera
@@ -9723,19 +8751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AS-5436_Grid Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Grid
   os_family: Android
   browser_family: Chrome
@@ -9743,19 +8769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5411 max Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Max Ritm
   os_family: Android
   browser_family: Chrome
@@ -9763,19 +8787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5433 max Secret Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Max Secret
   os_family: Android
   browser_family: Chrome
@@ -9783,19 +8805,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; AS-5431 AppleWebKit/537.36 KHTML, like Gecko Chrome/76.0.3809.21 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.21"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Prima
   os_family: Android
   browser_family: Chrome
@@ -9803,19 +8823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-6431 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Rider
   os_family: Android
   browser_family: Chrome
@@ -9823,19 +8841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5433 Secret Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Secret
   os_family: Android
   browser_family: Chrome
@@ -9843,19 +8859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5435 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Shine
   os_family: Android
   browser_family: Chrome
@@ -9863,19 +8877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AS-502) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.75"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Shot
   os_family: Android
   browser_family: Chrome
@@ -9883,19 +8895,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-5421) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Surf
   os_family: Android
   browser_family: Chrome
@@ -9903,19 +8913,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AS-503) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Target
   os_family: Android
   browser_family: Chrome
@@ -9923,19 +8931,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-4411) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Unami
   os_family: Android
   browser_family: Chrome
@@ -9943,19 +8949,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AS-4421) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A8
+    brand: Assistant
     model: Unami
   os_family: Android
   browser_family: Chrome
@@ -9963,19 +8967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5041 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: "5041"
   os_family: Android
   browser_family: Chrome
@@ -9983,19 +8985,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 5059 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: smartphone
-    brand: A9
+    brand: Advan
     model: "5059"
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/tablet-1.yml
+++ b/Tests/fixtures/tablet-1.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Bush 10.0 MyTablet Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36/TansoDL
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B1
+    brand: Bush
     model: 10.0 MyTablet
   os_family: Android
   browser_family: Chrome
@@ -23,7 +21,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; BUSH 7.85 TABLET Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36 GSA/3.3.12.1106182.arm
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ARM
   client:
@@ -32,7 +29,7 @@
     version: "3.3.12.1106182"
   device:
     type: tablet
-    brand: B1
+    brand: Bush
     model: 7.85 Tablet
   os_family: Android
   browser_family: Unknown
@@ -40,19 +37,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Beeline Tab) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B5
+    brand: Beeline
     model: Tab
   os_family: Android
   browser_family: Chrome
@@ -60,19 +55,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Beeline Tab 2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B5
+    brand: Beeline
     model: Tab 2
   os_family: Android
   browser_family: Chrome
@@ -80,19 +73,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; Beeline Tab Fast AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B5
+    brand: Beeline
     model: Tab Fast
   os_family: Android
   browser_family: Chrome
@@ -100,19 +91,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Beeline Tab Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B5
+    brand: Beeline
     model: Tab Pro
   os_family: Android
   browser_family: Chrome
@@ -120,19 +109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BDF-819) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: "819"
   os_family: Android
   browser_family: Chrome
@@ -140,19 +127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K960N_MT6580_32_N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: BK960N MT6580
   os_family: Android
   browser_family: Chrome
@@ -160,19 +145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K960N_MT6753 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36 YaApp_Android/10.44 YaSearchBrowser/10.44
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: BK960N MT6753
   os_family: Android
   browser_family: Chrome
@@ -180,19 +163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BDF K107H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: K107H
   os_family: Android
   browser_family: Chrome
@@ -200,19 +181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BDF-KT107) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: KT107
   os_family: Android
   browser_family: Chrome
@@ -220,19 +199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BDF-MT6753 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: MT6753
   os_family: Android
   browser_family: Chrome
@@ -240,19 +217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BDF-P10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: P10
   os_family: Android
   browser_family: Chrome
@@ -260,19 +235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; BDF-X20 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B6
+    brand: BDF
     model: X20
   os_family: Android
   browser_family: Chrome
@@ -280,19 +253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Mobitab10c-3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B7
+    brand: Bitmore
     model: Mobitab 10C 3G
   os_family: Android
   browser_family: Chrome
@@ -300,19 +271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tab1011Q_II Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36 OPR/51.0.2461.137246
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "51.0.2461.137246"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B7
+    brand: Bitmore
     model: Tab1011Q II
   os_family: Android
   browser_family: Opera
@@ -320,19 +289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.12; K10 SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.12"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B9
+    brand: Bobarry
     model: K10 SE
   os_family: Android
   browser_family: Chrome
@@ -340,19 +307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.12; K10SE Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.12"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: B9
+    brand: Bobarry
     model: K10 SE
   os_family: Android
   browser_family: Chrome
@@ -360,19 +325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Positivo BGH +Simple Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: +Simple
   os_family: Android
   browser_family: Chrome
@@ -380,19 +343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Positivo BGH Mini Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Mini
   os_family: Android
   browser_family: Chrome
@@ -400,19 +361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Positivo BGH Y100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y100
   os_family: Android
   browser_family: Chrome
@@ -420,19 +379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Positivo BGH Y1010 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y1010
   os_family: Android
   browser_family: Chrome
@@ -440,19 +397,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Positivo BGH Y200 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y200
   os_family: Android
   browser_family: Chrome
@@ -460,19 +415,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Positivo BGH Y210 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y210
   os_family: Android
   browser_family: Chrome
@@ -480,19 +433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Positivo BGH Y700) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y700
   os_family: Android
   browser_family: Chrome
@@ -500,19 +451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Positivo BGH Y710 KIDS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BG
+    brand: BGH
     model: Y710 Kids
   os_family: Android
   browser_family: Chrome
@@ -520,19 +469,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; NOOK BNRV200 Build/ERD79 1.4.3) Apple WebKit/533.1 (KHTML, like Gecko) Version/4
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook BNRV200
   os_family: Android
   browser_family: Android Browser
@@ -540,19 +487,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; NOOK BNTV250 Build/GINGERBREAD 1.4.3) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook BNTV250
   os_family: Android
   browser_family: Android Browser
@@ -560,19 +505,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; NOOK BNTV250A Build/GINGERBREAD 1.4.3) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook BNTV250A
   os_family: Android
   browser_family: Android Browser
@@ -580,19 +523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; BNTV400 Build/IMM76L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook BNTV400
   os_family: Android
   browser_family: Chrome
@@ -600,19 +541,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; BNTV600 Build/IMM76L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook BNTV600
   os_family: Android
   browser_family: Chrome
@@ -620,19 +559,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; el-gr; NookColor Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook Color
   os_family: Android
   browser_family: Android Browser
@@ -640,19 +577,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; uk-ua; Nook Tablet Build/GINGERBREAD; CyanogenMod-7.1.0 XDA Team) AppleWebKit/533.1 (KH
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: BN
+    brand: 'Barnes & Noble'
     model: Nook Tablet
   os_family: Android
   browser_family: Android Browser
@@ -660,19 +595,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Atlantis 1001A Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Atlantis 1001A
   os_family: Android
   browser_family: Chrome
@@ -680,19 +613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Atlantis 1010A Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Atlantis 1010A
   os_family: Android
   browser_family: Chrome
@@ -700,19 +631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Atlantis A10.G402 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Atlantis A10.G402
   os_family: Android
   browser_family: Chrome
@@ -720,19 +649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Atlantis A10.G403) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Atlantis A10.G403
   os_family: Android
   browser_family: Chrome
@@ -740,19 +667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Discovery 1000c Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Discovery 1000C
   os_family: Android
   browser_family: Chrome
@@ -760,19 +685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Discovery_1001 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Discovery 1001
   os_family: Android
   browser_family: Chrome
@@ -780,19 +703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Discovery 1001A Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Discovery 1001A
   os_family: Android
   browser_family: Chrome
@@ -800,19 +721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Discovery 111C Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Discovery 111C
   os_family: Android
   browser_family: Chrome
@@ -820,19 +739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Discovery_A10_302) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Discovery A10.302
   os_family: Android
   browser_family: Chrome
@@ -840,19 +757,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Endeavour 1001 DVB-T Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 1001
   os_family: Android
   browser_family: Android Browser
@@ -860,19 +775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Endeavour 1010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 1010
   os_family: Android
   browser_family: Chrome
@@ -880,19 +793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Endeavour 1013 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 1013
   os_family: Android
   browser_family: Chrome
@@ -900,19 +811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Endeavour_101L Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 101L
   os_family: Android
   browser_family: Chrome
@@ -920,19 +829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; Endeavour_1100 Build/LRX22C; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 1100
   os_family: Android
   browser_family: Chrome
@@ -940,19 +847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Endeavour 785 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Endeavour 785
   os_family: Android
   browser_family: Chrome
@@ -960,19 +865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; polaris_803 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BP
+    brand: Blaupunkt
     model: Polaris 803
   os_family: Android
   browser_family: Chrome
@@ -980,19 +883,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; Surfing TAB B 9.7 3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BR
+    brand: Brondi
     model: SURFING TAB B 9.7 3G
   os_family: Android
   browser_family: Android Browser
@@ -1000,19 +901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Surfing Tab C 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BR
+    brand: Brondi
     model: SURFING TAB C 3G
   os_family: Android
   browser_family: Chrome
@@ -1020,19 +919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NB105 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB105
   os_family: Android
   browser_family: Chrome
@@ -1040,19 +937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NB106M Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB106M
   os_family: Android
   browser_family: Chrome
@@ -1060,19 +955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NB107 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/66.0.3359.158 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB107
   os_family: Android
   browser_family: Chrome
@@ -1080,19 +973,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; NB108 Build/O11019; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB108
   os_family: Android
   browser_family: Chrome
@@ -1100,19 +991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NB74 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB74
   os_family: Android
   browser_family: Chrome
@@ -1120,19 +1009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; NB751 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB751
   os_family: Android
   browser_family: Chrome
@@ -1140,19 +1027,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; NB76 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB76
   os_family: Android
   browser_family: Chrome
@@ -1160,19 +1045,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; NB851 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB851
   os_family: Android
   browser_family: Chrome
@@ -1180,19 +1063,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; NB871 AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB871
   os_family: Android
   browser_family: Chrome
@@ -1200,19 +1081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NB961) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NB961
   os_family: Android
   browser_family: Chrome
@@ -1220,19 +1099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NP101 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NP101
   os_family: Android
   browser_family: Chrome
@@ -1240,19 +1117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BRAVIS NP 103) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NP103
   os_family: Android
   browser_family: Chrome
@@ -1260,19 +1135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NP 104 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NP104 3G
   os_family: Android
   browser_family: Chrome
@@ -1280,19 +1153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BRAVIS NP 844) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: NP844
   os_family: Android
   browser_family: Chrome
@@ -1300,19 +1171,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; BRAVIS_SLIM_3G Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BV
+    brand: Bravis
     model: Slim 3G
   os_family: Android
   browser_family: Android Browser
@@ -1320,19 +1189,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; BQru-1056L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Safari/537.36 OPR/37.1.2254.132401
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "37.1.2254.132401"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: 1056L
   os_family: Android
   browser_family: Opera
@@ -1340,19 +1207,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 6.0.1; en-us; BQru-7083 Build/JOP24G AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Chrome/43.0.2357.65 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.65"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: "7083"
   os_family: Android
   browser_family: Chrome
@@ -1360,19 +1225,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7061g Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Andros
   os_family: Android
   browser_family: Chrome
@@ -1380,19 +1243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Aquaris M8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Aquaris M8
   os_family: Android
   browser_family: Chrome
@@ -1400,19 +1261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-7082 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36 YaApp_Android/9.40 YaSearchBrowser/9.40
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor
   os_family: Android
   browser_family: Chrome
@@ -1420,19 +1279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BQ-7098G Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor Power
   os_family: Android
   browser_family: Chrome
@@ -1440,19 +1297,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-1082G Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Safari/537.36 YandexSearch/8.50/apad YandexSearchBrowser/8.50
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor Pro
   os_family: Android
   browser_family: Chrome
@@ -1460,19 +1315,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-1077L Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Safari/537.36 YandexSearch/8.50/apad YandexSearchBrowser/8.50
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor Pro LTE
   os_family: Android
   browser_family: Chrome
@@ -1480,19 +1333,17 @@
   user_agent: mozilla/5.0 (linux; android 9; bq-1022l) applewebkit/537.36 (khtml, like gecko) chrome/81.0.4044.117 safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor Pro LTE+
   os_family: Android
   browser_family: Chrome
@@ -1500,19 +1351,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-1083G Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/63.0.3239.111 Safari/537.36 YandexSearch/7.21/apad
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Armor Pro Plus
   os_family: Android
   browser_family: Chrome
@@ -1520,19 +1369,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-8041L Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Art
   os_family: Android
   browser_family: Chrome
@@ -1540,19 +1387,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; BQ-7001G Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-7001G
   os_family: Android
   browser_family: Android Browser
@@ -1560,19 +1405,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; BQ-7002G Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-7002G
   os_family: Android
   browser_family: Unknown
@@ -1580,19 +1423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQ-7056G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36 OPR/49.2.2361.134358
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "49.2.2361.134358"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-7056G
   os_family: Android
   browser_family: Opera
@@ -1600,19 +1441,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; BQ-7850 Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-7850
   os_family: Android
   browser_family: Android Browser
@@ -1620,19 +1459,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-8002G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/55.0.2883.95 YaBrowser/17.1.0.412.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.0.412.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-8002G
   os_family: Android
   browser_family: Unknown
@@ -1640,19 +1477,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; BQ-8052G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-8052G
   os_family: Android
   browser_family: Chrome
@@ -1660,19 +1495,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; BQ-9051G Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-9051G
   os_family: Android
   browser_family: Unknown
@@ -1680,19 +1513,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; BQ-9052G Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-9052G
   os_family: Android
   browser_family: Chrome
@@ -1700,19 +1531,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; BQ-9702G Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: BQ-9702G
   os_family: Android
   browser_family: Android Browser
@@ -1720,19 +1549,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-7022G AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.119 YaBrowser/19.3.2.347.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.3.2.347.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Canion
   os_family: Android
   browser_family: Unknown
@@ -1740,19 +1567,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-7022 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Canion
   os_family: Android
   browser_family: Chrome
@@ -1760,19 +1585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BQru-7081 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Charm
   os_family: Android
   browser_family: Chrome
@@ -1780,19 +1603,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7008G Build/KOT49H; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/66.0.3359.139 Safari/537.36 Puffin/7.7.5.30963AT
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.7.5.30963"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Clarion
   os_family: Android
   browser_family: Unknown
@@ -1800,19 +1621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQ-1051G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Corsika
   os_family: Android
   browser_family: Chrome
@@ -1820,19 +1639,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; bq Curie Build/1.1.0 20130322-14:50) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Curie
   os_family: Android
   browser_family: Android Browser
@@ -1840,19 +1657,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison Build/1.1.7 20121029-11:59) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Edison
   os_family: Android
   browser_family: Android Browser
@@ -1860,19 +1675,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-pt; bq Edison Build/1.1.5 20120929-11:03) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Edison
   os_family: Android
   browser_family: Android Browser
@@ -1880,19 +1693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; bq Edison 2 Quad Core Build/1.2.0_20140106-13:59) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Edison 2 Quad Core
   os_family: Android
   browser_family: Chrome
@@ -1900,19 +1711,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; bq Edison 3G Build/1.1.11-1015 20130125-15:24) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Edison 3G
   os_family: Android
   browser_family: Android Browser
@@ -1920,19 +1729,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7051G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Elba
   os_family: Android
   browser_family: Chrome
@@ -1940,19 +1747,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; es-es; bq Elcano Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Elcano
   os_family: Android
   browser_family: Android Browser
@@ -1960,19 +1765,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7062G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Fiji
   os_family: Android
   browser_family: Chrome
@@ -1980,19 +1783,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-7064G AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Fusion
   os_family: Android
   browser_family: Chrome
@@ -2000,19 +1801,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; BQ1008G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Grace
   os_family: Android
   browser_family: Chrome
@@ -2020,19 +1819,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-1008G Build/MDA89D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Grace
   os_family: Android
   browser_family: Chrome
@@ -2040,19 +1837,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; BQru-1081G Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/42.0.2254.139276
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "42.0.2254.139276"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Grace 3G
   os_family: Android
   browser_family: Opera
@@ -2060,19 +1855,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-1050G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/66.0.3359.158 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hawaii
   os_family: Android
   browser_family: Chrome
@@ -2080,19 +1873,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-7021G Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hit
   os_family: Android
   browser_family: Chrome
@@ -2100,19 +1891,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-7036L AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hornet
   os_family: Android
   browser_family: Chrome
@@ -2120,19 +1909,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-1084L Build/OPM2.171019.012; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hornet Max
   os_family: Android
   browser_family: Chrome
@@ -2140,19 +1927,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-1085L Build/OPM2.171019.012; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hornet Max Pro
   os_family: Android
   browser_family: Chrome
@@ -2160,19 +1945,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; BQ-8067L Build/OPM2.171019.012 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.4.2517.140781
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.4.2517.140781"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Hornet Plus
   os_family: Android
   browser_family: Opera
@@ -2180,19 +1963,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7003 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Jamaica
   os_family: Android
   browser_family: Chrome
@@ -2200,19 +1981,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-8006G AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.75 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "73.0.3683.75"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Java
   os_family: Android
   browser_family: Chrome
@@ -2220,19 +1999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-7038G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Light Plus
   os_family: Android
   browser_family: Chrome
@@ -2240,19 +2017,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7802G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Luzon
   os_family: Android
   browser_family: Chrome
@@ -2260,19 +2035,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7050G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Malta
   os_family: Android
   browser_family: Chrome
@@ -2280,19 +2053,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7005G Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Maui
   os_family: Android
   browser_family: Chrome
@@ -2300,19 +2071,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; BQ-7010G AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Max
   os_family: Android
   browser_family: Chrome
@@ -2320,19 +2089,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; bq Maxwell Plus Build/1.0.3 20121201-14:07) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Maxwell Plus
   os_family: Android
   browser_family: Android Browser
@@ -2340,19 +2107,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; BQ-1007 Build/KTU84Q AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Necker
   os_family: Android
   browser_family: Chrome
@@ -2360,19 +2125,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-1054L AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Nexion
   os_family: Android
   browser_family: Chrome
@@ -2380,19 +2143,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-1045G Build/MDA89D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Orion
   os_family: Android
   browser_family: Chrome
@@ -2400,19 +2161,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-1045 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Orion
   os_family: Android
   browser_family: Chrome
@@ -2420,19 +2179,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 7.0; BQru-1057L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.100 YaBrowser/19.7.0.117.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.0.117.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Passion
   os_family: Android
   browser_family: Unknown
@@ -2440,19 +2197,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; BQ-7084G Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.101 Mobile Safari/537.36 YandexSearch/8.50 YandexSearchBrowser/8.50
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Simple
   os_family: Android
   browser_family: Chrome
@@ -2460,19 +2215,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-7006G Build/LMY47D; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/72.0.3626.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Union
   os_family: Android
   browser_family: Chrome
@@ -2480,19 +2233,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; BQ-9011 Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Vision
   os_family: Android
   browser_family: Chrome
@@ -2500,19 +2251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; BQ-7000G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Сharm
   os_family: Android
   browser_family: Chrome
@@ -2520,19 +2269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; BQ-7040G Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: BX
+    brand: bq
     model: Сharm Plus
   os_family: Android
   browser_family: Chrome
@@ -2540,19 +2287,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; CTAB101L32G Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 ACHEETAHI/2100501090
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: CM Browser
-    short_name: CE
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: CTAB 101L32G
   os_family: Android
   browser_family: Chrome
@@ -2560,19 +2305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; st-fr; CTAB700L Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: CTAB 700L
   os_family: Android
   browser_family: Android Browser
@@ -2580,19 +2323,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; TFX712G Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: TFX712G
   os_family: Android
   browser_family: Android Browser
@@ -2600,19 +2341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; TGW709 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: TGW 709
   os_family: Android
   browser_family: Chrome
@@ -2620,19 +2359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TGW710G Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: TGW 710G
   os_family: Android
   browser_family: Chrome
@@ -2640,19 +2377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; TRA-901G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: C5
+    brand: Condor
     model: TRA 901G
   os_family: Android
   browser_family: Android Browser
@@ -2660,19 +2395,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-US; CT701G PLUS Build/IMM76D) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.0.2.299 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.0.2.299"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: tablet
-    brand: C6
+    brand: Comio
     model: CT701G Plus
   os_family: Android
   browser_family: Unknown
@@ -2680,19 +2413,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; CT701W Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: C6
+    brand: Comio
     model: CT701W
   os_family: Android
   browser_family: Android Browser
@@ -2700,19 +2431,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.2.2; en-US; GT100) U2/1.0.0 UCBrowser/9.4.0.460 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.460"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: C6
+    brand: Comio
     model: GT100
   os_family: Android
   browser_family: Unknown
@@ -2720,19 +2449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Tesla_Tablet_785 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: 7.85"
   os_family: Android
   browser_family: Chrome
@@ -2740,19 +2467,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; TESLA Gravity 9.7 SHD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: Gravity 9.7 SHD
   os_family: Android
   browser_family: Chrome
@@ -2760,19 +2485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Tesla TTH7 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: H7
   os_family: Android
   browser_family: Chrome
@@ -2780,19 +2503,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; Impulse 7.85 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: Impulse 7.85 3G
   os_family: Android
   browser_family: Chrome
@@ -2800,19 +2521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Tesla TTL7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7
   os_family: Android
   browser_family: Chrome
@@ -2820,19 +2539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Tesla_Tablet_L7_3G Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7 3G
   os_family: Android
   browser_family: Chrome
@@ -2840,19 +2557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Tesla L7 Quad Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7 Quad
   os_family: Android
   browser_family: Chrome
@@ -2860,19 +2575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Tesla Tablet L7 Quad Lite Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7 Quad Lite
   os_family: Android
   browser_family: Chrome
@@ -2880,19 +2593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla L7.1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7.1
   os_family: Android
   browser_family: Chrome
@@ -2900,19 +2611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TTL713G Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L7.1 3G
   os_family: Android
   browser_family: Chrome
@@ -2920,19 +2629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TTL8 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L8
   os_family: Android
   browser_family: Chrome
@@ -2940,19 +2647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Tesla L8.1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: L8.1
   os_family: Android
   browser_family: Chrome
@@ -2960,19 +2665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; TESLA_TABLET_M7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: M7
   os_family: Android
   browser_family: Chrome
@@ -2980,19 +2683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Tesla_Tablet_M8 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: C7
+    brand: ComTrade Tesla
     model: M8
   os_family: Android
   browser_family: Chrome
@@ -3000,19 +2701,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; C-721 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.4.1.565 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.4.1.565"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: C8
+    brand: Concord
     model: Flyfix Q
   os_family: Android
   browser_family: Unknown
@@ -3020,19 +2719,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; Cat Tablet Galactica X 9.7CA Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: Galactica X 9.7CA
   os_family: Android
   browser_family: Android Browser
@@ -3040,19 +2737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-us ; CAT NOVA Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.3.0.143/145/352
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.3.0.143"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: NOVA
   os_family: Android
   browser_family: Unknown
@@ -3060,19 +2755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ch; Cat Tablet Android 4.0.4 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: Nova
   os_family: Android
   browser_family: Android Browser
@@ -3080,19 +2773,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; De-de; CatNova8 Build/GRI40) AppleWebKit/533.16 (KHTML, Like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.16"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: Nova8
   os_family: Android
   browser_family: Android Browser
@@ -3100,19 +2791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Cat Tablet PHOENIX 8.1J0 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: PHOENIX 8.1J0
   os_family: Android
   browser_family: Chrome
@@ -3120,19 +2809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Cat Tablet PHOENIX 8.1J0 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: PHOENIX 8.1J0
   os_family: Android
   browser_family: Chrome
@@ -3140,19 +2827,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; en-us; Cat StarGate Build/GRH78) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: StarGate
   os_family: Android
   browser_family: Android Browser
@@ -3160,19 +2845,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; Cat Tablet StarGate 2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CA
+    brand: Cat
     model: StarGate 2
   os_family: Android
   browser_family: Android Browser
@@ -3180,19 +2863,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde tab PLAY Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CC
+    brand: ConCorde
     model: Tab PLAY
   os_family: Android
   browser_family: Android Browser
@@ -3200,19 +2881,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; hu-hu; ConCorde Tab T10 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CC
+    brand: ConCorde
     model: Tab T10
   os_family: Android
   browser_family: Android Browser
@@ -3220,19 +2899,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; CELKON CT2 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CE
+    brand: Celkon
     model: CT2
   os_family: Android
   browser_family: Android Browser
@@ -3240,19 +2917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; CT1000 Build/KRT16S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT1000
   os_family: Android
   browser_family: Chrome
@@ -3260,19 +2935,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; CT1010 Build/IMM76I.v006) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT1010
   os_family: Android
   browser_family: Chrome
@@ -3280,19 +2953,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CT1020W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT1020W
   os_family: Android
   browser_family: Chrome
@@ -3300,19 +2971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; CT1030 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT1030
   os_family: Android
   browser_family: Chrome
@@ -3320,19 +2989,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; CT710FR Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT710FR
   os_family: Android
   browser_family: Chrome
@@ -3340,19 +3007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; CT720 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: CT720
   os_family: Android
   browser_family: Chrome
@@ -3360,19 +3025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CT820 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CF
+    brand: Carrefour
     model: Touch Tablet Neo2
   os_family: Android
   browser_family: Chrome
@@ -3380,19 +3043,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; th-th; Fusion Bolt Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CH
+    brand: Cherry Mobile
     model: Fusion Bolt
   os_family: Android
   browser_family: Android Browser
@@ -3400,19 +3061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Q7A Build/ICS_IMM76D_B206) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: CM
+    brand: Crius Mea
     model: Q7A
   os_family: Android
   browser_family: Chrome
@@ -3420,19 +3079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Q7A+ Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CM
+    brand: Crius Mea
     model: Q7A+
   os_family: Android
   browser_family: Android Browser
@@ -3440,19 +3097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; CnM Touchpad 9.7 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CN
+    brand: CnM
     model: Touchpad 9.7
   os_family: Android
   browser_family: Android Browser
@@ -3460,19 +3115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CAPTIVA 10.1 HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CP
+    brand: Captiva
     model: Pad 10.1 HD
   os_family: Android
   browser_family: Chrome
@@ -3480,19 +3133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CAPTIVA 9.7 Super FHD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CP
+    brand: Captiva
     model: Pad 9.7 Super FHD
   os_family: Android
   browser_family: Chrome
@@ -3500,19 +3151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Captiva Pad 10 3G Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CP
+    brand: Captiva
     model: Pad Pad 10 3G Plus
   os_family: Android
   browser_family: Chrome
@@ -3520,19 +3169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Iwork10 Flagship) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Flagship
   os_family: Android
   browser_family: Chrome
@@ -3540,19 +3187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; i1002S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -3560,19 +3205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iwork10 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -3580,19 +3223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TFD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -3600,19 +3241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TF) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -3620,19 +3259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TFB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Air
   os_family: Android
   browser_family: Chrome
@@ -3640,19 +3277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; I1-TC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: iWork 8 Ultimate
   os_family: Android
   browser_family: Chrome
@@ -3660,19 +3295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T8-PLUS Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: T8 Ultimate
   os_family: Android
   browser_family: Chrome
@@ -3680,19 +3313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T8-PLUSMS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: T8 Ultimate
   os_family: Android
   browser_family: Chrome
@@ -3700,19 +3331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T8PLUSML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: T8 Ultimate
   os_family: Android
   browser_family: Chrome
@@ -3720,19 +3349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T8-PLUSM Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36 OPR/43.0.2246.121183
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43.0.2246.121183"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: T8 Ultimate
   os_family: Android
   browser_family: Opera
@@ -3740,19 +3367,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; U55GT Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: Talk 79
   os_family: Android
   browser_family: Android Browser
@@ -3760,19 +3385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U27GT-3GH Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: Talk 8
   os_family: Android
   browser_family: Chrome
@@ -3780,19 +3403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U65GT Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: Talk 9X
   os_family: Android
   browser_family: Chrome
@@ -3800,19 +3421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; U20GT_WS Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U20GT WS
   os_family: Android
   browser_family: Android Browser
@@ -3820,19 +3439,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; U23GTC4 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U23GTC4
   os_family: Android
   browser_family: Android Browser
@@ -3840,19 +3457,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; U25GT Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U25GT
   os_family: Android
   browser_family: Android Browser
@@ -3860,19 +3475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; U30GT 2H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.69 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.69"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U30GT 2H
   os_family: Android
   browser_family: Chrome
@@ -3880,19 +3493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; U30GT C4 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U30GT C4
   os_family: Android
   browser_family: Chrome
@@ -3900,19 +3511,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; U30GT-H Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U30GT-H
   os_family: Android
   browser_family: Android Browser
@@ -3920,19 +3529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; U30GT-HS Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U30GT-HS
   os_family: Android
   browser_family: Android Browser
@@ -3940,19 +3547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; u30gt2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: u30gt2
   os_family: Android
   browser_family: Chrome
@@ -3960,19 +3565,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; U39GT-3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U39GT-3G
   os_family: Android
   browser_family: Android Browser
@@ -3980,19 +3583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; U51GT-W Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U51GT-W
   os_family: Android
   browser_family: Android Browser
@@ -4000,19 +3601,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; U9GT V_Core 4 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U9GT V Core 4
   os_family: Android
   browser_family: Android Browser
@@ -4020,19 +3619,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; U9GT3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CU
+    brand: Cube
     model: U9GT3
   os_family: Android
   browser_family: Android Browser
@@ -4040,19 +3637,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; MID1024 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1024
   os_family: Android
   browser_family: Android Browser
@@ -4060,19 +3655,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; MID1045 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1045
   os_family: Android
   browser_family: Android Browser
@@ -4080,19 +3673,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MID1048 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1048
   os_family: Android
   browser_family: Android Browser
@@ -4100,19 +3691,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; MID1060 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1060
   os_family: Android
   browser_family: Android Browser
@@ -4120,19 +3709,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID1125 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1125
   os_family: Android
   browser_family: Android Browser
@@ -4140,19 +3727,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID1126 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID1126
   os_family: Android
   browser_family: Android Browser
@@ -4160,19 +3745,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID7012 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7012
   os_family: Android
   browser_family: Android Browser
@@ -4180,19 +3763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; MID7015 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7015
   os_family: Android
   browser_family: Android Browser
@@ -4200,19 +3781,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1-update1; fr-fr; MID7015A Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7015A
   os_family: Android
   browser_family: Android Browser
@@ -4220,19 +3799,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID7016 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7016
   os_family: Android
   browser_family: Android Browser
@@ -4240,19 +3817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-ca; MID7022 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7022
   os_family: Android
   browser_family: Android Browser
@@ -4260,19 +3835,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MID7032 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7032
   os_family: Android
   browser_family: Android Browser
@@ -4280,19 +3853,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID7035 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7035
   os_family: Android
   browser_family: Android Browser
@@ -4300,19 +3871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID7036 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7036
   os_family: Android
   browser_family: Android Browser
@@ -4320,19 +3889,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-ca; MID7042 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7042
   os_family: Android
   browser_family: Android Browser
@@ -4340,19 +3907,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; MID7048 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7048
   os_family: Android
   browser_family: Android Browser
@@ -4360,19 +3925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MID7052 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7052
   os_family: Android
   browser_family: Chrome
@@ -4380,19 +3943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MID7065 Build/ICS.MID7065.20121212) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7065
   os_family: Android
   browser_family: Chrome
@@ -4400,19 +3961,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID7120 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID7120
   os_family: Android
   browser_family: Android Browser
@@ -4420,19 +3979,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; MID8024 Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8024
   os_family: Android
   browser_family: Android Browser
@@ -4440,19 +3997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; pt-pt; MID8042 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8042
   os_family: Android
   browser_family: Android Browser
@@ -4460,19 +4015,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; MID8048 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8048
   os_family: Android
   browser_family: Android Browser
@@ -4480,19 +4033,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID8125 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8125
   os_family: Android
   browser_family: Android Browser
@@ -4500,19 +4051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID8127 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8127
   os_family: Android
   browser_family: Android Browser
@@ -4520,19 +4069,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID8128 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID8128
   os_family: Android
   browser_family: Android Browser
@@ -4540,19 +4087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MID9724 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID9724
   os_family: Android
   browser_family: Android Browser
@@ -4560,19 +4105,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID9740 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID9740
   os_family: Android
   browser_family: Android Browser
@@ -4580,19 +4123,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID9742 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: CY
+    brand: Coby Kyros
     model: MID9742
   os_family: Android
   browser_family: Android Browser
@@ -4600,19 +4141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CITI 1532 3G CS1144MG Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1532 3G
   os_family: Android
   browser_family: Chrome
@@ -4620,19 +4159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CITI_1544_3G_CS1154MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1544 3G
   os_family: Android
   browser_family: Chrome
@@ -4640,19 +4177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 1576 3G CS1194MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1576 3G
   os_family: Android
   browser_family: Chrome
@@ -4660,19 +4195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 1577 3G CS1195MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1577 3G
   os_family: Android
   browser_family: Chrome
@@ -4680,19 +4213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 1578 4G CS1196ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1578 4G
   os_family: Android
   browser_family: Chrome
@@ -4700,19 +4231,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; CITI 1901 4G CS1050PL Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1901 4G
   os_family: Android
   browser_family: Android Browser
@@ -4720,19 +4249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CITI 1902 3G CS1051PG Build/UNKNOWN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.1.359.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.1.359.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 1902 3G
   os_family: Android
   browser_family: Unknown
@@ -4740,19 +4267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 3000 4G CS3001ML Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 3000 4G
   os_family: Android
   browser_family: Chrome
@@ -4760,19 +4285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 7507 4G CS7113PL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 7507 4G
   os_family: Android
   browser_family: Chrome
@@ -4780,19 +4303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI 7575 3G CS7193MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 7575 3G
   os_family: Android
   browser_family: Chrome
@@ -4800,19 +4321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI_7586_3G_TS7203MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 7586 3G
   os_family: Android
   browser_family: Chrome
@@ -4820,19 +4339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CITI_8527_4G_CS8139ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 8527 4G
   os_family: Android
   browser_family: Chrome
@@ -4840,19 +4357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CITI_8542_4G_CS8152ML) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 8542 4G
   os_family: Android
   browser_family: Chrome
@@ -4860,19 +4375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; CITI_8588_3G_CS8205PG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 8588 3G
   os_family: Android
   browser_family: Chrome
@@ -4880,19 +4393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CITI 8592 3G CS8209MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.3.2672.50220
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.3.2672.50220"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI 8592 3G
   os_family: Android
   browser_family: Opera
@@ -4900,19 +4411,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; CITI Octa 80 CS8218PL Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI Octa 80
   os_family: Android
   browser_family: Opera
@@ -4920,19 +4429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CITI Z510 3G CT5006PG Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI Z510 3G
   os_family: Android
   browser_family: Chrome
@@ -4940,19 +4447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CITI Z520 3G CS5007PG Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: CITI Z520 3G
   os_family: Android
   browser_family: Chrome
@@ -4960,19 +4465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; iDxD8 3G Build/JB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: D-Plane2 8
   os_family: Android
   browser_family: Chrome
@@ -4980,19 +4483,17 @@
   user_agent: Mozilla/5.0(Linux; U; Android 2.2.1; ru-ru; Digma d700 Build/MASTER)AppleWebKit/533.1(KHTML, like Gecko)Version/4.0MobileSafari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: d700
   os_family: Android
   browser_family: Android Browser
@@ -5000,19 +4501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HIT 3G HT7071MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: HIT 3G
   os_family: Android
   browser_family: Chrome
@@ -5020,19 +4519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HIT HT7070MG Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: HIT 3G
   os_family: Android
   browser_family: Chrome
@@ -5040,19 +4537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HIT 4G HT7074ML Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: HIT 4G
   os_family: Android
   browser_family: Chrome
@@ -5060,19 +4555,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Digma iDj7 3G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDj7 3G
   os_family: Android
   browser_family: Android Browser
@@ -5080,19 +4573,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; iDnD7 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDnD7
   os_family: Android
   browser_family: Android Browser
@@ -5100,19 +4591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; iDrQ10 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.116 YaBrowser/16.10.2.1487.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.10.2.1487.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDrQ10 3G
   os_family: Android
   browser_family: Unknown
@@ -5120,19 +4609,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; DIGMA iDs10 3G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDs10 3G
   os_family: Android
   browser_family: Android Browser
@@ -5140,19 +4627,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; en-us; MVM900HWZ Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDx8
   os_family: Android
   browser_family: Android Browser
@@ -5160,19 +4645,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; MVM908HCZ Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDx9
   os_family: Android
   browser_family: Android Browser
@@ -5180,19 +4663,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; iDxD10 3G Build/ICS) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDxD10 3G
   os_family: Android
   browser_family: Android Browser
@@ -5200,19 +4681,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; iDxD7 3G Build/ICS) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: iDxD7 3G
   os_family: Android
   browser_family: Android Browser
@@ -5220,19 +4699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Optima 10.3 3G TT1003MG Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima 10.3 3G
   os_family: Android
   browser_family: Chrome
@@ -5240,19 +4717,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TT1004PG Build/KOT49H AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.0.2569.141184
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.0.2569.141184"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima 10.4" 3G
   os_family: Android
   browser_family: Opera
@@ -5260,19 +4735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Optima 1104S 3G TS1087MG Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima 1104S 3G
   os_family: Android
   browser_family: Chrome
@@ -5280,19 +4753,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; TT7025MG Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima 7.5" 3G
   os_family: Android
   browser_family: Android Browser
@@ -5300,19 +4771,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; ru-ru; Optima 8019N 4G TS8182ML Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/72.0.3626.121 Safari/537.36 Hawk/QuickBrowser/2.4.21.22910
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima 8019N 4G
   os_family: Android
   browser_family: Chrome
@@ -5320,19 +4789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Optima E7.1 3G TT7071MG Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 YaBrowser/15.10.2454.3845.01 Yowser/2.5.2 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.10.2454.3845.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima E7.1 3G
   os_family: Android
   browser_family: Unknown
@@ -5340,19 +4807,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; Optima M7.0 TT7008AW Build/KVT49L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.8.0.718 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.8.0.718"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima M7.0
   os_family: Android
   browser_family: Unknown
@@ -5360,19 +4825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Optima Prime 3G TT7000MG Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.95 YaBrowser/17.1.2.339.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.1.2.339.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Optima Prime 3G
   os_family: Android
   browser_family: Unknown
@@ -5380,19 +4843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PS1043MG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Plane 10.3" 3G
   os_family: Android
   browser_family: Chrome
@@ -5400,19 +4861,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Plane 8.4 3G PS8040MG Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.111 YaBrowser/16.2.1.7529.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.2.1.7529.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Plane 8.4 3G
   os_family: Android
   browser_family: Unknown
@@ -5420,19 +4879,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Plane 8555M 4G PS8168ML AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Plane 8555M 4G
   os_family: Android
   browser_family: Chrome
@@ -5440,19 +4897,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; Plane 8566N 3G PS8181MG AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Plane 8566N 3G
   os_family: Android
   browser_family: Chrome
@@ -5460,19 +4915,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; Platina 1579M 4G NS1800ML Build/O11019 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.2.1188 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Platina 1579M 4G
   os_family: Android
   browser_family: Unknown
@@ -5480,19 +4933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Platina 7.1 4G NS7001QL Build/G820) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Platina 7.1 4G
   os_family: Android
   browser_family: Chrome
@@ -5500,19 +4951,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Platina 9.7 3G NS9797MG Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18211.00 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18211.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Platina 7.2 3G
   os_family: Android
   browser_family: Unknown
@@ -5520,19 +4969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Platina 7.2 4G NS6902QL Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: D2
+    brand: Digma
     model: Platina 7.2 4G
   os_family: Android
   browser_family: Chrome
@@ -5540,19 +4987,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; DTA-07IDRF Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: D5
+    brand: Daewoo
     model: Archive 7P
   os_family: Android
   browser_family: Android Browser
@@ -5560,19 +5005,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; DSlide 1013 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 1013
   os_family: Android
   browser_family: Android Browser
@@ -5580,19 +5023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; DSlide 1013 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 1013
   os_family: Android
   browser_family: Chrome
@@ -5600,19 +5041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; Dslide 700 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 700
   os_family: Android
   browser_family: Android Browser
@@ -5620,19 +5059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; Dslide 702 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 702
   os_family: Android
   browser_family: Android Browser
@@ -5640,19 +5077,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Dslide 703R Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 703R
   os_family: Android
   browser_family: Android Browser
@@ -5660,19 +5095,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Dslide 704 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 704
   os_family: Android
   browser_family: Android Browser
@@ -5680,19 +5113,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; Dslide 706 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 706
   os_family: Android
   browser_family: Android Browser
@@ -5700,19 +5131,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Dslide 706 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 706
   os_family: Android
   browser_family: Android Browser
@@ -5720,19 +5149,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Dslide 707 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 707
   os_family: Android
   browser_family: Chrome
@@ -5740,19 +5167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Dslide800 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 800
   os_family: Android
   browser_family: Android Browser
@@ -5760,19 +5185,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Dslide801 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 801
   os_family: Android
   browser_family: Android Browser
@@ -5780,19 +5203,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Dslide900 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 900
   os_family: Android
   browser_family: Android Browser
@@ -5800,19 +5221,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Dslide 971 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 971
   os_family: Android
   browser_family: Android Browser
@@ -5820,19 +5239,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Dslide971DC Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 971DC
   os_family: Android
   browser_family: Android Browser
@@ -5840,19 +5257,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; DSlide972 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 972
   os_family: Android
   browser_family: Android Browser
@@ -5860,19 +5275,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; DSlide973 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 973
   os_family: Android
   browser_family: Android Browser
@@ -5880,19 +5293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Dslide973QC Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DA
+    brand: Danew
     model: DSlide 973QC
   os_family: Android
   browser_family: Chrome
@@ -5900,19 +5311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; DL1008M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DD
+    brand: Digiland
     model: DL1008M
   os_family: Android
   browser_family: Chrome
@@ -5920,19 +5329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; TAC-70051 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAC-70051
   os_family: Android
   browser_family: Android Browser
@@ -5940,19 +5347,17 @@
   user_agent: Android 4.0.3;AppleWebKit/534.30;Build/IML74K;TAC-7028 Build/IML74K
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAC-7028
   os_family: Android
   browser_family: Android Browser
@@ -5960,19 +5365,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; TAD-10023 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAD-10023
   os_family: Android
   browser_family: Android Browser
@@ -5980,19 +5383,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; sv-se; TAD-70092 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAD-70092
   os_family: Android
   browser_family: Android Browser
@@ -6000,19 +5401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pt-pt; TAD-97052 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAD-97052
   os_family: Android
   browser_family: Android Browser
@@ -6020,19 +5419,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; TAD-97072G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAD-97072
   os_family: Android
   browser_family: Android Browser
@@ -6040,19 +5437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; TAD-97072G Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.170 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.170"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAD-97072
   os_family: Android
   browser_family: Chrome
@@ -6060,19 +5455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PO10319TAQ-10172MK3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-10172MK3
   os_family: Android
   browser_family: Chrome
@@ -6080,19 +5473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PO10039TAQ-10172MK3 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-10172MK3
   os_family: Android
   browser_family: Chrome
@@ -6100,19 +5491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PO9659TAQ-10182 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-10182
   os_family: Android
   browser_family: Chrome
@@ -6120,19 +5509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; PO11141TAQ-10242MK2 Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-10242MK2
   os_family: Android
   browser_family: Chrome
@@ -6140,19 +5527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PO9818TAQ-70242 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-70242
   os_family: Android
   browser_family: Chrome
@@ -6160,19 +5545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PO10044TAQ-70242MK2 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DE
+    brand: Denver
     model: TAQ-70242MK2
   os_family: Android
   browser_family: Chrome
@@ -6180,19 +5563,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0; Touch; MDDCJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -6200,19 +5581,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; Dell Streak Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Streak
   os_family: Android
   browser_family: Android Browser
@@ -6220,19 +5599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.2; en-us; Dell Streak 7 Build/FRG83G) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Streak 7
   os_family: Android
   browser_family: Android Browser
@@ -6240,19 +5617,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venue 10 7040) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36 OPR/55.1.2719.50626
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "55.1.2719.50626"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 10 7040
   os_family: Android
   browser_family: Opera
@@ -6260,19 +5635,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Venue 7 3730 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 7 3730
   os_family: Android
   browser_family: Chrome
@@ -6280,19 +5653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Venue7 3740 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 7 3740
   os_family: Android
   browser_family: Chrome
@@ -6300,19 +5671,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Venue 8 3830 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 8 3830
   os_family: Android
   browser_family: Chrome
@@ -6320,19 +5689,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Venue 8 7840) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 8 7840
   os_family: Android
   browser_family: Chrome
@@ -6340,19 +5707,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Venue 8 HSPA+ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DL
+    brand: Dell
     model: Venue 8 HSPA+
   os_family: Android
   browser_family: Chrome
@@ -6360,19 +5725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; AirTab P970g Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: DN
+    brand: DNS
     model: AirTab P970g
   os_family: Android
   browser_family: Chrome
@@ -6380,19 +5743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; DNS AirTab PF7001 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.74 Safari/537.36 OPR/28.0.1764.89981
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "28.0.1764.89981"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DN
+    brand: DNS
     model: AirTab PF7001
   os_family: Android
   browser_family: Opera
@@ -6400,19 +5761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; DEXP Ursus 9EV 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.68 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.68"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus 9EV 3G
   os_family: Android
   browser_family: Chrome
@@ -6420,19 +5779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Ursus NS370i) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus NS370i
   os_family: Android
   browser_family: Chrome
@@ -6440,19 +5797,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Ursus TS170) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus TS170
   os_family: Android
   browser_family: Chrome
@@ -6460,19 +5815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Ursus TS197 Navis) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus TS197 Navis
   os_family: Android
   browser_family: Chrome
@@ -6480,19 +5833,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; VA110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 YaBrowser/19.10.1.100.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.10.1.100.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus VA110
   os_family: Android
   browser_family: Unknown
@@ -6500,19 +5851,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; VA210) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.2.121.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.2.121.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: DX
+    brand: DEXP
     model: Ursus VA210
   os_family: Android
   browser_family: Unknown
@@ -6520,19 +5869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Playpad 3G GOO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: E0
+    brand: EvroMedia
     model: Play Pad 3G Goo
   os_family: Android
   browser_family: Chrome
@@ -6540,19 +5887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PlayPad 3GTab XL Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: E0
+    brand: EvroMedia
     model: Play Pad 3G Tab XL
   os_family: Android
   browser_family: Chrome
@@ -6560,19 +5905,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; EVROMEDIA Play Pad PRO Build/LMY48Y) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: E0
+    brand: EvroMedia
     model: Play Pad Pro
   os_family: Android
   browser_family: Chrome
@@ -6580,19 +5923,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Energyi8Dual Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E1
+    brand: Energy Sistem
     model: i8Dual
   os_family: Android
   browser_family: Android Browser
@@ -6600,19 +5941,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ENERGY s10 DUAL Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E1
+    brand: Energy Sistem
     model: s10 DUAL
   os_family: Android
   browser_family: Android Browser
@@ -6620,19 +5959,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Energy x10 QUAD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E1
+    brand: Energy Sistem
     model: x10 QUAD
   os_family: Android
   browser_family: Android Browser
@@ -6640,19 +5977,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; GoTab GBT9 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 '
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E7
+    brand: Ergo
     model: GoTab GBT9
   os_family: Android
   browser_family: Android Browser
@@ -6660,19 +5995,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; GoTab Gti8 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E7
+    brand: Ergo
     model: GoTab GTi8
   os_family: Android
   browser_family: Android Browser
@@ -6680,19 +6013,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Ergo Tab Crystal Lite Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E7
+    brand: Ergo
     model: Tab Crystal Lite
   os_family: Android
   browser_family: Android Browser
@@ -6700,19 +6031,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Ergo Tab Hero II Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: E7
+    brand: Ergo
     model: Tab Hero II
   os_family: Android
   browser_family: Android Browser
@@ -6720,19 +6049,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme X80 Dual Core Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EB
+    brand: E-Boda
     model: Supreme X80 Dual Core
   os_family: Android
   browser_family: Android Browser
@@ -6740,19 +6067,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; E-Boda Supreme XL200IPS Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EB
+    brand: E-Boda
     model: Supreme XL200IPS
   os_family: Android
   browser_family: Android Browser
@@ -6760,19 +6085,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TAB101 3G Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB101 3G
   os_family: Android
   browser_family: Chrome
@@ -6780,19 +6103,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; bg-bg; TAB708 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB708
   os_family: Android
   browser_family: Android Browser
@@ -6800,19 +6121,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; TAB716 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB716
   os_family: Android
   browser_family: Chrome
@@ -6820,19 +6139,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB728 3G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB728 3G
   os_family: Android
   browser_family: Chrome
@@ -6840,19 +6157,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TAB730 Build/LMY47I AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.103 YaBrowser/18.7.0.823.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.7.0.823.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB730
   os_family: Android
   browser_family: Unknown
@@ -6860,19 +6175,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; TAB733 Build/LMY48G AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB733
   os_family: Android
   browser_family: Chrome
@@ -6880,19 +6193,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TAB738 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB738
   os_family: Android
   browser_family: Chrome
@@ -6900,19 +6211,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TAB740 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EG
+    brand: Elenberg
     model: TAB740
   os_family: Android
   browser_family: Chrome
@@ -6920,19 +6229,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; EasyPad 971 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EP
+    brand: Easypix
     model: EasyPad 971
   os_family: Android
   browser_family: Android Browser
@@ -6940,19 +6247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TA10CA3 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ES
+    brand: ECS
     model: TA10CA3
   os_family: Android
   browser_family: Chrome
@@ -6960,19 +6265,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TM105 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ES
+    brand: ECS
     model: TM105
   os_family: Android
   browser_family: Chrome
@@ -6980,19 +6283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TM105A Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ES
+    brand: ECS
     model: TM105A
   os_family: Android
   browser_family: Chrome
@@ -7000,19 +6301,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TR10CS1 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.122 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.122"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ES
+    brand: ECS
     model: TR10CS1
   os_family: Android
   browser_family: Chrome
@@ -7020,19 +6319,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ET7002C-H12 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EU
+    brand: Eurostar
     model: ePad 4S
   os_family: Android
   browser_family: Android Browser
@@ -7040,19 +6337,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; E7020HD Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EV
+    brand: Evertek
     model: Everpad E7020HD
   os_family: Android
   browser_family: Android Browser
@@ -7060,19 +6355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; E7050HD Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: EV
+    brand: Evertek
     model: Everpad E7050HD
   os_family: Android
   browser_family: Chrome
@@ -7080,19 +6373,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; E8050HG Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EV
+    brand: Evertek
     model: Everpad E8050HG
   os_family: Android
   browser_family: Android Browser
@@ -7100,19 +6391,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; E8051HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EV
+    brand: Evertek
     model: Everpad E8051HD
   os_family: Android
   browser_family: Chrome
@@ -7120,19 +6409,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; ActiveD 7.4 3G Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.131 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.131"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: ActiveD 7.4 3G
   os_family: Android
   browser_family: Chrome
@@ -7140,19 +6427,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; ru; ActiveD_8.2_3G) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: ActiveD 8.2 3G
   os_family: Android
   browser_family: Unknown
@@ -7160,19 +6445,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.2.1; CinemaTV 3G Build/JOP40D[20140225.095826]) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.86 YaBrowser/15.12.2.6773.01 Yowser/2.5.2 Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.12.2.6773.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: CinemaTV 3G
   os_family: Android
   browser_family: Unknown
@@ -7180,19 +6463,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Imperium7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Imperium 7 3G
   os_family: Android
   browser_family: Chrome
@@ -7200,19 +6481,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Imperium8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Imperium 8 3G
   os_family: Android
   browser_family: Chrome
@@ -7220,19 +6499,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Infinityll Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.2959.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.2959.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Infinity II
   os_family: Android
   browser_family: Chrome
@@ -7240,19 +6517,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Informer 705 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.65583
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "16.0.1212.65583"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Informer 705
   os_family: Android
   browser_family: Opera
@@ -7260,19 +6535,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-au; Informer 706 3G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Informer 706 3G
   os_family: Android
   browser_family: Android Browser
@@ -7280,19 +6553,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Informer 921 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Informer 921
   os_family: Android
   browser_family: Android Browser
@@ -7300,19 +6571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Leader Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Leader
   os_family: Android
   browser_family: Chrome
@@ -7320,19 +6589,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; Onliner1 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/136E72
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Onliner 1
   os_family: Android
   browser_family: Android Browser
@@ -7340,19 +6607,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Onliner2 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 YaBrowser/15.4.2272.3842.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.4.2272.3842.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Onliner 2
   os_family: Android
   browser_family: Unknown
@@ -7360,19 +6625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Onliner3 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.110 YaBrowser/16.4.0.9404.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "16.4.0.9404.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Onliner 3
   os_family: Android
   browser_family: Unknown
@@ -7380,19 +6643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; sQuad 10.06 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 YaBrowser/14.10.2062.11375.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.10.2062.11375.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: sQuad 10.06 3G
   os_family: Android
   browser_family: Unknown
@@ -7400,19 +6661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; sQuad 7.82 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: sQuad 7.82 3G
   os_family: Android
   browser_family: Chrome
@@ -7420,19 +6679,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; Surfer 10.11 Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Surfer 10.11
   os_family: Android
   browser_family: Android Browser
@@ -7440,19 +6697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Surfer 7.32 3G Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: EX
+    brand: Explay
     model: Surfer 7.32 3G
   os_family: Android
   browser_family: Chrome
@@ -7460,19 +6715,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; FinePower A1 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: F1
+    brand: FinePower
     model: A1
   os_family: Android
   browser_family: Android Browser
@@ -7480,19 +6733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FinePower A2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36 OPR/52.3.2517.140547
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "52.3.2517.140547"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: F1
+    brand: FinePower
     model: A2
   os_family: Android
   browser_family: Opera
@@ -7500,19 +6751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FinePower B1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: F1
+    brand: FinePower
     model: B1
   os_family: Android
   browser_family: Chrome
@@ -7520,19 +6769,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FinePower B2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: F1
+    brand: FinePower
     model: B2
   os_family: Android
   browser_family: Chrome
@@ -7540,19 +6787,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; FinePower B3 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: F1
+    brand: FinePower
     model: B3
   os_family: Android
   browser_family: Android Browser
@@ -7560,19 +6805,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q008B Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: Q008B
   os_family: Android
   browser_family: Chrome
@@ -7580,19 +6823,17 @@
   user_agent: Mozilla/5.0(Linux; Android 4.4.2; Q010B Build/KOT49H)AppleWebKit/537.36(KHTML, like Gecko)Chrome/61.0.3163.98Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: Q010B
   os_family: Android
   browser_family: Chrome
@@ -7600,19 +6841,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Q718B Build/HDQ718B) AppleWebKit/537.36 (KHTML. like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: Q718B
   os_family: Android
   browser_family: Chrome
@@ -7620,19 +6859,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Q902 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: Q902
   os_family: Android
   browser_family: Chrome
@@ -7640,19 +6877,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T707G Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: T707G
   os_family: Android
   browser_family: Chrome
@@ -7660,19 +6895,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; T708B) U2/1.0.0 UCBrowser/10.2.1.612 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.1.612"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: T708B
   os_family: Android
   browser_family: Unknown
@@ -7680,19 +6913,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T725B Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: T725B
   os_family: Android
   browser_family: Chrome
@@ -7700,19 +6931,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T725B1 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: T725B
   os_family: Android
   browser_family: Chrome
@@ -7720,19 +6949,17 @@
   user_agent: Mozilla/5.0(Linux; Android 4.4.2; T907B Build/KVT49L)AppleWebKit/537.36(KHTML, like Gecko)Version/4.0Chrome/30.0.0.0Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: FD
+    brand: Fondi
     model: T907B
   os_family: Android
   browser_family: Android Browser
@@ -7740,19 +6967,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.12; vKB004L Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.12"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FE
+    brand: Fengxiang
     model: vKB004L
   os_family: Android
   browser_family: Chrome
@@ -7760,19 +6985,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.12; vKB011B Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.12"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FE
+    brand: Fengxiang
     model: vKB011B
   os_family: Android
   browser_family: Chrome
@@ -7780,19 +7003,17 @@
   user_agent: Mozzila/5.0(Linux; U; Android 4.2.2; ru-ru; Flylife Connect 7 3G Build/JDQ39) AppleWebKit/534.30(KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: FL
+    brand: Fly
     model: Flylife Connect 7 3G
   os_family: Android
   browser_family: Android Browser
@@ -7800,19 +7021,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; Ru-ru; FLY_IQ310 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: FL
+    brand: Fly
     model: Panorama
   os_family: Android
   browser_family: Android Browser
@@ -7820,19 +7039,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; F-02F Build/V19R63A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FU
+    brand: Fujitsu
     model: Arrows Tab F-02F
   os_family: Android
   browser_family: Chrome
@@ -7840,19 +7057,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; F-02K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FU
+    brand: Fujitsu
     model: Arrows Tab F-02K
   os_family: Android
   browser_family: Chrome
@@ -7860,19 +7075,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; F-05E Build/V18R41A) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: FU
+    brand: Fujitsu
     model: Arrows Tab F-05E
   os_family: Android
   browser_family: Android Browser
@@ -7880,19 +7093,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; FARTM933KZ Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: FU
+    brand: Fujitsu
     model: Arrows Tab M504/HA4
   os_family: Android
   browser_family: Android Browser
@@ -7900,19 +7111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; M532 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: FU
+    brand: Fujitsu
     model: Stylistic
   os_family: Android
   browser_family: Chrome
@@ -7920,19 +7129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GU1011C Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: G4
+    brand: Globex
     model: GU1011C
   os_family: Android
   browser_family: Chrome
@@ -7940,19 +7147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GU-6012B Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: G4
+    brand: Globex
     model: GU6012B
   os_family: Android
   browser_family: Opera
@@ -7960,19 +7165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GU7013C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: G4
+    brand: Globex
     model: GU7013C
   os_family: Android
   browser_family: Chrome
@@ -7980,19 +7183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GU730C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: G4
+    brand: Globex
     model: GU730C
   os_family: Android
   browser_family: Chrome
@@ -8000,19 +7201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; GU8012C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: G4
+    brand: Globex
     model: X8
   os_family: Android
   browser_family: Chrome
@@ -8020,19 +7219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARIES_101 Build/GOCLEVER) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.169"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: ARIES 101
   os_family: Android
   browser_family: Chrome
@@ -8040,19 +7237,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; ELIPSO_71 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: ELIPSO 71
   os_family: Android
   browser_family: Android Browser
@@ -8060,19 +7255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; INSIGNIA_1010M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 1010M
   os_family: Android
   browser_family: Chrome
@@ -8080,19 +7273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; INSIGNIA_785_PRO Build/GOCLEVER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 785 PRO
   os_family: Android
   browser_family: Chrome
@@ -8100,19 +7291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; INSIGNIA_800M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: INSIGNIA 800M
   os_family: Android
   browser_family: Chrome
@@ -8120,19 +7309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; LIBRA 97 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: Libra 97
   os_family: Android
   browser_family: Chrome
@@ -8140,19 +7327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; ORION_102 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: ORION 102
   os_family: Android
   browser_family: Android Browser
@@ -8160,19 +7345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUANTUM_1010M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 1010M
   os_family: Android
   browser_family: Chrome
@@ -8180,19 +7363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUANTUM_1010N Build/GOCLEVER) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 1010N
   os_family: Android
   browser_family: Chrome
@@ -8200,19 +7381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TQ700N Build/GOCLEVER) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 700N
   os_family: Android
   browser_family: Chrome
@@ -8220,19 +7399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUANTUM_900 Build/GOCLEVER) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: QUANTUM 900
   os_family: Android
   browser_family: Chrome
@@ -8240,19 +7417,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; GOCLEVER TAB M723G Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: TAB M723G
   os_family: Android
   browser_family: Android Browser
@@ -8260,19 +7435,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; GOCLEVER TAB R106 Build/FR-MX68) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: TAB R106
   os_family: Android
   browser_family: Android Browser
@@ -8280,19 +7453,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; cs-cz; GOCLEVER TAB R70 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: TAB R70
   os_family: Android
   browser_family: Android Browser
@@ -8300,19 +7471,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; GOCLEVER TAB T76 Build/MID) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GC
+    brand: GOCLEVER
     model: TAB T76
   os_family: Android
   browser_family: Android Browser
@@ -8320,19 +7489,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; GEM10313BK Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GD
+    brand: Gemini
     model: GEM10313BK
   os_family: Android
   browser_family: Android Browser
@@ -8340,19 +7507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; GEM10313S Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GD
+    brand: Gemini
     model: GEM10313S
   os_family: Android
   browser_family: Android Browser
@@ -8360,19 +7525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; GEM7008 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GD
+    brand: Gemini
     model: GEM7008
   os_family: Android
   browser_family: Android Browser
@@ -8380,19 +7543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; GEM7020 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GD
+    brand: Gemini
     model: GEM7020
   os_family: Android
   browser_family: Android Browser
@@ -8400,19 +7561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; GEM7032G-rev2 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: GD
+    brand: Gemini
     model: GEM7032G
   os_family: Android
   browser_family: Chrome
@@ -8420,19 +7579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; GHIA_AXIS7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GH
+    brand: Ghia
     model: Axis 7
   os_family: Android
   browser_family: Chrome
@@ -8440,19 +7597,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-gb; Nexus 10 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 10
   os_family: Android
   browser_family: Android Browser
@@ -8460,19 +7615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Nexus 10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 10
   os_family: Android
   browser_family: Chrome
@@ -8480,19 +7633,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Ainovo Flame (Nexus 7) Build/JRO03D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Android Browser
@@ -8500,19 +7651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2; vi-vn; Nexus 7 Build/JVP15S) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Android Browser
@@ -8520,19 +7669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Chrome
@@ -8540,19 +7687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Nexus 7 2013 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Chrome
@@ -8560,19 +7705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; zh-cn; Nexus 7 Build/JOP40D; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Android Browser
@@ -8580,19 +7723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Nexus 7 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 CyanogenMod/10.1.0/grouper
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 7
   os_family: Android
   browser_family: Android Browser
@@ -8600,19 +7741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Nexus 9 Build/LRX21F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.509 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.509"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Nexus 9
   os_family: Android
   browser_family: Chrome
@@ -8620,19 +7759,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.1.1; Pixel C Build/N4F26I)
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: GO
+    brand: Google
     model: Pixel C
   os_family: Android
   browser_family: Android Browser
@@ -8640,19 +7777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Gigaset QV1030 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: GS
+    brand: Gigaset
     model: Gigaset QV1030
   os_family: Android
   browser_family: Android Browser
@@ -8660,19 +7795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Gigaset QV830 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GS
+    brand: Gigaset
     model: Gigaset QV830
   os_family: Android
   browser_family: Chrome
@@ -8680,19 +7813,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; GR-TB10S Build/ICS.GR-TB10S.20130322) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: GU
+    brand: Grundig
     model: GR-TB10S
   os_family: Android
   browser_family: Chrome
@@ -8700,19 +7831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ginzzu GT-1050) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-1050
   os_family: Android
   browser_family: Chrome
@@ -8720,19 +7849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-7010 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7010
   os_family: Android
   browser_family: Chrome
@@ -8740,19 +7867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-7020 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7020
   os_family: Android
   browser_family: Chrome
@@ -8760,19 +7885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-7030 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7030
   os_family: Android
   browser_family: Chrome
@@ -8780,19 +7903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-7040) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7040
   os_family: Android
   browser_family: Chrome
@@ -8800,19 +7921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ginzzu GT-7105 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7105
   os_family: Android
   browser_family: Chrome
@@ -8820,19 +7939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; Ginzzu GT-7115 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.2.1188 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.2.1188"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7115
   os_family: Android
   browser_family: Unknown
@@ -8840,19 +7957,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; Ginzzu GT-7210 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.2.1184 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.2.1184"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7210
   os_family: Android
   browser_family: Unknown
@@ -8860,19 +7975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-7810 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-7810
   os_family: Android
   browser_family: Chrome
@@ -8880,19 +7993,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; Ginzzu GT-8010 Build/LMY47D AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36 YandexSearch/7.80/apad YandexSearchBrowser/7.80
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-8010
   os_family: Android
   browser_family: Chrome
@@ -8900,19 +8011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ginzzu GT-8110) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-8110
   os_family: Android
   browser_family: Chrome
@@ -8920,19 +8029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-W831) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-W831
   os_family: Android
   browser_family: Chrome
@@ -8940,19 +8047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; Ginzzu_GT-X770 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.8.1206 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.8.1206"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-X770
   os_family: Android
   browser_family: Unknown
@@ -8960,19 +8065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Ginzzu GT-X831 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.169 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.169"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: GZ
+    brand: Ginzzu
     model: GT-X831
   os_family: Android
   browser_family: Chrome
@@ -8980,19 +8083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PAD D71 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HA
+    brand: Haier
     model: D71
   os_family: Android
   browser_family: Chrome
@@ -9000,19 +8101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PAD G781 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HA
+    brand: Haier
     model: G781
   os_family: Android
   browser_family: Chrome
@@ -9020,19 +8119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HSG1316 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: HSG1316
   os_family: Android
   browser_family: Chrome
@@ -9040,19 +8137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SN1AT71W(B) Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SN1AT71W(B)
   os_family: Android
   browser_family: Chrome
@@ -9060,19 +8155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; SN70T3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SN70T3
   os_family: Android
   browser_family: Android Browser
@@ -9080,19 +8173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; SN70T31 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SN70T31
   os_family: Android
   browser_family: Android Browser
@@ -9100,19 +8191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-au; SN70T51A Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SN70T51A
   os_family: Android
   browser_family: Android Browser
@@ -9120,19 +8209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SN97T41W Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SN97T41W
   os_family: Android
   browser_family: Chrome
@@ -9140,19 +8227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; T7-QC Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HE
+    brand: HannSpree
     model: SNAT71BUE
   os_family: Android
   browser_family: Android Browser
@@ -9160,19 +8245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-ca; E270BSA Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HI
+    brand: Hisense
     model: Sero 7
   os_family: Android
   browser_family: Android Browser
@@ -9180,19 +8263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-gb; M470BSA Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HI
+    brand: Hisense
     model: Sero 7 Pro
   os_family: Android
   browser_family: Android Browser
@@ -9200,19 +8281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; M470BSE Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.66961
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "18.0.1290.66961"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HI
+    brand: Hisense
     model: Sero 7 Pro
   os_family: Android
   browser_family: Opera
@@ -9220,19 +8299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; E2281 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36/TansoDL
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HI
+    brand: Hisense
     model: Sero 8
   os_family: Android
   browser_family: Chrome
@@ -9240,19 +8317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; HLV-T1002W Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HL
+    brand: Hi-Level
     model: HLV-T1002W
   os_family: Android
   browser_family: Android Browser
@@ -9260,19 +8335,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; tr-tr; HLV-T702 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HL
+    brand: Hi-Level
     model: HLV-T702
   os_family: Android
   browser_family: Android Browser
@@ -9280,19 +8353,17 @@
   user_agent: Android 4.0.4;AppleWebKit/537.22;Build/HLV-T704.7201.SML.2-2-2-HL.20130314;HLV-T704 Build/HLV-T704.7201.SML.2-2-2-HL.20130314
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: HL
+    brand: Hi-Level
     model: HLV-T704
   os_family: Android
   browser_family: Android Browser
@@ -9300,19 +8371,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; HLV-TN75 Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: HL
+    brand: Hi-Level
     model: HLV-TN75
   os_family: Android
   browser_family: Android Browser
@@ -9320,19 +8389,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; el-gr; HYUNDAI T10 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HN
+    brand: Hyundai
     model: T10
   os_family: Android
   browser_family: Android Browser
@@ -9340,19 +8407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HYUNDAI T7S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HN
+    brand: Hyundai
     model: T7S
   os_family: Android
   browser_family: Chrome
@@ -9360,13 +8425,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP 10 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
@@ -9380,7 +8443,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Compaq 7 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -9397,13 +8459,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Compaq 8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 LieBaoFast/3.17.4
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: LieBaoFast
-    short_name: LF
     version: "3.17.4"
     engine: WebKit
     engine_version: "534.30"
@@ -9417,13 +8477,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; HP Pro Slate 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
@@ -9437,13 +8495,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HP Slate 10 HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
@@ -9457,13 +8513,11 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.1; HP Slate 7 Build/JRO03H) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
@@ -9477,13 +8531,11 @@
   user_agent: Kik/7.1.0.83 (Android 4.1.2) Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; HP 7 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -9497,13 +8549,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; HP 7 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -9517,13 +8567,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HP Slate7 Extreme Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.169"
     engine: WebKit
     engine_version: "537.22"
@@ -9537,13 +8585,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP 7 G2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
@@ -9557,13 +8603,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HP 7 Plus Build/1.1.3_WW-ILEX-13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
@@ -9577,13 +8621,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; HP Slate 7 Plus Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
@@ -9597,13 +8639,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP 7 Plus G2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
@@ -9617,13 +8657,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP 7 VoiceTab) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
@@ -9637,13 +8675,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; HP 8 Build/1.0.7_WW-FIR-13) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -9657,13 +8693,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; HP 8 G2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
@@ -9677,13 +8711,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; HP Slate 8 Pro Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -9697,13 +8729,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; HP SlateBook 10 x2 PC Build/4.3-17r20-03-23) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
@@ -9717,13 +8747,11 @@
   user_agent: Mozilla/5.0 (hp-tablet; Linux; hpwOS/3.0.5; U; en-US) AppleWebKit/534.6 (KHTML, like Gecko) wOSBrowser/234.83 Safari/534.6 TouchPad/1.0
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: wOSBrowser
-    short_name: WO
     version: "3.0.5"
     engine: WebKit
     engine_version: "534.6"
@@ -9737,19 +8765,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; en-za;Sprint ATP515CKIT Build/HTK75C) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: ATP515CKIT (Sprint)
   os_family: Android
   browser_family: Android Browser
@@ -9757,19 +8783,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; HTC Flyer Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: Flyer
   os_family: Android
   browser_family: Android Browser
@@ -9777,19 +8801,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; el-gr; HTC_Flyer_P510e Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: Flyer P510e
   os_family: Android
   browser_family: Android Browser
@@ -9797,19 +8819,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; HTC_Flyer_P510e; pl-pl) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16
   os:
     name: Mac
-    short_name: MAC
     version: "10.6.3"
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "5.0"
     engine: WebKit
     engine_version: "533.16"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: Flyer P510e
   os_family: Mac
   browser_family: Safari
@@ -9817,19 +8837,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; HTC Flyer P512 Build/JRO03C; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: Flyer P512
   os_family: Android
   browser_family: Android Browser
@@ -9837,19 +8855,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; HTC_Flyer_P512; pl-gb) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16
   os:
     name: Mac
-    short_name: MAC
     version: "10.6.3"
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "5.0"
     engine: WebKit
     engine_version: "533.16"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: Flyer P512
   os_family: Mac
   browser_family: Safari
@@ -9857,7 +8873,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; zh-tw; HTC-P715a Build/HMJ15) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13 baiduboxapp/4.7.1 (Baidu; P1 3.1)
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
@@ -9866,7 +8881,7 @@
     version: "4.7.1"
   device:
     type: tablet
-    brand: HT
+    brand: HTC
     model: P715a
   os_family: Android
   browser_family: Unknown
@@ -9874,19 +8889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BZA-W00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: C3 9.6
   os_family: Android
   browser_family: Chrome
@@ -9894,19 +8907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; d-02H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: D Tab Compact
   os_family: Android
   browser_family: Chrome
@@ -9914,19 +8925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; d-01J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: D Tab Compact
   os_family: Android
   browser_family: Chrome
@@ -9934,19 +8943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; d-02K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: D Tab Compact
   os_family: Android
   browser_family: Chrome
@@ -9954,19 +8961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AGS2-AL00 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Enjoy Tablet 10.1
   os_family: Android
   browser_family: Chrome
@@ -9974,19 +8979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; JDN-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Pad 2
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/tablet-2.yml
+++ b/Tests/fixtures/tablet-2.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; JDN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Pad 2
   os_family: Android
   browser_family: Chrome
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AGS2-AL00HN Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Tab 5
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; zh-Hans-CN; JDN2-W09HN Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Quark/3.1.1.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "3.1.1.105"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Tab 5
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HDN-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Water Play 10.1
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; HDN-L09 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Water Play 10.1
   os_family: Android
   browser_family: Chrome
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; HDL-AL09 Build/XXXXX HDL-AL09) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Water Play 8.0
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; HDL-W09 Build/XXXXX HDL-W09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Honor Water Play 8.0
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; BAH3-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MatePad 10.4
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MON-W19 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MatePad C5 8
   os_family: Android
   browser_family: Android Browser
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MON-AL19 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MatePad C5 8
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MRX-AL09 Build/HUAWEIMRX-AL09; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MatePad Pro
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; MRX-W09 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MatePad Pro
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fa-ir; HUAWEI MediaPad Build/HuaweiMediaPad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad
   os_family: Android
   browser_family: Android Browser
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MediaPad 10 FHD Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 10 FHD
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; MediaPad 10 LINK Build/HuaweiMediaPad) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 10 LINK
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; MediaPad 7 Lite Build/HuaweiMediaPad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 7 Lite
   os_family: Android
   browser_family: Android Browser
@@ -323,19 +291,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.3; MediaPad 7 Lite Build/HuaweiMediaPad) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 7 Lite
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; MediaPad 7 Vogue Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 7 Vogue
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; MediaPad 7 Youth Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad 7 Youth
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BZT-AL00 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad C5 10.1
   os_family: Android
   browser_family: Android Browser
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BZT-AL10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad C5 10.1
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; HUAWEI M2-801L Build/HUAWEIM2-801L)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M2 8.0"
   os_family: Android
   browser_family: Android Browser
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BTV-DL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BTV-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 8
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BAH-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CPN-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CPN-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CPN-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BAH-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite 10
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BAH-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite 10
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; BAH3-W09 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M3 Lite 10
   os_family: Android
   browser_family: Chrome
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; CMR-AL19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 10.8
   os_family: Android
   browser_family: Chrome
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; CMR-AL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 10.8
   os_family: Android
   browser_family: Chrome
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; CMR-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 10.8
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHT-AL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 8.4
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; SHT-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 8.4
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BAH2-AL00 Build/XXXXX BAH2-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Android Browser
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BAH2-AL10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.0.0; BAH2-W19) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.6.137.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.6.137.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Unknown
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; arm_64; Android 8.0.0; BAH2-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.7.115.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.7.115.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Unknown
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JDN2-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Chrome
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JDN2-AL00) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JDN2-AL50 Build/XXXXX JDN2-AL50; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Chrome
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; JDN2-W09 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Lite
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SCM-AL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Pro
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; CMR-W19 Build/XXXXX CMR-W19; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M5 Pro 10.8
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SCM-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M6 10
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VRD-AL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M6 8.4
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VRD-AL10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M6 8.4
   os_family: Android
   browser_family: Chrome
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; VRD-W09 Build/HUAWEIVRD-W09) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.64 HuaweiBrowser/10.0.1.333 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Huawei Browser
-    short_name: HU
     version: "10.0.1.333"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M6 8.4
   os_family: Android
   browser_family: Unknown
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; VRD-W10 Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad M6 8.4
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T1-A21w Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 10
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T1-A21w) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 10
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T1-A21L Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 10
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; T1-A21L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 10
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; T1-A23L Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 10
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T1-701u) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3970.3 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3970.3"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 7
   os_family: Android
   browser_family: Chrome
@@ -1143,19 +1029,17 @@
   user_agent: mozilla/5.0 (linux; android 4.3; mediapad t1 8.0) applewebkit/537.36 (khtml, like gecko) chrome/70.0.3538.110 safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 8
   os_family: Android
   browser_family: Chrome
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T1-821w Build/XXXXX MediaPad; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 8
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; zh-CN; T1-823L Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.7.1077 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.7.1077"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T1 8
   os_family: Android
   browser_family: Unknown
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; FDR-A01L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 10.0" Pro
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; FDR-A01w) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 10.0" Pro
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; FDR-A03L Build/XXXXX; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 10.0" Pro
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: 'Mozilla/5.0 (Linux;Android 6.0.1;605HW Build/<buildID>)AppleWebKit/53 7.36(KHTML,like Gecko)Chrome/55.0.2883.91 Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 10.0" Pro
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BGO-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 7.0
   os_family: Android
   browser_family: Chrome
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; zh-CN; PLE-703L Build/HuaweiMediaPad) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 7.0 Pro
   os_family: Android
   browser_family: Android Browser
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PLE-701L Build/HuaweiMediaPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 7.0 Pro
   os_family: Android
   browser_family: Chrome
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BGO-DL09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 7.0 Pro
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; JDN-L01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T2 8.0 Pro
   os_family: Android
   browser_family: Chrome
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AGS-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 10
   os_family: Android
   browser_family: Chrome
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AGS-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 10
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AGS-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 10
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; BG2-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 7
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BG2-U03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 7
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BG2-U01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 7
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BZK-W00 Build/XXXXX) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 8
   os_family: Android
   browser_family: Android Browser
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KOB-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 8
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KOB-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 8
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BZK-L00 Build/XXXXX BZK-L00; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/56.0.2924.87 Mobile Safari/537.36 SogouMSE,SogouMobileBrowser/5.23.53
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Sogou Mobile Browser
-    short_name: SO
     version: "5.23.53"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T3 8
   os_family: Android
   browser_family: Safari
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AGS2-L09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T5 10
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AGS2-W09) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T5 10
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; AGS2-L03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad T5 10
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; GEM-701L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad X2
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GEM-703L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad X2
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; GEM-702L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: MediaPad X2
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; HWT31 Build/Federer)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: HU
+    brand: Huawei
     model: Qua Tab 02 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 1001-G Go Build/OPM2.171019.012; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HW
+    brand: How
     model: HT-1001G Go Kids
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; 705-G Go Build/OPM2.171019.012)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: HW
+    brand: How
     model: HT-705-G Go
   os_family: Android
   browser_family: Android Browser
@@ -1763,19 +1587,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; HT-705XS Build/PPR1.181005.003)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: HW
+    brand: How
     model: HT-705XS
   os_family: Android
   browser_family: Android Browser
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Hoozo MT Pad 116 LTE Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HZ
+    brand: Hoozo
     model: MT Pad 116 LTE
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0; Hoozo MT116 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Safari/537.36 OPR/44.1.2254.142553
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.142553"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HZ
+    brand: Hoozo
     model: MT116
   os_family: Android
   browser_family: Opera
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; HOOZO MT232 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HZ
+    brand: Hoozo
     model: MT232
   os_family: Android
   browser_family: Chrome
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Hoozo_X1001 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: HZ
+    brand: Hoozo
     model: X1001
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-3702M Build/JRO03C AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Matrix 3G duo
   os_family: Android
   browser_family: Android Browser
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-3703M Build/JRO03C AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Matrix 3GT
   os_family: Android
   browser_family: Android Browser
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-3601P/3602P Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "29.0.1547.72"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Pocket 3G
   os_family: Android
   browser_family: Chrome
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-3603P Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Pocket 3G Slim
   os_family: Android
   browser_family: Chrome
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-3805C Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Skat 3G quad
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-0805C Build/JRO03C AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Skat MX
   os_family: Android
   browser_family: Android Browser
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; en-US; NT-3701S Build/JRO03C AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.8.8.1140 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.8.8.1140"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Sky 3G duo
   os_family: Android
   browser_family: Unknown
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-3702S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Sky HD 3G
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-0704S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Sky LE
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-0701S Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Sky net
   os_family: Android
   browser_family: Android Browser
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-0902S Build/NT-0902S AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Space quad RX
   os_family: Android
   browser_family: Android Browser
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-1017T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor 3G quad
   os_family: Android
   browser_family: Chrome
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-0909T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor IZ
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NT-1001T Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor LE
   os_family: Android
   browser_family: Android Browser
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-1011T Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.169 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.169"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor LE
   os_family: Android
   browser_family: Chrome
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-1009T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor quad II
   os_family: Android
   browser_family: Chrome
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NT-3905T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I2
+    brand: IconBIT
     model: NetTAB Thor ZX 3G
   os_family: Android
   browser_family: Chrome
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ImPad0113 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 YaBrowser/14.12.2125.9740.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.12.2125.9740.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 0113
   os_family: Android
   browser_family: Unknown
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImPAD0314 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 0314
   os_family: Android
   browser_family: Chrome
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ImPAD_0413 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 0413
   os_family: Android
   browser_family: Chrome
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; ImPAD 1002 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1002
   os_family: Android
   browser_family: Android Browser
@@ -2283,19 +2055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImPad1005 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1005
   os_family: Android
   browser_family: Chrome
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ImPad 1006v2 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1006v2
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; uk-ua; ImPAD 1113 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1113
   os_family: Android
   browser_family: Android Browser
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; ru-ru; ImPAD1311 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1311
   os_family: Android
   browser_family: Android Browser
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; uk-ua; ImPAD 1412 Build/FR-MX68) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1412
   os_family: Android
   browser_family: Android Browser
@@ -2383,19 +2145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; uk-; ImPAD 1412 rev2 Build/FR-MX68) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 1412 rev2
   os_family: Android
   browser_family: Android Browser
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; ImPAD 2113 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 2113
   os_family: Android
   browser_family: Android Browser
@@ -2423,19 +2181,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.0.4; ImPAD 2412 Build/IMM76D)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 2412
   os_family: Android
   browser_family: Android Browser
@@ -2443,19 +2199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ImPAD_2413 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 2413
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ImPAD 3113 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 3113
   os_family: Android
   browser_family: Chrome
@@ -2483,19 +2235,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ImPAD 3412 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 3412
   os_family: Android
   browser_family: Chrome
@@ -2503,19 +2253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ImPad4113 Build/20130124) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 4113
   os_family: Android
   browser_family: Chrome
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImPad 6015 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 6015
   os_family: Android
   browser_family: Chrome
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Impad6115 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 YaBrowser/15.6.2311.5718.01 Yowser/2.0.2 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.6.2311.5718.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 6115
   os_family: Android
   browser_family: Unknown
@@ -2563,19 +2307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ImPad 6115M Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 6115M
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ImPAD6214 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 6214
   os_family: Android
   browser_family: Chrome
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; ImPAD 8213 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 8213
   os_family: Android
   browser_family: Android Browser
@@ -2623,19 +2361,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; uk-ua; ImPAD 8901 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 8901
   os_family: Android
   browser_family: Android Browser
@@ -2643,19 +2379,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; ImPAD 9213 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 9213
   os_family: Android
   browser_family: Android Browser
@@ -2663,19 +2397,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; ImPAD 9702 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 9702
   os_family: Android
   browser_family: Android Browser
@@ -2683,19 +2415,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; ImPAD 9704 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad 9704
   os_family: Android
   browser_family: Android Browser
@@ -2703,19 +2433,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Impression ImPAD B702 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad B702
   os_family: Android
   browser_family: Chrome
@@ -2723,19 +2451,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ImPad_P104) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I3
+    brand: Impression
     model: ImPad P104
   os_family: Android
   browser_family: Chrome
@@ -2743,19 +2469,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IRBIS TZ01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ01
   os_family: Android
   browser_family: Chrome
@@ -2763,19 +2487,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IRBIS TZ02 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Safari/537.36 OPR/47.0.2249.129167
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "47.0.2249.129167"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ02
   os_family: Android
   browser_family: Opera
@@ -2783,19 +2505,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ100
   os_family: Android
   browser_family: Chrome
@@ -2803,19 +2523,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ104) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ104
   os_family: Android
   browser_family: Chrome
@@ -2823,19 +2541,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; TZ142 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ142
   os_family: Android
   browser_family: Android Browser
@@ -2843,19 +2559,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ150) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ150
   os_family: Android
   browser_family: Chrome
@@ -2863,19 +2577,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ165) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ165
   os_family: Android
   browser_family: Chrome
@@ -2883,19 +2595,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ170) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.2.127.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.2.127.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ170
   os_family: Android
   browser_family: Unknown
@@ -2903,19 +2613,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ171) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ171
   os_family: Android
   browser_family: Chrome
@@ -2923,19 +2631,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ173) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ173
   os_family: Android
   browser_family: Chrome
@@ -2943,19 +2649,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ174) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ174
   os_family: Android
   browser_family: Chrome
@@ -2963,19 +2667,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ175 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ175
   os_family: Android
   browser_family: Chrome
@@ -2983,19 +2685,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ176) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ176
   os_family: Android
   browser_family: Chrome
@@ -3003,19 +2703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ177) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ177
   os_family: Android
   browser_family: Chrome
@@ -3023,19 +2721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ178 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Mobile Safari/537.36 OPR/52.3.2517.140547
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "52.3.2517.140547"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ178
   os_family: Android
   browser_family: Opera
@@ -3043,19 +2739,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ179) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.97 YaBrowser/19.12.1.121.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.12.1.121.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ179
   os_family: Android
   browser_family: Unknown
@@ -3063,19 +2757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ183) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ183
   os_family: Android
   browser_family: Chrome
@@ -3083,19 +2775,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ184 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Safari/537.36 YandexSearch/6.10/apad
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ184
   os_family: Android
   browser_family: Chrome
@@ -3103,19 +2793,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ185) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ185
   os_family: Android
   browser_family: Chrome
@@ -3123,19 +2811,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ186) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ186
   os_family: Android
   browser_family: Chrome
@@ -3143,19 +2829,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ191) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ191
   os_family: Android
   browser_family: Chrome
@@ -3163,19 +2847,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ192) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ192
   os_family: Android
   browser_family: Chrome
@@ -3183,19 +2865,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ195 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Mobile Safari/537.36 OPR/43.3.2254.142003
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "43.3.2254.142003"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ195
   os_family: Android
   browser_family: Opera
@@ -3203,19 +2883,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TZ197) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ197
   os_family: Android
   browser_family: Chrome
@@ -3223,19 +2901,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ198 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.116 Safari/537.36 OPR/44.0.2254.141977
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.0.2254.141977"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ198
   os_family: Android
   browser_family: Opera
@@ -3243,19 +2919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TZ49 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ49
   os_family: Android
   browser_family: Chrome
@@ -3263,19 +2937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IRBIS TZ56) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ56
   os_family: Android
   browser_family: Chrome
@@ -3283,19 +2955,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ712) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.6.137.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.6.137.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ712
   os_family: Android
   browser_family: Unknown
@@ -3303,19 +2973,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ714) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ714
   os_family: Android
   browser_family: Chrome
@@ -3323,19 +2991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ716 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ716
   os_family: Android
   browser_family: Chrome
@@ -3343,19 +3009,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ717) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ717
   os_family: Android
   browser_family: Chrome
@@ -3363,19 +3027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ720
   os_family: Android
   browser_family: Chrome
@@ -3383,19 +3045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ721) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ721
   os_family: Android
   browser_family: Chrome
@@ -3403,19 +3063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ725 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.0.2569.141117
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.0.2569.141117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ725
   os_family: Android
   browser_family: Opera
@@ -3423,19 +3081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ726) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ726
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3099,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ727) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.2.90.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.2.90.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ727
   os_family: Android
   browser_family: Unknown
@@ -3463,19 +3117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ737) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ737
   os_family: Android
   browser_family: Chrome
@@ -3483,19 +3135,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ742 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ742
   os_family: Android
   browser_family: Opera
@@ -3503,19 +3153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ745) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ745
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ747) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ747
   os_family: Android
   browser_family: Chrome
@@ -3543,19 +3189,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ752 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ752
   os_family: Android
   browser_family: Opera
@@ -3563,19 +3207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ753) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ753
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TZ754) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ754
   os_family: Android
   browser_family: Chrome
@@ -3603,19 +3243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TZ757) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36 OPR/55.1.2719.50626
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "55.1.2719.50626"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ757
   os_family: Android
   browser_family: Opera
@@ -3623,19 +3261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ761) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ761
   os_family: Android
   browser_family: Chrome
@@ -3643,19 +3279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ762) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ762
   os_family: Android
   browser_family: Chrome
@@ -3663,19 +3297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ771) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ771
   os_family: Android
   browser_family: Chrome
@@ -3683,19 +3315,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; en-US; TZ772 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1196 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1196"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ772
   os_family: Android
   browser_family: Unknown
@@ -3703,19 +3333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ777) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ777
   os_family: Android
   browser_family: Chrome
@@ -3723,19 +3351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ781 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ781
   os_family: Android
   browser_family: Chrome
@@ -3743,19 +3369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ794) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ794
   os_family: Android
   browser_family: Chrome
@@ -3763,19 +3387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TZ797 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ797
   os_family: Android
   browser_family: Chrome
@@ -3783,19 +3405,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TZ81L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ81L
   os_family: Android
   browser_family: Chrome
@@ -3803,19 +3423,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ831) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ831
   os_family: Android
   browser_family: Chrome
@@ -3823,19 +3441,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ841) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ841
   os_family: Android
   browser_family: Chrome
@@ -3843,19 +3459,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TZ853 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 YaBrowser/15.6.2311.5718.01 Yowser/2.0.2 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.6.2311.5718.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ853
   os_family: Android
   browser_family: Unknown
@@ -3863,19 +3477,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; TZ854 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ854
   os_family: Android
   browser_family: Chrome
@@ -3883,19 +3495,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ855) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ855
   os_family: Android
   browser_family: Chrome
@@ -3903,19 +3513,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ856) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ856
   os_family: Android
   browser_family: Chrome
@@ -3923,19 +3531,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; TZ857 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ857
   os_family: Android
   browser_family: Chrome
@@ -3943,19 +3549,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ858) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 YaBrowser/20.2.0.215.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "20.2.0.215.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ858
   os_family: Android
   browser_family: Unknown
@@ -3963,19 +3567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ864 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ864
   os_family: Android
   browser_family: Chrome
@@ -3983,19 +3585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ865) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ865
   os_family: Android
   browser_family: Chrome
@@ -4003,19 +3603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ872 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ872
   os_family: Android
   browser_family: Chrome
@@ -4023,19 +3621,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ874 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ874
   os_family: Android
   browser_family: Chrome
@@ -4043,19 +3639,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ877) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ877
   os_family: Android
   browser_family: Chrome
@@ -4063,19 +3657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TZ878) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ878
   os_family: Android
   browser_family: Chrome
@@ -4083,19 +3675,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ881) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ881
   os_family: Android
   browser_family: Chrome
@@ -4103,19 +3693,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ882) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ882
   os_family: Android
   browser_family: Chrome
@@ -4123,19 +3711,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ884) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ884
   os_family: Android
   browser_family: Chrome
@@ -4143,19 +3729,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ885 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Safari/537.36 OPR/44.1.2254.142088
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.142088"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ885
   os_family: Android
   browser_family: Opera
@@ -4163,19 +3747,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ890) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ890
   os_family: Android
   browser_family: Chrome
@@ -4183,19 +3765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ891) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ891
   os_family: Android
   browser_family: Chrome
@@ -4203,19 +3783,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZ892 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ892
   os_family: Android
   browser_family: Chrome
@@ -4223,19 +3801,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 8.1.0; TZ897) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 YaBrowser/19.9.6.88.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.9.6.88.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ897
   os_family: Android
   browser_family: Unknown
@@ -4243,19 +3819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IRBIS TZ93) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ93
   os_family: Android
   browser_family: Chrome
@@ -4263,19 +3837,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; ru-RU; TZ960 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.10.0.1163
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.10.0.1163"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ960
   os_family: Android
   browser_family: Unknown
@@ -4283,19 +3855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ961) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ961
   os_family: Android
   browser_family: Chrome
@@ -4303,19 +3873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ962) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ962
   os_family: Android
   browser_family: Chrome
@@ -4323,19 +3891,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ963) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ963
   os_family: Android
   browser_family: Chrome
@@ -4343,19 +3909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ964) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ964
   os_family: Android
   browser_family: Chrome
@@ -4363,19 +3927,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ965 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Safari/537.36 OPR/38.0.2254.134507
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "38.0.2254.134507"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ965
   os_family: Android
   browser_family: Opera
@@ -4383,19 +3945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ967) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ967
   os_family: Android
   browser_family: Chrome
@@ -4403,19 +3963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TZ968) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ968
   os_family: Android
   browser_family: Chrome
@@ -4423,19 +3981,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TZ969 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.111 Safari/537.36 OPR/44.1.2254.142088
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.142088"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZ969
   os_family: Android
   browser_family: Opera
@@ -4443,19 +3999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TZart) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 YaBrowser/18.11.2.730.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "18.11.2.730.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZart
   os_family: Android
   browser_family: Unknown
@@ -4463,19 +4017,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TZHIT Build/LMY47I AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36 YandexSearch/7.16/apad
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZHIT
   os_family: Android
   browser_family: Chrome
@@ -4483,19 +4035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TZone Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I6
+    brand: Irbis
     model: TZone
   os_family: Android
   browser_family: Chrome
@@ -4503,19 +4053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Mi7_HERO_BETA Build/8312cw) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I9
+    brand: iZotron
     model: MI7 Hero Beta
   os_family: Android
   browser_family: Chrome
@@ -4523,19 +4071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Mi7_HERO_TAB Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: I9
+    brand: iZotron
     model: MI7 Hero Tab
   os_family: Android
   browser_family: Chrome
@@ -4543,19 +4089,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; iBall Slide 3G7271 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IB
+    brand: iBall
     model: Slide 3G7271
   os_family: Android
   browser_family: Android Browser
@@ -4563,19 +4107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Snap_4G2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IB
+    brand: iBall
     model: Snap 4G2
   os_family: Android
   browser_family: Chrome
@@ -4583,19 +4125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 733TPC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IE
+    brand: iView
     model: 733TPC
   os_family: Android
   browser_family: Chrome
@@ -4603,19 +4143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_G101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IG
+    brand: iGet
     model: Smart G101
   os_family: Android
   browser_family: Chrome
@@ -4623,19 +4161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_G102) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IG
+    brand: iGet
     model: Smart G102
   os_family: Android
   browser_family: Chrome
@@ -4643,19 +4179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_G71) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IG
+    brand: iGet
     model: Smart G71
   os_family: Android
   browser_family: Chrome
@@ -4663,19 +4197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_G81) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IG
+    brand: iGet
     model: Smart G81
   os_family: Android
   browser_family: Chrome
@@ -4683,19 +4215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SMART_G81H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IG
+    brand: iGet
     model: Smart G81H
   os_family: Android
   browser_family: Chrome
@@ -4703,19 +4233,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; da-dk; DEOX Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IJ
+    brand: i-Joy
     model: Deox
   os_family: Android
   browser_family: Android Browser
@@ -4723,19 +4251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; Neon7 Build/20130122) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IJ
+    brand: i-Joy
     model: Neon 7
   os_family: Android
   browser_family: Android Browser
@@ -4743,19 +4269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Neon9 Build/20130128) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IJ
+    brand: i-Joy
     model: Neon 9
   os_family: Android
   browser_family: Chrome
@@ -4763,19 +4287,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; uk-ua; Sygnus Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IJ
+    brand: i-Joy
     model: Sygnus
   os_family: Android
   browser_family: Android Browser
@@ -4783,19 +4305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; id-id; IMO TAB X9 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IL
+    brand: IMO Mobile
     model: Tab X9
   os_family: Android
   browser_family: Android Browser
@@ -4803,19 +4323,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; IMO Y5 Build/IMM76D) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IL
+    brand: IMO Mobile
     model: Tab Y5
   os_family: Android
   browser_family: Android Browser
@@ -4823,19 +4341,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; id-id; IMO Z6 Build/IML74K) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IL
+    brand: IMO Mobile
     model: Tab Z6
   os_family: Android
   browser_family: Android Browser
@@ -4843,19 +4359,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; IMO Z7 Build/IMM76D) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IL
+    brand: IMO Mobile
     model: Tab Z7
   os_family: Android
   browser_family: Android Browser
@@ -4863,19 +4377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; i-mobile i-note 2 Build/ICS_IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IO
+    brand: i-mobile
     model: i-note 2
   os_family: Android
   browser_family: Android Browser
@@ -4883,19 +4395,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; th-th; i-mobile i-note 3 Build/JB_JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IO
+    brand: i-mobile
     model: i-note 3
   os_family: Android
   browser_family: Android Browser
@@ -4903,19 +4413,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; hu-hu; i-mobile i-note WiFi 9 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IO
+    brand: i-mobile
     model: i-note WiFi 9
   os_family: Android
   browser_family: Android Browser
@@ -4923,19 +4431,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; iRola DX752 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: IR
+    brand: iRola
     model: DX752
   os_family: Android
   browser_family: Android Browser
@@ -4943,19 +4449,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.4; DX758 Build/KTU84Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 OPR/22.0.2254.112936
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "22.0.2254.112936"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IR
+    brand: iRola
     model: DX758
   os_family: Android
   browser_family: Opera
@@ -4963,19 +4467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; DX758Pro Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IR
+    brand: iRola
     model: DX758 Pro
   os_family: Android
   browser_family: Chrome
@@ -4983,19 +4485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; NS-P10A7100 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: 10.1"
   os_family: Android
   browser_family: Chrome
@@ -5003,19 +4503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS-P10A8100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: 10.1"
   os_family: Android
   browser_family: Chrome
@@ -5023,19 +4521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; NS-P11A8100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: 11.6"
   os_family: Android
   browser_family: Chrome
@@ -5043,19 +4539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; NS-P08A7100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: 8"
   os_family: Android
   browser_family: Chrome
@@ -5063,19 +4557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; NS-P16AT10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: Flex 10.1"
   os_family: Android
   browser_family: Chrome
@@ -5083,19 +4575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; NS-P10A6100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: Flex 10.1"
   os_family: Android
   browser_family: Chrome
@@ -5103,19 +4593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; NS-P16AT08) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: Flex 8"
   os_family: Android
   browser_family: Chrome
@@ -5123,19 +4611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; NS-P16AT785HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IS
+    brand: Insignia
     model: Flex Elite 7.85"
   os_family: Android
   browser_family: Chrome
@@ -5143,19 +4629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; iRULU_V3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IU
+    brand: iRulu
     model: V3
   os_family: Android
   browser_family: Chrome
@@ -5163,19 +4647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; iRULU_V4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IU
+    brand: iRulu
     model: V4
   os_family: Android
   browser_family: Chrome
@@ -5183,19 +4665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; iRULU X11 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: IU
+    brand: iRulu
     model: X11
   os_family: Android
   browser_family: Chrome
@@ -5203,19 +4683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; AUXUS CoreX4 3G Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: IY
+    brand: iBerry
     model: CoreX4 3G
   os_family: Android
   browser_family: Chrome
@@ -5223,19 +4701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TPC-101 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: Tablet PC 101
   os_family: Android
   browser_family: Chrome
@@ -5243,19 +4719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TPC-PA7807 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: Tablet PC PA7807
   os_family: Android
   browser_family: Chrome
@@ -5263,19 +4737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TPC-X10F1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: Tablet PC X10F1
   os_family: Android
   browser_family: Chrome
@@ -5283,19 +4755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10D Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE10D
   os_family: Android
   browser_family: Chrome
@@ -5303,19 +4773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE10DS
   os_family: Android
   browser_family: Chrome
@@ -5323,19 +4791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DW Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/72.0.3626.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE10DW
   os_family: Android
   browser_family: Chrome
@@ -5343,19 +4809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE10DW232 Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE10DW232
   os_family: Android
   browser_family: Chrome
@@ -5363,19 +4827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE7D Build/MXC89K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE7D
   os_family: Android
   browser_family: Chrome
@@ -5383,19 +4845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TPCY-TXE7DW) Build/MXC89K; wv AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXE7DW
   os_family: Android
   browser_family: Chrome
@@ -5403,19 +4863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TPCY-TXTE10D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXTE10D
   os_family: Android
   browser_family: Chrome
@@ -5423,19 +4881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TPCY-TXTE7D) Build/MRA58K AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: JA
+    brand: JAY-Tech
     model: TPCY-TXTE7D
   os_family: Android
   browser_family: Chrome
@@ -5443,19 +4899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Cavion Base 10 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Cavion Base 10
   os_family: Android
   browser_family: Chrome
@@ -5463,19 +4917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CAVION_10_3GRQ Build/LMY48Y) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Cavion Base 10
   os_family: Android
   browser_family: Chrome
@@ -5483,19 +4935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Cavion Base 7 Dual Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Cavion Base 7
   os_family: Android
   browser_family: Chrome
@@ -5503,19 +4953,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; CORE 10.1 DUAL 3G Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: CORE 10.1 DUAL 3G
   os_family: Android
   browser_family: Android Browser
@@ -5523,19 +4971,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Kiano Elegance by Zanetti Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Elegance
   os_family: Android
   browser_family: Android Browser
@@ -5543,19 +4989,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Kiano Elegance 8 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Elegance 8
   os_family: Android
   browser_family: Chrome
@@ -5563,19 +5007,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Intelect103G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Intelect 10
   os_family: Android
   browser_family: Android Browser
@@ -5583,19 +5025,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; KianoIntelect73G Build/Elegance) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Intelect 7
   os_family: Android
   browser_family: Android Browser
@@ -5603,19 +5043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SlimTab10_3GR Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Slim Tab 10
   os_family: Android
   browser_family: Chrome
@@ -5623,19 +5061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SlimTab7_3GR Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Slim Tab 7
   os_family: Android
   browser_family: Chrome
@@ -5643,19 +5079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Kiano Slim Tab 8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Slim Tab 8
   os_family: Android
   browser_family: Android Browser
@@ -5663,19 +5097,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Slim Tab 8 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Slim Tab 8
   os_family: Android
   browser_family: Chrome
@@ -5683,19 +5115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SlimTab8_3GR Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K1
+    brand: Kiano
     model: Slim Tab 8
   os_family: Android
   browser_family: Chrome
@@ -5703,19 +5133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; KJ-OB03) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: K6
+    brand: Kanji
     model: Cata 7
   os_family: Android
   browser_family: Chrome
@@ -5723,19 +5151,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; KJ-YUBI Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: K6
+    brand: Kanji
     model: Yubi 3G
   os_family: Android
   browser_family: Android Browser
@@ -5743,19 +5169,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; pt-br; KaiCloud 744 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K7
+    brand: Kaiomy
     model: KaiCloud 744
   os_family: Android
   browser_family: Android Browser
@@ -5763,19 +5187,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; KaiCloud 784 Build/JDQ39 AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K7
+    brand: Kaiomy
     model: KaiCloud 784
   os_family: Android
   browser_family: Android Browser
@@ -5783,19 +5205,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; KaiCloud942 Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: K7
+    brand: Kaiomy
     model: KaiCloud 942
   os_family: Android
   browser_family: Android Browser
@@ -5803,19 +5223,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-br; KaiCloud 942 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: K7
+    brand: Kaiomy
     model: KaiCloud 942
   os_family: Android
   browser_family: Android Browser
@@ -5823,19 +5241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; M1050S Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1050s
   os_family: Android
   browser_family: Chrome
@@ -5843,19 +5259,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; M1060W Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1060
   os_family: Android
   browser_family: Android Browser
@@ -5863,19 +5277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; M1061 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1061
   os_family: Android
   browser_family: Android Browser
@@ -5883,19 +5295,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; Es-es; M1062 Build/IMM76D) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1062
   os_family: Android
   browser_family: Android Browser
@@ -5903,7 +5313,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; M1063W Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 [FB_IAB/FB4A;FBAV/104.0.0.17.71;]'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -5912,7 +5321,7 @@
     version: "104.0.0.17.71"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1063
   os_family: Android
   browser_family: Unknown
@@ -5920,19 +5329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; M1066 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1066
   os_family: Android
   browser_family: Android Browser
@@ -5940,19 +5347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M1068 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1068
   os_family: Android
   browser_family: Chrome
@@ -5960,19 +5365,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; sk-sk; M1070 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M1070
   os_family: Android
   browser_family: Android Browser
@@ -5980,19 +5383,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; M729 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.3.0.552 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.3.0.552"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M729
   os_family: Android
   browser_family: Unknown
@@ -6000,19 +5401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; es-us; M730W Build/GRJ22) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M730
   os_family: Android
   browser_family: Android Browser
@@ -6020,19 +5419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M750 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M750
   os_family: Android
   browser_family: Chrome
@@ -6040,19 +5437,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; M752 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M752
   os_family: Android
   browser_family: Chrome
@@ -6060,19 +5455,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M752H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M752
   os_family: Android
   browser_family: Chrome
@@ -6080,19 +5473,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; M756 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "28.0.1500.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M756
   os_family: Android
   browser_family: Chrome
@@ -6100,19 +5491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M760 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M760
   os_family: Android
   browser_family: Chrome
@@ -6120,19 +5509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; M762B Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M762
   os_family: Android
   browser_family: Chrome
@@ -6140,19 +5527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; M766 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M766
   os_family: Android
   browser_family: Chrome
@@ -6160,19 +5545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M776H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M776
   os_family: Android
   browser_family: Chrome
@@ -6180,19 +5563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; en-US; M836 Build/MMB29M) AppleWebKit/537.36 (KHTML, Like Gecko) Version/4.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M836
   os_family: Android
   browser_family: Android Browser
@@ -6200,19 +5581,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; M870 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M870
   os_family: Android
   browser_family: Chrome
@@ -6220,19 +5599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; KOCASO-M9100 Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.8.0.435 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.8.0.435"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: M9100
   os_family: Android
   browser_family: Unknown
@@ -6240,7 +5617,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; MX736-Kit Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 [FB_IAB/FB4A;FBAV/43.0.0.29.147;]'
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -6249,7 +5625,7 @@
     version: "43.0.0.29.147"
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: MX736
   os_family: Android
   browser_family: Unknown
@@ -6257,19 +5633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MX780 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KC
+    brand: Kocaso
     model: MX780
   os_family: Android
   browser_family: Chrome
@@ -6277,19 +5651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KM1065G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KE
+    brand: 'Krüger&Matz'
     model: EAGLE 1065G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -6297,19 +5669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; KM1066) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KE
+    brand: 'Krüger&Matz'
     model: EAGLE 1066 10.1"
   os_family: Android
   browser_family: Chrome
@@ -6317,19 +5687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KM1067) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KE
+    brand: 'Krüger&Matz'
     model: EAGLE 1067 10.1"
   os_family: Android
   browser_family: Chrome
@@ -6337,19 +5705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KM0701_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KE
+    brand: 'Krüger&Matz'
     model: EAGLE 701 7.1"
   os_family: Android
   browser_family: Chrome
@@ -6357,19 +5723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KM0805_1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KE
+    brand: 'Krüger&Matz'
     model: EAGLE 805 8.0"
   os_family: Android
   browser_family: Chrome
@@ -6377,19 +5741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KODAK Tablet 10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KK
+    brand: Kodak
     model: Tablet 10
   os_family: Android
   browser_family: Chrome
@@ -6397,19 +5759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; KODAK Tablet 7 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KK
+    brand: Kodak
     model: Tablet 7
   os_family: Android
   browser_family: Chrome
@@ -6417,19 +5777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KFFOWI Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Silk/49.2.1 like Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "49.2.1"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire 7"
   os_family: Android
   browser_family: Chrome
@@ -6437,19 +5795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; KFMUWI) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.4.14 like Chrome/80.0.3987.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "80.4.14"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire 7" (2019)
   os_family: Android
   browser_family: Chrome
@@ -6457,19 +5813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KFTBWI Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 10
   os_family: Android
   browser_family: Chrome
@@ -6477,19 +5831,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; en-US; KFSUWI Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.3.1204 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.3.1204"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 10 (2017)
   os_family: Android
   browser_family: Unknown
@@ -6497,19 +5849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KFMAWI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 10 (2019)
   os_family: Android
   browser_family: Chrome
@@ -6517,19 +5867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; en-us; KFARWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.45 like Chrome/37.0.2026.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.45"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 6
   os_family: Android
   browser_family: Chrome
@@ -6537,19 +5885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; en-gb; KFASWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.37 like Chrome/34.0.1847.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.37"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 7
   os_family: Android
   browser_family: Chrome
@@ -6557,19 +5903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KFMEWI Build/LMY47O) AppleWebKit/537.36 (KHTML, like Gecko) Silk/50.2.1 like Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "50.2.1"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 8 (2015)
   os_family: Android
   browser_family: Chrome
@@ -6577,19 +5921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KFGIWI Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.94 Safari/537.36 OPR/37.0.2192.105088
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "37.0.2192.105088"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 8 (2016)
   os_family: Android
   browser_family: Opera
@@ -6597,19 +5939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KFDOWI Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 8 (2017)
   os_family: Android
   browser_family: Chrome
@@ -6617,19 +5957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; KFKAWI Build/NS6301) AppleWebKit/537.36 (KHTML, like Gecko) Silk/69.4.17 like Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "69.4.17"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 8 (2018)
   os_family: Android
   browser_family: Chrome
@@ -6637,19 +5975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KFONWI Build/PS7315; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HD 8 (2020)
   os_family: Android
   browser_family: Chrome
@@ -6657,19 +5993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; en-gb; KFSAWI Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.46 like Chrome/37.0.2026.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.46"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HDX 8.9
   os_family: Android
   browser_family: Chrome
@@ -6677,19 +6011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; en-us; KFSAWA Build/KTU84M) AppleWebKit/537.36 (KHTML, like Gecko) Silk/3.41 like Chrome/37.0.2026.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.41"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Fire HDX 8.9 4G
   os_family: Android
   browser_family: Chrome
@@ -6697,19 +6029,17 @@
   user_agent: Mozilla/4.0 (compatible; Linux 2.6.22) NetFront/3.4 Kindle/2.0 (screen 600x800)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Kindle Browser
-    short_name: KI
     version: "2.0"
     engine: NetFront
     engine_version: "3.4"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle
   os_family: GNU/Linux
   browser_family: Unknown
@@ -6717,19 +6047,17 @@
   user_agent: Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_3; en-us; Silk/1.0.22.153_10033210) AppleWebKit/533.16 (KHTML, like Gecko) Version/5.0 Safari/533.16 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "1.0.22.153"
     engine: WebKit
     engine_version: "533.16"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire
   os_family: Android
   browser_family: Chrome
@@ -6737,19 +6065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; de-de; KFOT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.10 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.10"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire
   os_family: Android
   browser_family: Chrome
@@ -6757,19 +6083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; en-us; Silk/1.0.22.153_10033210) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "1.0.22.153"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire
   os_family: Android
   browser_family: Chrome
@@ -6777,19 +6101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Amazon Kindle Fire Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire
   os_family: Android
   browser_family: Chrome
@@ -6797,19 +6119,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Amazon Kindle Fire Build/JOP40D; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire
   os_family: Android
   browser_family: Android Browser
@@ -6817,19 +6137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; de-de; KFTT Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.8 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.8"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD
   os_family: Android
   browser_family: Chrome
@@ -6837,19 +6155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; KFTT Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD
   os_family: Android
   browser_family: Android Browser
@@ -6857,19 +6173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; en-gb; KFSOWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.12 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.12"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6877,19 +6191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; en-us; KFSOWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.12 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.12"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6897,19 +6209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Amazon Tate Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6917,19 +6227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; KFJWA Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.42 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.42"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 8.9" 4G
   os_family: Android
   browser_family: Chrome
@@ -6937,19 +6245,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; KFJWI Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 8.9" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6957,19 +6263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; KFJWI Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Silk/2.2 Mobile Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "2.2"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 8.9" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6977,19 +6281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; Amazon Jem Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HD 8.9" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6997,19 +6299,17 @@
   user_agent: Mozilla/5.0 (Linux; U; en-us; KFTHWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.12 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.12"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HDX 7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -7017,19 +6317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; en-us; KFAPWI Build/JDQ39) AppleWebKit/535.19 (KHTML, like Gecko) Silk/3.8 Safari/535.19 Silk-Accelerated=true
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "3.8"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HDX 8.9" WiFi
   os_family: Android
   browser_family: Chrome
@@ -7037,19 +6335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; KFAPWI Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: KN
+    brand: Amazon
     model: Kindle Fire HDX 8.9" WiFi
   os_family: Android
   browser_family: Chrome
@@ -7057,19 +6353,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; A811 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: L3
+    brand: Lexand
     model: A811
   os_family: Android
   browser_family: Android Browser
@@ -7077,19 +6371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Leapad 7s Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: L5
+    brand: Leagoo
     model: Leapad 7s
   os_family: Android
   browser_family: Chrome
@@ -7097,19 +6389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ilium Pad E8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LA
+    brand: Lanix
     model: Ilium Pad E8
   os_family: Android
   browser_family: Chrome
@@ -7117,19 +6407,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Trident/6.0; Touch; MALCJS; WebView/1.0)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -7137,19 +6425,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.3; Trident/7.0; Touch; MALCJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -7157,19 +6443,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch; MALNJS)
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ""
   os_family: Windows Mobile
   browser_family: Internet Explorer
@@ -7177,19 +6461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; A2107A-H Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: A2107
   os_family: Android
   browser_family: Chrome
@@ -7197,19 +6479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Lenovo TB-X104F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: E10
   os_family: Android
   browser_family: Chrome
@@ -7217,19 +6497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Lenovo TB-X104L Build/OPM1.171019.026) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.2912.171 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "61.0.2912.171"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: E10
   os_family: Android
   browser_family: Chrome
@@ -7237,19 +6515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Lenovo TB-X104X Build/OPM1.171019.026; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: E10
   os_family: Android
   browser_family: Chrome
@@ -7257,19 +6533,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; IdeaPadA10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaPad A10
   os_family: Android
   browser_family: Android Browser
@@ -7277,19 +6551,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Ideapad K1 Build/JDQ39E) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 CyanogenMod/10.1.3/k1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaPad K1
   os_family: Android
   browser_family: Android Browser
@@ -7297,19 +6569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A7600-H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A10-70
   os_family: Android
   browser_family: Chrome
@@ -7317,19 +6587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A7600-F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A10-70
   os_family: Android
   browser_family: Chrome
@@ -7337,13 +6605,12 @@
   user_agent: Orca-Android/2.2.5-release OS/4.0.3 Model/IdeaTab_A2107A-H VersionCode/108531 Product/Messenger Carrier/o2_-_de Manufacturer/LENOVO Brand/Lenovo
   os:
     name: Android
-    short_name: AND
     version: "2.2.5"
     platform: ""
   client: null
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A2107A
   os_family: Android
   browser_family: Unknown
@@ -7351,19 +6618,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; IdeaTabA2109A Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A2109A
   os_family: Android
   browser_family: Android Browser
@@ -7371,19 +6636,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; IdeaTabA2109A Build/JRO03R) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A2109A
   os_family: Android
   browser_family: Chrome
@@ -7391,19 +6654,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo A3000-H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A3000
   os_family: Android
   browser_family: Chrome
@@ -7411,19 +6672,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo A3500-FL Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A7-40
   os_family: Android
   browser_family: Chrome
@@ -7431,19 +6690,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo A3500-HV Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A7-50
   os_family: Android
   browser_family: Chrome
@@ -7451,19 +6708,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A3500-F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A7-50
   os_family: Android
   browser_family: Chrome
@@ -7471,19 +6726,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A3500-H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A7-50
   os_family: Android
   browser_family: Chrome
@@ -7491,19 +6744,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A5500-H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A8-50
   os_family: Android
   browser_family: Chrome
@@ -7511,19 +6762,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo A5500-F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab A8-50
   os_family: Android
   browser_family: Chrome
@@ -7531,19 +6780,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-ve; IdeaTabS2109A-F Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S2109A
   os_family: Android
   browser_family: Android Browser
@@ -7551,19 +6798,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo S5000-F Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S5000
   os_family: Android
   browser_family: Chrome
@@ -7571,19 +6816,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo S5000-H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S5000
   os_family: Android
   browser_family: Chrome
@@ -7591,19 +6834,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; IdeaTab S6000-H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S6000
   os_family: Android
   browser_family: Chrome
@@ -7611,19 +6852,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenovo S6000L-F Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S6000
   os_family: Android
   browser_family: Chrome
@@ -7631,19 +6870,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S6000 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: IdeaTab S6000
   os_family: Android
   browser_family: Chrome
@@ -7651,19 +6888,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Lenovo TB-X505F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: M10
   os_family: Android
   browser_family: Chrome
@@ -7671,19 +6906,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TB-X704A Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Moto Tab
   os_family: Android
   browser_family: Chrome
@@ -7691,19 +6924,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo TB2-X30F Build/LenovoTB2-X30F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Tab 2 A10-30
   os_family: Android
   browser_family: Chrome
@@ -7711,19 +6942,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo TB2-X30L Build/LenovoTB2-X30L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Tab 2 A10-30
   os_family: Android
   browser_family: Chrome
@@ -7731,19 +6960,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TB2-X30L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Tab 2 A10-30
   os_family: Android
   browser_family: Chrome
@@ -7751,19 +6978,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TAB 2 A10-70L Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A10-70L
   os_family: Android
   browser_family: Chrome
@@ -7771,19 +6996,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; Tab2A7-10F Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A7-10F
   os_family: Android
   browser_family: Chrome
@@ -7791,19 +7014,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LenovoA3300-GV Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A7-30
   os_family: Android
   browser_family: Chrome
@@ -7811,19 +7032,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LenovoA3300-H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A7-30
   os_family: Android
   browser_family: Chrome
@@ -7831,19 +7050,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo TAB 2 A7-30D Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A7-30D
   os_family: Android
   browser_family: Chrome
@@ -7851,19 +7068,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo TAB 2 A8-50L Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 2 A8-50L
   os_family: Android
   browser_family: Chrome
@@ -7871,19 +7086,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TB-X304F Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 4 10
   os_family: Android
   browser_family: Chrome
@@ -7891,19 +7104,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Lenovo TB-X704F Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Tab 4 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -7911,19 +7122,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; TB-8504F Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB 4 8
   os_family: Android
   browser_family: Chrome
@@ -7931,19 +7140,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Lenovo TB-X605F Build/OPM1.171019.019; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Tab M10
   os_family: Android
   browser_family: Chrome
@@ -7951,19 +7158,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lenovo TAB S8-50L Build/BMAIN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB S8-50L
   os_family: Android
   browser_family: Chrome
@@ -7971,19 +7176,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB 2 A8-50LC Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB2 A8-50LC
   os_family: Android
   browser_family: Chrome
@@ -7991,19 +7194,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo TB3-730X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 7
   os_family: Android
   browser_family: Chrome
@@ -8011,19 +7212,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; Lenovo TB3-710F Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 7 Essential
   os_family: Android
   browser_family: Chrome
@@ -8031,19 +7230,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo TB3-710I Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 7 Essential
   os_family: Android
   browser_family: Chrome
@@ -8051,19 +7248,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TB3-710I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 7 Essential
   os_family: Android
   browser_family: Chrome
@@ -8071,19 +7266,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo TB3-850M Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 8
   os_family: Android
   browser_family: Chrome
@@ -8091,19 +7284,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 601LV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 8
   os_family: Android
   browser_family: Chrome
@@ -8111,19 +7302,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Lenovo TB3-850M Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.123 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB3 8
   os_family: Android
   browser_family: Chrome
@@ -8131,19 +7320,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Lenovo TB-X304L Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB4 10
   os_family: Android
   browser_family: Chrome
@@ -8151,19 +7338,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Lenovo TB-X304L Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 YaBrowser/17.7.0.1173.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.7.0.1173.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB4 10
   os_family: Android
   browser_family: Unknown
@@ -8171,19 +7356,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; TB-X704V Build/NMF26F AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.86 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB4 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -8191,19 +7374,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 701LV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB4 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -8211,19 +7392,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Lenovo TB-X704L Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/85.0.4183.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "85.0.4183.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: TAB4 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -8231,19 +7410,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; ThinkPadTablet Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ThinkPad Tablet
   os_family: Android
   browser_family: Chrome
@@ -8251,19 +7428,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; fr-ca; ThinkPad Tablet Build/ThinkPadTablet_A310_02) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ThinkPad Tablet A310
   os_family: Android
   browser_family: Android Browser
@@ -8271,19 +7446,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; ThinkPad Tablet Build/ThinkPadTablet_A400_03) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: ThinkPad Tablet A400
   os_family: Android
   browser_family: Android Browser
@@ -8291,19 +7464,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo YT3-X90X Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -8311,19 +7482,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Lenovo YT3-X90L Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -8331,19 +7500,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo YT3-X90F Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -8351,19 +7518,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo YT3-X50F Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3
   os_family: Android
   browser_family: Chrome
@@ -8371,19 +7536,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo YT3-X50L Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3
   os_family: Android
   browser_family: Chrome
@@ -8391,19 +7554,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; YT3-X50M Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.84 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3
   os_family: Android
   browser_family: Chrome
@@ -8411,19 +7572,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Lenovo YT3-850M Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3 10
   os_family: Android
   browser_family: Chrome
@@ -8431,19 +7590,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo YT3-850F Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3 8
   os_family: Android
   browser_family: Chrome
@@ -8451,19 +7608,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Lenovo YT3-850L Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tab 3 8
   os_family: Android
   browser_family: Chrome
@@ -8471,19 +7626,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Lenovo B8000-F Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 10
   os_family: Android
   browser_family: Android Browser
@@ -8491,19 +7644,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lenovo B8000-H/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 10
   os_family: Android
   browser_family: Android Browser
@@ -8511,19 +7662,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2;pl-pl; Lenovo B8000-F/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 10
   os_family: Android
   browser_family: Android Browser
@@ -8531,19 +7680,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YOGA Tablet 2-1050F Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 10.1"
   os_family: Android
   browser_family: Chrome
@@ -8551,19 +7698,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2-1050F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 10.1"
   os_family: Android
   browser_family: Chrome
@@ -8571,19 +7716,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2-1050L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 10.1"
   os_family: Android
   browser_family: Chrome
@@ -8591,19 +7734,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YOGA Tablet 2-830L Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -8611,19 +7752,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2-830L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -8631,19 +7770,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2-830F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -8651,19 +7788,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2-830LC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -8671,19 +7806,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; YOGA Tablet 2 Pro-1380L Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 Pro 13.3"
   os_family: Android
   browser_family: Chrome
@@ -8691,19 +7824,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2 Pro-1380F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 Pro 13.3"
   os_family: Android
   browser_family: Chrome
@@ -8711,19 +7842,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; YOGA Tablet 2 Pro-1380L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 2 Pro 13.3"
   os_family: Android
   browser_family: Chrome
@@ -8731,19 +7860,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2;pl-pl; Lenovo B6000-F/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LE
+    brand: Lenovo
     model: Yoga Tablet 8
   os_family: Android
   browser_family: Android Browser
@@ -8751,13 +7878,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LG-V700 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -8771,13 +7896,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; LG-V490 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -8791,13 +7914,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LG-V500 Build/KOT49I.V50020f) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -8811,13 +7932,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; VK810 4G Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
@@ -8831,13 +7950,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; LG-V935 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
@@ -8851,13 +7968,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LG-V521 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
@@ -8871,13 +7986,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VK815) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
@@ -8891,13 +8004,11 @@
   user_agent: Android 3.1;AppleWebKit/534.13;Build/HMJ37;LG Optimus Pad L-06C Build/HMJ37
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
@@ -8911,13 +8022,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 3.0.1; LG-V905R Build/HRI66) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.63780
   os:
     name: Android
-    short_name: AND
     version: "3.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "16.0.1212.63780"
     engine: Blink
     engine_version: ""
@@ -8931,19 +8040,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; Lark Evolution 10 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Evolution 10
   os_family: Android
   browser_family: Android Browser
@@ -8951,19 +8058,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lark Evolution X2 7 3G-GPS Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Evolution X2 7 3G-GPS
   os_family: Android
   browser_family: Chrome
@@ -8971,19 +8076,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; LARK_Evolution_X4_10.1 Build/LARK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Evolution X4 10.1
   os_family: Android
   browser_family: Chrome
@@ -8991,19 +8094,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Evolution X4 7 IPS Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Evolution X4 7 IPS
   os_family: Android
   browser_family: Chrome
@@ -9011,19 +8112,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lark FreeMe X2 7 Build/JDQ39) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.16"
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 7
   os_family: Android
   browser_family: Android Browser
@@ -9031,19 +8130,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lark FreeMe X2 7 ver.2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 7 Version 2
   os_family: Android
   browser_family: Android Browser
@@ -9051,19 +8148,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Lark FreeMe X2 7 ver.3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 7 Version 3
   os_family: Android
   browser_family: Chrome
@@ -9071,19 +8166,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lark FreeMe X2 8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 8
   os_family: Android
   browser_family: Android Browser
@@ -9091,19 +8184,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; Lark FreeMe X2 9 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 9
   os_family: Android
   browser_family: Android Browser
@@ -9111,19 +8202,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FreeMe x2 9 v.2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 9 Version 2
   os_family: Android
   browser_family: Chrome
@@ -9131,19 +8220,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FreeMe x2 9 ver.3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X2 9 Version 3
   os_family: Android
   browser_family: Chrome
@@ -9151,19 +8238,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; (Lark FreeMe X4 7 3G HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X4 7HD 3G
   os_family: Android
   browser_family: Chrome
@@ -9171,19 +8256,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; FreeMe X4 9 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: FreeMe X4 9
   os_family: Android
   browser_family: Chrome
@@ -9191,19 +8274,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PHABLET 7 Build/LARK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Phablet 7
   os_family: Android
   browser_family: Chrome
@@ -9211,19 +8292,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.4; Ultimate 7i Build/KTU84P AppleWebKit/537.36 KHTML, like Gecko Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Ultimate 7i
   os_family: Android
   browser_family: Chrome
@@ -9231,19 +8310,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Ultimate X4 10.1 3G IPS Build/Lark; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Ultimate X4 10.1 3G IPS
   os_family: Android
   browser_family: Chrome
@@ -9251,19 +8328,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Ultimate X4 8s 3G Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LK
+    brand: Lark
     model: Ultimate X4 8s 3G
   os_family: Android
   browser_family: Chrome
@@ -9271,19 +8346,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B BOT 550 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2785.124 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: B BOT 550
   os_family: Android
   browser_family: Chrome
@@ -9291,19 +8364,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; E1031 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: E1031
   os_family: Android
   browser_family: Android Browser
@@ -9311,19 +8382,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-; E731 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 bdbrowser_i18n/3.1.2.2
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "3.1.2.2"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: E731
   os_family: Android
   browser_family: Baidu
@@ -9331,19 +8400,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; E812 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: E812
   os_family: Android
   browser_family: Android Browser
@@ -9351,19 +8418,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; E912 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: E912
   os_family: Android
   browser_family: Android Browser
@@ -9371,19 +8436,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ID bot 53+ Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: ID BOT 53+
   os_family: Android
   browser_family: Chrome
@@ -9391,19 +8454,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; IDbot553 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: ID BOT 553
   os_family: Android
   browser_family: Chrome
@@ -9411,19 +8472,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; IDbot553PLUS Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: ID BOT 553PLUS
   os_family: Android
   browser_family: Chrome
@@ -9431,19 +8490,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; L-EMENT_TAB1040_BT Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ement Tab 1040 BT
   os_family: Android
   browser_family: Chrome
@@ -9451,19 +8508,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; L-EMENT 741 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ement Tab 741
   os_family: Android
   browser_family: Chrome
@@ -9471,19 +8526,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; LEMENT_TAB901 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ement Tab 901
   os_family: Android
   browser_family: Chrome
@@ -9491,19 +8544,17 @@
   user_agent: Android 5.1;AppleWebKit/533.1;Build/LMY47D;L-ITE 402 Build/LMY47D
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ite Tab 402
   os_family: Android
   browser_family: Android Browser
@@ -9511,19 +8562,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; L-ITE 502 PLUS Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ite Tab 502 PLUS
   os_family: Android
   browser_family: Chrome
@@ -9531,19 +8580,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; L-ITE 504 HD Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2564.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ite Tab 504 HD
   os_family: Android
   browser_family: Chrome
@@ -9551,19 +8598,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; LIXIR1041 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ixir Tab 1041
   os_family: Android
   browser_family: Chrome
@@ -9571,19 +8616,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; KT712A_4.4 Build/KOT49H) AppleWebKit/537.36 (KHTML, Like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ixir Tab 701
   os_family: Android
   browser_family: Chrome
@@ -9591,19 +8634,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; L-IXIR TAB 701 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: L-ixir Tab 701 3G
   os_family: Android
   browser_family: Chrome
@@ -9611,19 +8652,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; La Tab 72 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: La Tab 72
   os_family: Android
   browser_family: Chrome
@@ -9631,19 +8670,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; LOGICOM_LA_TAB_LINK_71) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: La Tab Link 71
   os_family: Android
   browser_family: Chrome
@@ -9651,19 +8688,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M BOT 551 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: M BOT 551
   os_family: Android
   browser_family: Chrome
@@ -9671,19 +8706,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M bot 60 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: M BOT 60
   os_family: Android
   browser_family: Chrome
@@ -9691,19 +8724,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; M_bot_tab_1150 Build/N9F27F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: M BOT tab 1150
   os_family: Android
   browser_family: Chrome
@@ -9711,19 +8742,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M_bot_tab_71 Build/NHG47K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: M BOT tab 71
   os_family: Android
   browser_family: Chrome
@@ -9731,19 +8760,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; POWER BOT Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: POWER BOT
   os_family: Android
   browser_family: Chrome
@@ -9751,19 +8778,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; TAB1062 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: TAB1062
   os_family: Android
   browser_family: Android Browser
@@ -9771,19 +8796,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; TAB950 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LM
+    brand: Logicom
     model: TAB950
   os_family: Android
   browser_family: Android Browser
@@ -9791,19 +8814,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; Lenco CARTAB-920 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CARTAB-920
   os_family: Android
   browser_family: Chrome
@@ -9811,19 +8832,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Lenco CARTAB-925 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CARTAB-925
   os_family: Android
   browser_family: Android Browser
@@ -9831,19 +8850,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Lenco CoolTab-70 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CoolTab-70
   os_family: Android
   browser_family: Android Browser
@@ -9851,19 +8868,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Lenco CoolTAB-72 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CoolTAB-72
   os_family: Android
   browser_family: Android Browser
@@ -9871,19 +8886,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Lenco CoolTAB-72 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CoolTAB-72
   os_family: Android
   browser_family: Opera
@@ -9891,19 +8904,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; Lenco CoolTab-80 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: CoolTab-80
   os_family: Android
   browser_family: Chrome
@@ -9911,19 +8922,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Lenco KidzTab-70 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: KidzTab-70
   os_family: Android
   browser_family: Android Browser
@@ -9931,19 +8940,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Lenco TAB-1014 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-1014
   os_family: Android
   browser_family: Android Browser
@@ -9951,19 +8958,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; Lenco TAB-1030 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-1030
   os_family: Android
   browser_family: Android Browser
@@ -9971,19 +8976,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Lenco TAB-704 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-704
   os_family: Android
   browser_family: Android Browser

--- a/Tests/fixtures/tablet-3.yml
+++ b/Tests/fixtures/tablet-3.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Lenco TAB-712 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-712
   os_family: Android
   browser_family: Android Browser
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Lenco TAB-813 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-813
   os_family: Android
   browser_family: Android Browser
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Lenco TAB-900 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-900
   os_family: Android
   browser_family: Android Browser
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Lenco TAB-925 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-925
   os_family: Android
   browser_family: Android Browser
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Lenco TAB-9720 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LN
+    brand: Lenco
     model: TAB-9720
   os_family: Android
   browser_family: Android Browser
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; tr-tr; LePanII Build/HTK75) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: LP
+    brand: Le Pan
     model: Le Pan II
   os_family: Android
   browser_family: Android Browser
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Le Pan TC802A Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LP
+    brand: Le Pan
     model: Le Pan Mini
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; Le Pan S Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LP
+    brand: Le Pan
     model: Le Pan S
   os_family: Android
   browser_family: Android Browser
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; es-es; TC970 (Wi-Fi) Build/s3394) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: LP
+    brand: Le Pan
     model: TC970 (Wi-Fi)
   os_family: Android
   browser_family: Android Browser
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; IQ1019N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Alu Plus 4G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ9610 Build/iQ9610_v1.2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Angel 3G
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQM960) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Angel 3G (2018)
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQM801 Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Brace 2018 4G
   os_family: Android
   browser_family: Android Browser
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; IQ1010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab 10
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; iQ1010w Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab 10
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1025 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Action 4G
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1012 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Brave 3G
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQ1012N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Brave 3G
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQ181011N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Care 8.0"
   os_family: Android
   browser_family: Chrome
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQ1805N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Ideal 8.0"
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1808 Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Master
   os_family: Android
   browser_family: Android Browser
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; iQ1810B_M Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Novel 3G
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1806)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: iQTab Rose
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; iQ1832 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Jet 3G
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQM1001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Level 4G
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; iQ9013_4N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Life 10.1"
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; iQS1001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LS
+    brand: MLS
     model: Vista 4G
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUPERNOVA i3G96 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LT
+    brand: Leotec
     model: Supernova i3G96
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUPERNOVA i3G96X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LT
+    brand: Leotec
     model: Supernova i3G96X
   os_family: Android
   browser_family: Chrome
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SUPERNOVA Qi16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LT
+    brand: Leotec
     model: Supernova Qi16
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; MFC190BBFR Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Barbie Tablet
   os_family: Android
   browser_family: Android Browser
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC195FUFR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Furby Tablet
   os_family: Android
   browser_family: Android Browser
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MFC140FR1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: LapTab
   os_family: Android
   browser_family: Android Browser
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MFC141FR Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: LapTab 2
   os_family: Android
   browser_family: Android Browser
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC162FR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Power Tablet
   os_family: Android
   browser_family: Android Browser
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC180FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Advanced
   os_family: Android
   browser_family: Android Browser
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MFC181FR Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Advanced 2
   os_family: Android
   browser_family: Android Browser
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC195DCFR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Disney Cars HD
   os_family: Android
   browser_family: Android Browser
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC195DPFR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Disney Princesse HD
   os_family: Android
   browser_family: Android Browser
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC250FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Junior
   os_family: Android
   browser_family: Android Browser
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MFC280FR Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Junior 2
   os_family: Android
   browser_family: Android Browser
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC270FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Junior Power Touch
   os_family: Android
   browser_family: Android Browser
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; mfc142fr Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Kids
   os_family: Android
   browser_family: Android Browser
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC155FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Master
   os_family: Android
   browser_family: Android Browser
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC157FR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Master 2
   os_family: Android
   browser_family: Android Browser
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MFC157FR Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Master 2
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MFC163FR Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Master 3
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MFC156FR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet One
   os_family: Android
   browser_family: Android Browser
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC170FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Ultra
   os_family: Android
   browser_family: Android Browser
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MFC175FR Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Ultra
   os_family: Android
   browser_family: Android Browser
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ca-es; MFC375FR Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet Ultra 2
   os_family: Android
   browser_family: Android Browser
@@ -1023,19 +921,17 @@
   user_agent: mozilla/5.0 (linux; u; android 4.2.2; fr-fr; mfc500fr build/jdq39) applewebkit/534.30 (khtml, like gecko) version/4.0 safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: Tablet XL
   os_family: Android
   browser_family: Android Browser
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MFC045FR Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: LX
+    brand: Lexibook
     model: TabTab
   os_family: Android
   browser_family: Android Browser
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; X1010 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M3
+    brand: Mecer
     model: X1010
   os_family: Android
   browser_family: Android Browser
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 101P51C Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M3
+    brand: Mecer
     model: Xpress Smartlife 101P51C
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; 800P31C Build/JDQ39) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M3
+    brand: Mecer
     model: Xpress Smartlife 800P31C
   os_family: Android
   browser_family: Android Browser
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; M785 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M3
+    brand: Mecer
     model: Xpress Smartlife M785
   os_family: Android
   browser_family: Android Browser
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; FreeTAB Build/RK2906) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M4
+    brand: Modecom
     model: FreeTab
   os_family: Android
   browser_family: Android Browser
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; FreeTAB 7001 HD IC Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M4
+    brand: Modecom
     model: FreeTab 7001 HD IC
   os_family: Android
   browser_family: Chrome
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; pl-pl; FreeTAB 8001 IPS X2 3G+ Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M4
+    brand: Modecom
     model: FreeTab 8001 IPS X2 3G+
   os_family: Android
   browser_family: Android Browser
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; lt-lt; FreeWAY TAB 7.0 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/18.0.1025.133 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.133"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: M4
+    brand: Modecom
     model: FreeWay Tab 7.0
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; MIDM-8803 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M7
+    brand: Miray
     model: MIDM 8803
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Cozy Build/MOB30M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M8
+    brand: Myria
     model: Cozy
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Easy tab 9 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M8
+    brand: Myria
     model: Easy tab 9
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MTC 1078 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: M9
+    brand: MTC
     model: "1078"
   os_family: Android
   browser_family: Chrome
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; MID1001 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID1001
   os_family: Android
   browser_family: Android Browser
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MID1009 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID1009
   os_family: Android
   browser_family: Chrome
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MID1010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID1010
   os_family: Android
   browser_family: Chrome
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MID704 Build/MID704) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID704
   os_family: Android
   browser_family: Android Browser
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MID705 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID705
   os_family: Android
   browser_family: Android Browser
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MID706A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID706A
   os_family: Android
   browser_family: Android Browser
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MID713 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID713
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MID901 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID901
   os_family: Android
   browser_family: Chrome
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MID9701 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MA
+    brand: Manta Multimedia
     model: MID9701
   os_family: Android
   browser_family: Android Browser
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; M-SP1AGO3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10 Go 3G
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP10PA Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 HD Pro
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP10PA3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 HD Pro 3G
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP1040M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 HD S4 3G
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP1040MC Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 HD S4 3G
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP1040S2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S2
   os_family: Android
   browser_family: Android Browser
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP1041S2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S2
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; M-MP1051S2 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.78"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S2
   os_family: Android
   browser_family: Chrome
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP1S2A3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP10S4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S4
   os_family: Android
   browser_family: Android Browser
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP12S4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S4
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP1S4B3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S4 3G
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP1S4A3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 10.1 S4 3G
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; M-MP101S2 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 101 S2
   os_family: Android
   browser_family: Android Browser
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; it-it; M-MP1010i Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 1010i
   os_family: Android
   browser_family: Android Browser
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; M-MP102S2W Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 102 S2
   os_family: Android
   browser_family: Android Browser
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; M-MP102S2B Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 102 S2
   os_family: Android
   browser_family: Android Browser
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; M-MP720GO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Go
   os_family: Android
   browser_family: Android Browser
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP740GOx Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Go
   os_family: Android
   browser_family: Chrome
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP726GOx Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 7.0 Go
   os_family: Android
   browser_family: Chrome
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; it-it; M-MP722I Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 722I
   os_family: Android
   browser_family: Android Browser
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SmartPad7503G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 750 3G
   os_family: Android
   browser_family: Android Browser
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-IPRO110B Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 HD iPro110 3G
   os_family: Android
   browser_family: Chrome
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-IPRO800B Build/Version1.20) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 HD iPro800 3G
   os_family: Android
   browser_family: Chrome
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-IPRO810B Build/Version1.30) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 HD iPro810 3G
   os_family: Android
   browser_family: Chrome
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-IPRO810W Build/Version1.20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 HD iPro810 3G
   os_family: Android
   browser_family: Chrome
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP8PA3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 HD Pro 3G
   os_family: Android
   browser_family: Chrome
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP842M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 Mobile
   os_family: Android
   browser_family: Chrome
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP840M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Safari/537.36 OPR/29.0.1809.92117
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "29.0.1809.92117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 Mobile
   os_family: Android
   browser_family: Opera
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; M-MP876S2 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 M
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S2
   os_family: Android
   browser_family: Android Browser
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP8S2A3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S2 3G
   os_family: Android
   browser_family: Android Browser
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; M-MP8S23G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP8S2B3G Build/MEDIACOM Version 1.20 (01/2015)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S2 3G
   os_family: Android
   browser_family: Chrome
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP82S4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S4
   os_family: Android
   browser_family: Android Browser
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP84S4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S4
   os_family: Android
   browser_family: Android Browser
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-ch; M-MP8S4A3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S4 3G
   os_family: Android
   browser_family: Android Browser
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; M-MP8S4B3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 8.0 S4 3G
   os_family: Android
   browser_family: Chrome
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; M-MP860S2 Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 860 S2
   os_family: Android
   browser_family: Opera
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; M-MP875S2 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 875 S2
   os_family: Android
   browser_family: Android Browser
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; M-MP85S23G Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 875 S2 3G
   os_family: Android
   browser_family: Android Browser
@@ -2283,19 +2055,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.2.1; M-MP940M Build/JOP40D[20131128.193712]) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 9.7 Mobile
   os_family: Android
   browser_family: Chrome
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-it; M-MP9S4A3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 9.7 S4 3G
   os_family: Android
   browser_family: Android Browser
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; SmartPad970s2 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 970 S2
   os_family: Android
   browser_family: Android Browser
@@ -2343,19 +2109,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; SmartPad970s23G Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad 970 S2 3G
   os_family: Android
   browser_family: Android Browser
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; M-SP10MXA Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MC
+    brand: Mediacom
     model: SmartPad MX 10
   os_family: Android
   browser_family: Chrome
@@ -2383,19 +2145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; E1041X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: E1041X
   os_family: Android
   browser_family: Chrome
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; E1051X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: E1051X
   os_family: Android
   browser_family: Chrome
@@ -2423,19 +2181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; LIFETAB_E10310 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E10310
   os_family: Android
   browser_family: Chrome
@@ -2443,7 +2199,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; LIFETAB_E10312 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -2452,7 +2207,7 @@
     version: "3.4.16.1149292"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E10312
   os_family: Android
   browser_family: Unknown
@@ -2460,19 +2215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; LIFETAB_E10316 Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E10316
   os_family: Android
   browser_family: Chrome
@@ -2480,19 +2233,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; LIFETAB_E10320 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E10320
   os_family: Android
   browser_family: Android Browser
@@ -2500,19 +2251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; LIFETAB_E7310 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E7310
   os_family: Android
   browser_family: Chrome
@@ -2520,19 +2269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; LIFETAB_E7312 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E7312
   os_family: Android
   browser_family: Chrome
@@ -2540,7 +2287,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; LIFETAB_E7316 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.4.16.1149292.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -2549,7 +2295,7 @@
     version: "3.4.16.1149292"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab E7316
   os_family: Android
   browser_family: Unknown
@@ -2557,19 +2303,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; P1035X Build/LRX21V)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P1035X
   os_family: Android
   browser_family: Android Browser
@@ -2577,19 +2321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; P1035X Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P1035X
   os_family: Android
   browser_family: Chrome
@@ -2597,19 +2339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; P850X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P850X
   os_family: Android
   browser_family: Chrome
@@ -2617,19 +2357,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; P851X Build/MMB29M)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P851X
   os_family: Android
   browser_family: Android Browser
@@ -2637,19 +2375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; LIFETAB_P9514 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P9514
   os_family: Android
   browser_family: Chrome
@@ -2657,19 +2393,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; MD_LIFETAB_P9516 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P9516
   os_family: Android
   browser_family: Android Browser
@@ -2677,19 +2411,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MD_LIFETAB_P9516 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab P9516
   os_family: Android
   browser_family: Android Browser
@@ -2697,19 +2429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; S1035X Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab S1035X
   os_family: Android
   browser_family: Chrome
@@ -2717,19 +2447,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; LIFETAB_S9512 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab S9512
   os_family: Android
   browser_family: Android Browser
@@ -2737,19 +2465,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; LIFETAB_S9714 Build/JRO03R) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab S9714
   os_family: Android
   browser_family: Android Browser
@@ -2757,19 +2483,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0; X1030X Build/MRA58K)
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: MD
+    brand: Medion
     model: Lifetab X1030X
   os_family: Android
   browser_family: Android Browser
@@ -2777,19 +2501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; P70221 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MI
+    brand: MicroMax
     model: Canvas Tab
   os_family: Android
   browser_family: Chrome
@@ -2797,19 +2519,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Micromax P280 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MI
+    brand: MicroMax
     model: P280
   os_family: Android
   browser_family: Android Browser
@@ -2817,19 +2537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MAJESTIC TAB 371 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: MJ
+    brand: Majestic
     model: Tab 371
   os_family: Android
   browser_family: Chrome
@@ -2837,19 +2555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB 411 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MJ
+    brand: Majestic
     model: Tab 411 3G
   os_family: Android
   browser_family: Chrome
@@ -2857,19 +2573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB 647 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MJ
+    brand: Majestic
     model: Tab 647 3G
   os_family: Android
   browser_family: Chrome
@@ -2877,19 +2591,17 @@
   user_agent: Mozilla/5.0 (Linux;U; Android 4.0.4; en-us; MID102C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID102C
   os_family: Android
   browser_family: Android Browser
@@ -2897,19 +2609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MID102C Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID102C
   os_family: Android
   browser_family: Chrome
@@ -2917,19 +2627,17 @@
   user_agent: Mozilla/5.0 (Linux;U; Android 4.0.4; en-us; MID103C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID103C
   os_family: Android
   browser_family: Android Browser
@@ -2937,19 +2645,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID104C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID104C
   os_family: Android
   browser_family: Android Browser
@@ -2957,19 +2663,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID114C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID114C
   os_family: Android
   browser_family: Android Browser
@@ -2977,19 +2681,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MID43C Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID43C
   os_family: Android
   browser_family: Android Browser
@@ -2997,19 +2699,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MID701 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID701
   os_family: Android
   browser_family: Android Browser
@@ -3017,19 +2717,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID74C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID74C
   os_family: Android
   browser_family: Android Browser
@@ -3037,19 +2735,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MID77C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID77C
   os_family: Android
   browser_family: Android Browser
@@ -3057,19 +2753,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; MID7C Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID7C
   os_family: Android
   browser_family: Android Browser
@@ -3077,19 +2771,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; MID801 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID801
   os_family: Android
   browser_family: Android Browser
@@ -3097,19 +2789,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MID82C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID82C
   os_family: Android
   browser_family: Android Browser
@@ -3117,19 +2807,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MID84C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID84C
   os_family: Android
   browser_family: Android Browser
@@ -3137,19 +2825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; MID84C Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MID84C
   os_family: Android
   browser_family: Chrome
@@ -3157,19 +2843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MP100i OCTA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP100i OCTA
   os_family: Android
   browser_family: Chrome
@@ -3177,19 +2861,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MP1010 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP1010
   os_family: Android
   browser_family: Android Browser
@@ -3197,19 +2879,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MP7007 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP7007
   os_family: Android
   browser_family: Android Browser
@@ -3217,19 +2897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MP7007 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP7007
   os_family: Android
   browser_family: Opera
@@ -3237,19 +2915,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MP717 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP717
   os_family: Android
   browser_family: Android Browser
@@ -3257,19 +2933,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; MP843 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP843
   os_family: Android
   browser_family: Android Browser
@@ -3277,19 +2951,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MP888 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP888
   os_family: Android
   browser_family: Android Browser
@@ -3297,19 +2969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MP959 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP959
   os_family: Android
   browser_family: Android Browser
@@ -3317,19 +2987,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MP969 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MP969
   os_family: Android
   browser_family: Android Browser
@@ -3337,19 +3005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MPDC100 BT Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC100 BT
   os_family: Android
   browser_family: Chrome
@@ -3357,19 +3023,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; MPDC110 BT IPS Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC110 BT IPS
   os_family: Android
   browser_family: Android Browser
@@ -3377,19 +3041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MPDC112 BT IPS Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC112 BT IPS
   os_family: Android
   browser_family: Android Browser
@@ -3397,19 +3059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MPDC8 BT Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC8 BT
   os_family: Android
   browser_family: Android Browser
@@ -3417,7 +3077,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MPDC88 BT IPS Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/2.0.0.392829
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -3426,7 +3085,7 @@
     version: "2.0.0.392829"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC88 BT IPS
   os_family: Android
   browser_family: Unknown
@@ -3434,19 +3093,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MPDC903 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPDC903
   os_family: Android
   browser_family: Android Browser
@@ -3454,19 +3111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MPQC1030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC1030
   os_family: Android
   browser_family: Chrome
@@ -3474,19 +3129,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MPQC30i) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC30i
   os_family: Android
   browser_family: Chrome
@@ -3494,19 +3147,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MPQC704 HD Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC704 HD
   os_family: Android
   browser_family: Android Browser
@@ -3514,19 +3165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MPQC730) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC730
   os_family: Android
   browser_family: Chrome
@@ -3534,19 +3183,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; MPQC784 IPS Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC784 IPS
   os_family: Android
   browser_family: Android Browser
@@ -3554,19 +3201,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; MPQC804HD Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MM
+    brand: Mpman
     model: MPQC804HD
   os_family: Android
   browser_family: Android Browser
@@ -3574,19 +3219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MegaFon Login 3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MP
+    brand: MegaFon
     model: Login 3
   os_family: Android
   browser_family: Chrome
@@ -3594,19 +3237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MFLogin3T Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36 YandexSearch/6.45/apad
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MP
+    brand: MegaFon
     model: Login 3
   os_family: Android
   browser_family: Chrome
@@ -3614,19 +3255,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; M.T.T. Tablet Build/M.T.T.) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MQ
+    brand: M.T.T.
     model: Tablet
   os_family: Android
   browser_family: Android Browser
@@ -3634,19 +3273,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.0.1; en-gb; MZ601 Build/H.6.1-38-1) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Android Browser
@@ -3654,19 +3291,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; en-us; MZ601 Build/H.6.3-25-5) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Android Browser
@@ -3674,19 +3309,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-gb; MZ601 Build/H.6.5-17-3) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Android Browser
@@ -3694,19 +3327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; MZ601 Build/I.7.1-45) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Android Browser
@@ -3714,19 +3345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MZ601 Build/I.7.1-42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "18.0.1290.67495"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Opera
@@ -3734,19 +3363,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; MZ601 Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ601
   os_family: Android
   browser_family: Android Browser
@@ -3754,19 +3381,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-us; MZ604 Build/H.6.6-23) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ604
   os_family: Android
   browser_family: Android Browser
@@ -3774,19 +3399,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; MZ604 Build/I.7.1-42) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ604
   os_family: Android
   browser_family: Android Browser
@@ -3794,19 +3417,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.2; en-us; MZ617 Build/1.6.0M_279_MZ617) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: MZ617
   os_family: Android
   browser_family: Android Browser
@@ -3814,19 +3435,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; en-us; Xoom Build/HMJ25) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: Xoom
   os_family: Android
   browser_family: Android Browser
@@ -3834,19 +3453,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.2; he-il; XOOM 2 Build/1.6.0_268.4-MZ616) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: XOOM 2
   os_family: Android
   browser_family: Android Browser
@@ -3854,19 +3471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; XOOM 2 Build/7.7.1-128_MZ615-12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: XOOM 2
   os_family: Android
   browser_family: Chrome
@@ -3874,19 +3489,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; fr-fr; XOOM 2 ME Build/1.6.0_218.3-MZ607) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: XOOM 2 ME
   os_family: Android
   browser_family: Android Browser
@@ -3894,19 +3507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xoom Wifi Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MR
+    brand: Motorola
     model: Xoom Wifi
   os_family: Android
   browser_family: Chrome
@@ -3914,19 +3525,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-fr; Slidepad Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad
   os_family: Android
   browser_family: Android Browser
@@ -3934,19 +3543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; SLIDEPAD Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad
   os_family: Android
   browser_family: Android Browser
@@ -3954,19 +3561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SlidePad 104 Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31 OPR/14.0.1074.58201
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "14.0.1074.58201"
     engine: Presto
     engine_version: ""
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 104
   os_family: Android
   browser_family: Opera
@@ -3974,19 +3579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SlidePad 108 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 108
   os_family: Android
   browser_family: Android Browser
@@ -3994,19 +3597,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; SP704C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 704C
   os_family: Android
   browser_family: Android Browser
@@ -4014,19 +3615,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; SP704CE Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 704CE
   os_family: Android
   browser_family: Android Browser
@@ -4034,19 +3633,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SlidePad704CE Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 704CE
   os_family: Android
   browser_family: Android Browser
@@ -4054,7 +3651,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; SlidePad704CE Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.1.24.941712.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -4063,7 +3659,7 @@
     version: "3.1.24.941712"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 704CE
   os_family: Android
   browser_family: Unknown
@@ -4071,19 +3667,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; SlidePad 816P Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad 816P
   os_family: Android
   browser_family: Android Browser
@@ -4091,19 +3685,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; SlidePad Elite 9708 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad Elite 9708
   os_family: Android
   browser_family: Android Browser
@@ -4111,19 +3703,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SlidePad Elite 9708 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad Elite 9708
   os_family: Android
   browser_family: Opera
@@ -4131,19 +3721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SlidePad Kids Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Mobile Safari/537.36 OPR/21.0.1437.74904
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad Kids
   os_family: Android
   browser_family: Opera
@@ -4151,19 +3739,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; SlidePad NG 116DC Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG 116DC
   os_family: Android
   browser_family: Android Browser
@@ -4171,19 +3757,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; SlidePad NG 116DC Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG 116DC
   os_family: Android
   browser_family: Android Browser
@@ -4191,19 +3775,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; SlidePad NG 704DC Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG 704DC
   os_family: Android
   browser_family: Android Browser
@@ -4211,19 +3793,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; SPNG708 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG708
   os_family: Android
   browser_family: Android Browser
@@ -4231,19 +3811,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.0.3; en-US; SPNG708) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG708
   os_family: Android
   browser_family: Unknown
@@ -4251,19 +3829,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; SPNG808 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG808
   os_family: Android
   browser_family: Android Browser
@@ -4271,19 +3847,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; SPNG9708 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG9708
   os_family: Android
   browser_family: Android Browser
@@ -4291,19 +3865,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SPNG9716DC Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MU
+    brand: Memup
     model: SlidePad NG9716DC
   os_family: Android
   browser_family: Android Browser
@@ -4311,19 +3883,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MyPad 1000 HD Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MY
+    brand: MyPhone
     model: MyPad 1000 HD
   os_family: Android
   browser_family: Android Browser
@@ -4331,19 +3901,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us ; MyPad 2 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.6.1.262/145/405
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.6.1.262"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: MY
+    brand: MyPhone
     model: MyPad 2
   os_family: Android
   browser_family: Unknown
@@ -4351,19 +3919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MyPad 750HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MY
+    brand: MyPhone
     model: MyPad 750HD
   os_family: Android
   browser_family: Chrome
@@ -4371,19 +3937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; myTab10II Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MY
+    brand: MyPhone
     model: MyTab 10 II
   os_family: Android
   browser_family: Chrome
@@ -4391,19 +3955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; myTab_10_Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MY
+    brand: MyPhone
     model: MyTab 10 Q
   os_family: Android
   browser_family: Chrome
@@ -4411,19 +3973,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; Enjoy 7 Plus Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MZ
+    brand: MSI
     model: Enjoy 7 Plus
   os_family: Android
   browser_family: Android Browser
@@ -4431,19 +3991,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Primo76 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: MZ
+    brand: MSI
     model: Primo 76
   os_family: Android
   browser_family: Chrome
@@ -4451,19 +4009,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Primo 91 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: MZ
+    brand: MSI
     model: Primo 91
   os_family: Android
   browser_family: Android Browser
@@ -4471,19 +4027,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MTN-8978P Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: N4
+    brand: MTN
     model: Steppa
   os_family: Android
   browser_family: Chrome
@@ -4491,19 +4045,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; PC-TE508HAW Build/NMF26F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NE
+    brand: NEC
     model: LAVIE Tab E TE508
   os_family: Android
   browser_family: Chrome
@@ -4511,19 +4063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07000 Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07000
   os_family: Android
   browser_family: Chrome
@@ -4531,19 +4081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07002
   os_family: Android
   browser_family: Chrome
@@ -4551,19 +4099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07002HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07002HD
   os_family: Android
   browser_family: Chrome
@@ -4571,19 +4117,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07003) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07003
   os_family: Android
   browser_family: Chrome
@@ -4591,19 +4135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07005
   os_family: Android
   browser_family: Chrome
@@ -4611,19 +4153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07008) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07008
   os_family: Android
   browser_family: Chrome
@@ -4631,19 +4171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C07850) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C07850
   os_family: Android
   browser_family: Chrome
@@ -4651,19 +4189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C10100) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C10100
   os_family: Android
   browser_family: Chrome
@@ -4671,19 +4207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C10101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C10101
   os_family: Android
   browser_family: Chrome
@@ -4691,19 +4225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C10102) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C10102
   os_family: Android
   browser_family: Chrome
@@ -4711,19 +4243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; C10103) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: C10103
   os_family: Android
   browser_family: Chrome
@@ -4731,19 +4261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; C101010 Ultra2 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NM
+    brand: Nomi
     model: Ultra 2
   os_family: Android
   browser_family: Chrome
@@ -4751,19 +4279,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; NX785QC8G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: "8"
   os_family: Android
   browser_family: Android Browser
@@ -4771,19 +4297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; NXM900MC Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: 8 HD
   os_family: Android
   browser_family: Chrome
@@ -4791,19 +4315,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; NXA8QC116 Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.62 Safari/537.36 OPR/37.0.2254.130605
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "37.0.2254.130605"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Ares 8
   os_family: Android
   browser_family: Opera
@@ -4811,19 +4333,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; Next10P12 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Next 10P12
   os_family: Android
   browser_family: Android Browser
@@ -4831,19 +4351,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; Next7P12-8G Build/IMM76I) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Next 7P12-8G
   os_family: Android
   browser_family: Chrome
@@ -4851,19 +4369,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Next800K Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Next 800K
   os_family: Android
   browser_family: Android Browser
@@ -4871,19 +4387,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; Next8P12 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Next 8P12
   os_family: Android
   browser_family: Android Browser
@@ -4891,19 +4405,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Next9P Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Next 9P
   os_family: Android
   browser_family: Android Browser
@@ -4911,19 +4423,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; NX010HI8G Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Premium 10 Hi
   os_family: Android
   browser_family: Android Browser
@@ -4931,19 +4441,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; en-gb; NXM726 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Premium 7
   os_family: Android
   browser_family: Android Browser
@@ -4951,7 +4459,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-us; NX008HD8G Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -4960,7 +4467,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Premium 8 HD
   os_family: Android
   browser_family: Unknown
@@ -4968,19 +4475,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; NXM908HC Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: NT
+    brand: NextBook
     model: Premium 9
   os_family: Android
   browser_family: Android Browser
@@ -4988,19 +4493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SHIELD Tablet K1 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NV
+    brand: Nvidia
     model: SHIELD Tablet K1
   os_family: Android
   browser_family: Chrome
@@ -5008,19 +4511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tegra Note 7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NV
+    brand: Nvidia
     model: Tegra Note 7
   os_family: Android
   browser_family: Chrome
@@ -5028,19 +4529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TegraNote-P1640) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: NV
+    brand: Nvidia
     model: Tegra Note P1640
   os_family: Android
   browser_family: Chrome
@@ -5048,19 +4547,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; AEON Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Aeon
   os_family: Android
   browser_family: Android Browser
@@ -5068,19 +4565,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; CONNECT7PRO Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Connect 7 Pro
   os_family: Android
   browser_family: Android Browser
@@ -5088,19 +4583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CONNECT8PLUS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Connect 8 Plus
   os_family: Android
   browser_family: Chrome
@@ -5108,19 +4601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ELEMENT10_PLUS_3G Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Element 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5128,19 +4619,17 @@
   user_agent: Kinder-Tablet-1.0-Weltbild-Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; EOS10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: EOS 10
   os_family: Android
   browser_family: Android Browser
@@ -5148,19 +4637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; FALCON_10_PLUS_3G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.68 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.68"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Falcon 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5168,19 +4655,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; FUSION Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Fusion 7
   os_family: Android
   browser_family: Android Browser
@@ -5188,19 +4673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; IEOS_QUAD_10_PRO Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Ieos QUAD 10 PRO
   os_family: Android
   browser_family: Chrome
@@ -5208,19 +4691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; JUNIOR_8_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Junior 8 Pro
   os_family: Android
   browser_family: Chrome
@@ -5228,19 +4709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; MAVEN10_HD Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven 10 HD
   os_family: Android
   browser_family: Chrome
@@ -5248,19 +4727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MAVEN_10_PLUS Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven 10 Plus
   os_family: Android
   browser_family: Chrome
@@ -5268,19 +4745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MAVEN_10_PRO Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5288,19 +4763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MAVEN10_PRO_PLUS_3G Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven 10 Pro Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5308,19 +4781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MAVEN_X10_HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven X10 HD
   os_family: Android
   browser_family: Chrome
@@ -5328,19 +4799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MAVEN_X10_HD_LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Maven X10 HD LTE
   os_family: Android
   browser_family: Chrome
@@ -5348,19 +4817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; ADM816HC Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Neo X
   os_family: Android
   browser_family: Android Browser
@@ -5368,19 +4835,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; NOON Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Noon
   os_family: Android
   browser_family: Android Browser
@@ -5388,19 +4853,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; ODYS-NOON Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Noon
   os_family: Android
   browser_family: Android Browser
@@ -5408,19 +4871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RAPID_10_LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Rapid 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -5428,19 +4889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; RAPID7LTE Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Rapid 7 LTE
   os_family: Android
   browser_family: Chrome
@@ -5448,19 +4907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SPACE10_PLUS_3G Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Space 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5468,19 +4925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SPACE10_PRO_3G Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Space 10 Pro 3G
   os_family: Android
   browser_family: Chrome
@@ -5488,19 +4943,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; TAO_X10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Tao X10
   os_family: Android
   browser_family: Android Browser
@@ -5508,19 +4961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; THANOS_10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Thanos 10
   os_family: Android
   browser_family: Chrome
@@ -5528,19 +4979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; THOR10 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.78 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "60.0.3112.78"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Thor 10
   os_family: Android
   browser_family: Chrome
@@ -5548,19 +4997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; THOR_10 Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Thor 10
   os_family: Android
   browser_family: Chrome
@@ -5568,19 +5015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; THOR_10_PLUS_3G Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Thor 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5588,19 +5033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; THOR10_PLUS_3G Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Thor 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5608,19 +5051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; ADM8000KP Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Titan
   os_family: Android
   browser_family: Android Browser
@@ -5628,19 +5069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; XELIO10_PLUS_3G Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Xelio 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5648,19 +5087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-at; XELIO10EXTREME Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Xelio 10 Xtreme
   os_family: Android
   browser_family: Android Browser
@@ -5668,19 +5105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; XELIO_A10 Build/O11019) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Xelio A10
   os_family: Android
   browser_family: Chrome
@@ -5688,19 +5123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; XELIO_NEXT_10_PLUS_3G Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Xelio Next 10 Plus 3G
   os_family: Android
   browser_family: Chrome
@@ -5708,19 +5141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; XELIOPHONETAB3 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O1
+    brand: Odys
     model: Xelio Phonetab 3
   os_family: Android
   browser_family: Chrome
@@ -5728,19 +5159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ONA19TB002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O4
+    brand: ONN
     model: ONA19TB002
   os_family: Android
   browser_family: Chrome
@@ -5748,19 +5177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; ONA19TB007 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: O4
+    brand: ONN
     model: ONA19TB007
   os_family: Android
   browser_family: Chrome
@@ -5768,19 +5195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; OYYUT11 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: O6
+    brand: Oyyu
     model: T11 3G
   os_family: Android
   browser_family: Chrome
@@ -5788,19 +5213,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; ONDA MID Build/ICS.g12refM1006.20120915) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: MID
   os_family: Android
   browser_family: Android Browser
@@ -5808,19 +5231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; OBOOK10 SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: oBook 10 SE
   os_family: Android
   browser_family: Chrome
@@ -5828,19 +5249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T2101L2B1C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: oBook 20 Plus Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5848,19 +5267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; OBOOK 20 PLUS DUALOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: oBook 20 Plus Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5868,19 +5285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; OBOOK 20 SE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: oBook 20 SE
   os_family: Android
   browser_family: Chrome
@@ -5888,19 +5303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; V10 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V10 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -5908,19 +5321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V820w-DualOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V820W Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5928,19 +5339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V891-DualOS Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.8 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.8"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V891 Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5948,19 +5357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V891w DualOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V891W Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5968,19 +5375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V919 3G Air DualOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V919 3G Air Dual OS
   os_family: Android
   browser_family: Chrome
@@ -5988,19 +5393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V919 4G Air Core8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V919 4G Air Core 8
   os_family: Android
   browser_family: Chrome
@@ -6008,19 +5411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; V919 Air CH DualOS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V919 Air CH Dual OS
   os_family: Android
   browser_family: Chrome
@@ -6028,19 +5429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V919 Air DualOS Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.0.2651.48970
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.0.2651.48970"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V919 Air Dual OS
   os_family: Android
   browser_family: Opera
@@ -6048,19 +5447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; V989 Air Core8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OD
+    brand: Onda
     model: V989 Air Core 8
   os_family: Android
   browser_family: Chrome
@@ -6068,19 +5465,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; FunTab 8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OR
+    brand: Orange
     model: FunTab 8
   os_family: Android
   browser_family: Android Browser
@@ -6088,19 +5483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Orange Sego Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OR
+    brand: Orange
     model: Sego
   os_family: Android
   browser_family: Chrome
@@ -6108,19 +5501,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; OV-BasicTab Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-BasicTab
   os_family: Android
   browser_family: Android Browser
@@ -6128,19 +5519,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; OV-Quattor10 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-Quattor10
   os_family: Android
   browser_family: Android Browser
@@ -6148,19 +5537,17 @@
   user_agent: OV-SteelCore(B) Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.34 Safari/534.24
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "11.0.696.34"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-SteelCore
   os_family: GNU/Linux
   browser_family: Chrome
@@ -6168,19 +5555,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; OV-SteelCore10+II Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-SteelCore10+II
   os_family: Android
   browser_family: Android Browser
@@ -6188,19 +5573,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-TB-07B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-TB-07B
   os_family: Android
   browser_family: Android Browser
@@ -6208,19 +5591,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ro-ro; OV-TB-07B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-TB-07B
   os_family: Android
   browser_family: Android Browser
@@ -6228,19 +5609,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; OV-TB-08 II Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: OV-TB-08 II
   os_family: Android
   browser_family: Android Browser
@@ -6248,19 +5627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Qualcore 1010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: Qualcore 1010
   os_family: Android
   browser_family: Chrome
@@ -6268,19 +5645,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; OV10273G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: Qualcore 1027 3G
   os_family: Android
   browser_family: Chrome
@@ -6288,19 +5663,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; OV10274G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OV
+    brand: Overmax
     model: Qualcore 1027 4G
   os_family: Android
   browser_family: Chrome
@@ -6308,19 +5681,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 6.0.1; AT101-1116 Build/MOB30R)
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: OX
+    brand: Onix
     model: AT101-1116
   os_family: Android
   browser_family: Android Browser
@@ -6328,19 +5699,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.0; T102ER3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T102ER 3G
   os_family: Android
   browser_family: Chrome
@@ -6348,19 +5717,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T102MS_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T102MS 3G
   os_family: Android
   browser_family: Chrome
@@ -6368,19 +5735,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T104B_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104B 3G
   os_family: Android
   browser_family: Chrome
@@ -6388,19 +5753,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; T104B_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104B 4G
   os_family: Android
   browser_family: Chrome
@@ -6408,19 +5771,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T104ER4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.118 YaBrowser/15.4.2272.3608.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "15.4.2272.3608.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104ER 4G
   os_family: Android
   browser_family: Unknown
@@ -6428,19 +5789,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Oysters T104HVi 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.3.2672.50220
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.3.2672.50220"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104HVi 3G
   os_family: Android
   browser_family: Opera
@@ -6448,19 +5807,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T104MBi_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104MBi 3G
   os_family: Android
   browser_family: Chrome
@@ -6468,19 +5825,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T104SCi_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T104SCi 3G
   os_family: Android
   browser_family: Chrome
@@ -6488,19 +5843,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; OYSTERS T14N 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "19.0.1340.69721"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T14N 3G
   os_family: Android
   browser_family: Opera
@@ -6508,19 +5861,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Oysters T3 3G Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T3 3G
   os_family: Android
   browser_family: Android Browser
@@ -6528,19 +5879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T72HA_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T72HA 3G
   os_family: Android
   browser_family: Chrome
@@ -6548,19 +5897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T72HM3G Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T72HM3G
   os_family: Android
   browser_family: Chrome
@@ -6568,19 +5915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T72HMs_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T72HMs 3G
   os_family: Android
   browser_family: Chrome
@@ -6588,19 +5933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T74D_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74D 3G
   os_family: Android
   browser_family: Chrome
@@ -6608,19 +5951,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; T74HMi_4G AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74HMi 4G
   os_family: Android
   browser_family: Chrome
@@ -6628,19 +5969,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T74Mai_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74MAi 3G
   os_family: Android
   browser_family: Chrome
@@ -6648,19 +5987,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T74MR4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74MR 4G
   os_family: Android
   browser_family: Chrome
@@ -6668,19 +6005,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T74N_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74N 3G
   os_family: Android
   browser_family: Chrome
@@ -6688,19 +6023,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T74SC_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T74SC 3G
   os_family: Android
   browser_family: Chrome
@@ -6708,19 +6041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; Oysters T7X 3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T7X 3G
   os_family: Android
   browser_family: Android Browser
@@ -6728,19 +6059,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; T84Bi_4G AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T84Bi 4G
   os_family: Android
   browser_family: Chrome
@@ -6748,19 +6077,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; T84ERi_3G Build/HD) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T84ERi 3G
   os_family: Android
   browser_family: Chrome
@@ -6768,19 +6095,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T84Ni_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T84Ni 3G
   os_family: Android
   browser_family: Chrome
@@ -6788,19 +6113,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; T84Ni_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: OY
+    brand: Oysters
     model: T84Ni 4G
   os_family: Android
   browser_family: Chrome
@@ -6808,19 +6131,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; PLT7035-C Build/MID713) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: P1
+    brand: ProScan
     model: PLT7035-C
   os_family: Android
   browser_family: Android Browser
@@ -6828,19 +6149,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-ca; PLT7044K-B Build/MID713) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: P1
+    brand: ProScan
     model: PLT7044K-B
   os_family: Android
   browser_family: Android Browser
@@ -6848,19 +6167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; PLT7602G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: P1
+    brand: ProScan
     model: PLT7602G
   os_family: Android
   browser_family: Android Browser
@@ -6868,19 +6185,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; PLT7802 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: P1
+    brand: ProScan
     model: PLT7802
   os_family: Android
   browser_family: Android Browser
@@ -6888,19 +6203,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; POLYTRON T7800 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: P5
+    brand: Polytron
     model: Cosmica T7800
   os_family: Android
   browser_family: Android Browser
@@ -6908,19 +6221,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; POLYTRON_T7700 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: P5
+    brand: Polytron
     model: Rocket Pad
   os_family: Android
   browser_family: Chrome
@@ -6928,19 +6239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; H10882M-TN Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/37.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "37.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: P6
+    brand: Proline
     model: H10882M-TN
   os_family: Android
   browser_family: Chrome
@@ -6948,19 +6257,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PocketBook SURFpad 3 (10,1) Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: P8
+    brand: PocketBook
     model: Surfpad 3 10.1"
   os_family: Android
   browser_family: Chrome
@@ -6968,19 +6275,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PocketBook SURFpad 3 (7,85))
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: P8
+    brand: PocketBook
     model: Surfpad 3 7.85"
   os_family: Android
   browser_family: Android Browser
@@ -6988,19 +6293,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PD-3127 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: P9
+    brand: Primepad
     model: PD-3127
   os_family: Android
   browser_family: Chrome
@@ -7008,19 +6311,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PD-3127NC Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: P9
+    brand: Primepad
     model: PD-3127NC
   os_family: Android
   browser_family: Chrome
@@ -7028,19 +6329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; P-08D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PA
+    brand: Panasonic
     model: Eluga Live 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -7048,19 +6347,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; FZ-B2D Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PA
+    brand: Panasonic
     model: Toughpad FZ-B2D
   os_family: Android
   browser_family: Chrome
@@ -7068,19 +6365,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PCB-T103 CURI LITE Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PB
+    brand: PCBOX
     model: Curi Lite
   os_family: Android
   browser_family: Chrome
@@ -7088,19 +6383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; PCB-T715 Build/MXC89K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PB
+    brand: PCBOX
     model: T715
   os_family: Android
   browser_family: Chrome
@@ -7108,19 +6401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; PENTAGRAM_EON_PRIX Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: PG
+    brand: Pentagram
     model: Eon Prix
   os_family: Android
   browser_family: Android Browser
@@ -7128,19 +6419,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Quadra 7 UltraSlim Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Safari/537.36 OPR/25.0.1619.84037
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "25.0.1619.84037"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PG
+    brand: Pentagram
     model: Quadra 7 UltraSlim
   os_family: Android
   browser_family: Opera
@@ -7148,19 +6437,17 @@
   user_agent: Mozilla/5.0 (Linux;4.1.1;Quadra 7 UltraSlim AppleWebKit/537.36 (KHTML, like Gecko) Chrome/ 192.168.1.16 Mobile Safari/537.36
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: PG
+    brand: Pentagram
     model: Quadra 7 UltraSlim
   os_family: GNU/Linux
   browser_family: Chrome
@@ -7168,19 +6455,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; PentagramTAB7.6 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PG
+    brand: Pentagram
     model: Tab 7.6
   os_family: Android
   browser_family: Android Browser
@@ -7188,19 +6473,17 @@
   user_agent: Android 4.1.1;AppleWebKit/534.30;Build/JRO03C;PENTAGRAM TAB 8.5 Build/JRO03C
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PG
+    brand: Pentagram
     model: Tab 8.5
   os_family: Android
   browser_family: Android Browser
@@ -7208,19 +6491,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; PI3210G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PH
+    brand: Philips
     model: PI3210G
   os_family: Android
   browser_family: Android Browser
@@ -7228,19 +6509,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TLE722G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PH
+    brand: Philips
     model: TLE722G
   os_family: Android
   browser_family: Chrome
@@ -7248,19 +6527,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TLE821L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PH
+    brand: Philips
     model: TLE821L 4G LTE
   os_family: Android
   browser_family: Chrome
@@ -7268,19 +6545,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; dvr700pi) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PI
+    brand: Pioneer
     model: DVR700PI 7.0"
   os_family: Android
   browser_family: Chrome
@@ -7288,19 +6563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.3; zh-CN; R1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.6.0.620 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.6.0.620"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PI
+    brand: Pioneer
     model: R1
   os_family: Android
   browser_family: Unknown
@@ -7308,19 +6581,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MID0714PGE02.133 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MID0714
   os_family: Android
   browser_family: Android Browser
@@ -7328,19 +6599,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MID0714PCE01 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MID0714
   os_family: Android
   browser_family: Android Browser
@@ -7348,19 +6617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; nl-nl; MID0714 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MID0714
   os_family: Android
   browser_family: Android Browser
@@ -7368,7 +6635,6 @@
   user_agent: AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; MID0714 Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -7377,7 +6643,7 @@
     version: "4.1.1"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MID0714
   os_family: Android
   browser_family: Unknown
@@ -7385,19 +6651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MID1014 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MID1014
   os_family: Android
   browser_family: Android Browser
@@ -7405,19 +6669,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-sg; MIDC010PR001 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC010PR001
   os_family: Android
   browser_family: Android Browser
@@ -7425,19 +6687,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; MIDC110 Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC110
   os_family: Android
   browser_family: Android Browser
@@ -7445,19 +6705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MIDC124 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC124
   os_family: Android
   browser_family: Android Browser
@@ -7465,19 +6723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MIDC127 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC127
   os_family: Android
   browser_family: Android Browser
@@ -7485,19 +6741,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; MIDC128 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC128
   os_family: Android
   browser_family: Android Browser
@@ -7505,19 +6759,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MIDC407 Build/eng.glwx.20121119.172601) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC407
   os_family: Android
   browser_family: Android Browser
@@ -7525,19 +6777,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MIDC408 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC408
   os_family: Android
   browser_family: Android Browser
@@ -7545,19 +6795,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MIDC408PR002 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC408PR002
   os_family: Android
   browser_family: Android Browser
@@ -7565,19 +6813,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; MIDC409 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC409
   os_family: Android
   browser_family: Android Browser
@@ -7585,19 +6831,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MIDC410 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC410
   os_family: Android
   browser_family: Android Browser
@@ -7605,19 +6849,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; MIDC410PR Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC410PR
   os_family: Android
   browser_family: Android Browser
@@ -7625,19 +6867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MIDC430 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC430
   os_family: Android
   browser_family: Android Browser
@@ -7645,19 +6885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MIDC497 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC497
   os_family: Android
   browser_family: Chrome
@@ -7665,19 +6903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; it-it; MIDC801 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC801
   os_family: Android
   browser_family: Android Browser
@@ -7685,19 +6921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MIDC802 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC802
   os_family: Android
   browser_family: Android Browser
@@ -7705,19 +6939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MIDC901 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC901
   os_family: Android
   browser_family: Chrome
@@ -7725,19 +6957,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MIDC970 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDC970
   os_family: Android
   browser_family: Android Browser
@@ -7745,19 +6975,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MIDCD10 Build/ICS.d5h1083_8188.20121126) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDCD10
   os_family: Android
   browser_family: Android Browser
@@ -7765,19 +6993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; MIDCD97 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: MIDCD97
   os_family: Android
   browser_family: Android Browser
@@ -7785,19 +7011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; PMID4311 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: PMID4311
   os_family: Android
   browser_family: Android Browser
@@ -7805,19 +7029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PMID71C Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PL
+    brand: Polaroid
     model: PMID71C
   os_family: Android
   browser_family: Chrome
@@ -7825,19 +7047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; T-i708D Build/LMY49F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PN
+    brand: Panacom
     model: T-i708D
   os_family: Android
   browser_family: Chrome
@@ -7845,19 +7065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; Build/ICS.polypad.7208HD.Dualcore.20121101) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PP
+    brand: PolyPad
     model: 7208HD
   os_family: Android
   browser_family: Android Browser
@@ -7865,19 +7083,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; tr-tr; POLY PAD_8208HD Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PP
+    brand: PolyPad
     model: 8208HD
   os_family: Android
   browser_family: Android Browser
@@ -7885,19 +7101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; PGPS7797) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: Geo Vision Tour 2
   os_family: Android
   browser_family: Chrome
@@ -7905,19 +7119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PGPS7799CIS08GBPG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: Geo Vision Tour 3
   os_family: Android
   browser_family: Chrome
@@ -7925,19 +7137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; PMT3201_4G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/69.0.3497.100 Safari/537.36 YandexSearch/7.90/apad YandexSearchBrowser/7.90
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: Grace 4G
   os_family: Android
   browser_family: Chrome
@@ -7945,19 +7155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1.1; PSP5551DUO Build/LMY48B; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Mobile Safari/537.36 OPR/44.1.2254.143214
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "44.1.2254.143214"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: Grace S5
   os_family: Android
   browser_family: Opera
@@ -7965,19 +7173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; PMT3277_3G Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: MultiPad Ranger 7.0 3G
   os_family: Android
   browser_family: Chrome
@@ -7985,19 +7191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; PMT3287_3G Build/JLS36C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: MultiPad Ranger 8.0 3G
   os_family: Android
   browser_family: Chrome
@@ -8005,19 +7209,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; PMT3208_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36 OPR/55.0.2719.50560
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "55.0.2719.50560"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: MultiPad Wize 8.0 3G
   os_family: Android
   browser_family: Opera
@@ -8025,19 +7227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; PMP3370B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP3370B
   os_family: Android
   browser_family: Android Browser
@@ -8045,19 +7245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PMP3670B Build/PMP3670B_20130323_v1.0.9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP3670B
   os_family: Android
   browser_family: Android Browser
@@ -8065,19 +7263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; PMP5080B Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5080B
   os_family: Android
   browser_family: Android Browser
@@ -8085,19 +7281,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; PMP5080CPRO Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5080CPRO
   os_family: Android
   browser_family: Android Browser
@@ -8105,19 +7299,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; cs-cz; PMP5101C_QUAD Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5101C QUAD
   os_family: Android
   browser_family: Android Browser
@@ -8125,19 +7317,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; sk-sk; PMP5570C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5570C
   os_family: Android
   browser_family: Android Browser
@@ -8145,19 +7335,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; PMP5580C Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5580C
   os_family: Android
   browser_family: Android Browser
@@ -8165,19 +7353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; PMP5580C Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5580C
   os_family: Android
   browser_family: Chrome
@@ -8185,19 +7371,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.2.1; PMP5588C Build/E8HD-ELITE-1280x768) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5588C
   os_family: Android
   browser_family: Chrome
@@ -8205,19 +7389,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; PMP5770D Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5770D
   os_family: Android
   browser_family: Android Browser
@@ -8225,19 +7407,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PMP5870C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP5870C
   os_family: Android
   browser_family: Android Browser
@@ -8245,19 +7425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PMP7079D3G_QUAD Build/JDQ39) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7079D3G QUAD
   os_family: Android
   browser_family: Chrome
@@ -8265,19 +7443,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; PMP7100D3G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7100D3G
   os_family: Android
   browser_family: Android Browser
@@ -8285,19 +7461,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; PMP7170B3G Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7170B3G
   os_family: Android
   browser_family: Chrome
@@ -8305,19 +7479,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; PMP7170B3G_DUO Build/JZO54K) AppleWebKit/534.30 (KHTML, \xd0\xba\xd0\xb0\xd0\xba Gecko) Version/4.0 \xd0\x9c\xd0\xbe\xd0\xb1\xd0\xb8\xd0\xbb\xd1\x8c\xd0\xbd\xd1\x8b\xd0\xb9Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7170B3G DUO
   os_family: Android
   browser_family: Android Browser
@@ -8325,19 +7497,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; PMP7280C Build/PMP7280C_20130123_v1.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7280C
   os_family: Android
   browser_family: Android Browser
@@ -8345,19 +7515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; PMP7280C3G_QUAD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7280C3G QUAD
   os_family: Android
   browser_family: Chrome
@@ -8365,19 +7533,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PMP7880D3G Build/PMP7880D3G_20130220_v1.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: PMP7880D3G
   os_family: Android
   browser_family: Android Browser
@@ -8385,19 +7551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PSP7610DUO Build/OPM2.171019.012) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: S Max
   os_family: Android
   browser_family: Chrome
@@ -8405,19 +7569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; PSP7610DUO_RU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: S Max
   os_family: Android
   browser_family: Chrome
@@ -8425,19 +7587,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; PSP7546DUO_RU AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: X Pro
   os_family: Android
   browser_family: Chrome
@@ -8445,19 +7605,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 8.1.0; en-US; PSP7546DUO Build/OPM2.171019.012 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.0.1187 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.0.1187"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: PR
+    brand: Prestigio
     model: X Pro
   os_family: Android
   browser_family: Unknown
@@ -8465,19 +7623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; POV_TAB-PL1015 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: Mobii 1015
   os_family: Android
   browser_family: Android Browser
@@ -8485,7 +7641,6 @@
   user_agent: AndroidDownloadManager/4.1.1 (Linux; U; Android 4.1.1; POV_TAB-P1325(V1.1) Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -8494,7 +7649,7 @@
     version: "4.1.1"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: Mobii 1325
   os_family: Android
   browser_family: Unknown
@@ -8502,19 +7657,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; POV_TAB-P722C(V1.0) Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: Mobii 722C
   os_family: Android
   browser_family: Chrome
@@ -8522,19 +7675,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; POV_TAB-P925(V1.0) Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: Mobii 925
   os_family: Android
   browser_family: Android Browser
@@ -8542,19 +7693,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; POV_TAB-P506 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ONYX 506 Navi
   os_family: Android
   browser_family: Android Browser
@@ -8562,19 +7711,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; POV_TAB-NAVI7-3G-M Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ONYX 507 Navi
   os_family: Android
   browser_family: Android Browser
@@ -8582,19 +7729,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; POV_TAB_NAVI7_3G_M Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ONYX 507 Navi
   os_family: Android
   browser_family: Android Browser
@@ -8602,19 +7747,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-gb; POV_TAB-P527S(v1.0) Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ONYX 527S
   os_family: Android
   browser_family: Android Browser
@@ -8622,19 +7765,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; POV_TAB-P547(v1.0) Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ONYX 547 Navi
   os_family: Android
   browser_family: Android Browser
@@ -8642,19 +7783,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; POV_TAB-PROTAB25XXL8 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ProTab 25XXL
   os_family: Android
   browser_family: Android Browser
@@ -8662,19 +7801,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; POV_TAB-PROTAB26 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PV
+    brand: Point of View
     model: ProTab 26 XXL IPS
   os_family: Android
   browser_family: Android Browser
@@ -8682,19 +7819,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Pixus hiMAX Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: HiMax 9.6"
   os_family: Android
   browser_family: Chrome
@@ -8702,19 +7837,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; Play Three v2.0 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Play Three v2.0
   os_family: Android
   browser_family: Android Browser
@@ -8722,19 +7855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; play three v3.1 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.71 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.71"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Play Three v3.1
   os_family: Android
   browser_family: Chrome
@@ -8742,19 +7873,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Play Three v4.0 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Play Three v4.0
   os_family: Android
   browser_family: Chrome
@@ -8762,19 +7891,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; uk-ua; Pixus Play Two Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Play Two
   os_family: Android
   browser_family: Android Browser
@@ -8782,19 +7909,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ride_3G Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Ride 3G
   os_family: Android
   browser_family: Chrome
@@ -8802,19 +7927,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Ride_4G Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36 OPR/49.2.2361.134358
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "49.2.2361.134358"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Ride 4G
   os_family: Android
   browser_family: Opera
@@ -8822,19 +7945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Pixus Touch 7 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PX
+    brand: Pixus
     model: Touch 7 3G
   os_family: Android
   browser_family: Chrome
@@ -8842,19 +7963,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; MOMO19 Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: PY
+    brand: Ployer
     model: MOMO 19
   os_family: Android
   browser_family: Android Browser
@@ -8862,19 +7981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; MOMO8W Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PY
+    brand: Ployer
     model: MOMO 8W
   os_family: Android
   browser_family: Chrome
@@ -8882,19 +7999,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Android 4.0.4; zh-CN; MOMO9star) U2/1.0.0 UCBrowser/9.9.3.478 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.3.478"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: PY
+    brand: Ployer
     model: MOMO 9star
   os_family: Android
   browser_family: Unknown
@@ -8902,19 +8017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; momo mini 3GS Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PY
+    brand: Ployer
     model: MOMO Mini 3GS
   os_family: Android
   browser_family: Chrome
@@ -8922,19 +8035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MOMOminiS Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: PY
+    brand: Ployer
     model: MOMO mini S
   os_family: Android
   browser_family: Chrome
@@ -8942,19 +8053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QiLive 8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: "8"
   os_family: Android
   browser_family: Chrome
@@ -8962,19 +8071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QiLive 8QC Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: 8QC
   os_family: Android
   browser_family: Chrome
@@ -8982,19 +8089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QiLive 97 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: "97"
   os_family: Android
   browser_family: Chrome
@@ -9002,19 +8107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QiLive 97R Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: 97R
   os_family: Android
   browser_family: Chrome
@@ -9022,19 +8125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q7T10INP) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: Q7 10.1"
   os_family: Android
   browser_family: Chrome
@@ -9042,19 +8143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Q8T10IN) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QI
+    brand: Qilive
     model: Q8 10.1"
   os_family: Android
   browser_family: Chrome
@@ -9062,19 +8161,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; QTab Q400 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QM
+    brand: QMobile
     model: Q400 Tab
   os_family: Android
   browser_family: Android Browser
@@ -9082,19 +8179,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ur-pk; QTab Q50 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QM
+    brand: QMobile
     model: Q50 Tab
   os_family: Android
   browser_family: Android Browser
@@ -9102,19 +8197,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; th-th; QTAB Tab4 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QM
+    brand: QMobile
     model: Tab4 Tab
   os_family: Android
   browser_family: Android Browser
@@ -9122,19 +8215,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; QUMO Altair 7002 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Altair 7002
   os_family: Android
   browser_family: Chrome
@@ -9142,19 +8233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUMO Altair 7004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Altair 7004
   os_family: Android
   browser_family: Chrome
@@ -9162,19 +8251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; QUMO Altair 701 8GB Black Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Altair 701 8GB Black
   os_family: Android
   browser_family: Android Browser
@@ -9182,19 +8269,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; QUMO Altair 706 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Altair 706
   os_family: Android
   browser_family: Chrome
@@ -9202,19 +8287,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; QUMO Altair 71 4GB Black AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Altair 71 4GB Black
   os_family: Android
   browser_family: Chrome
@@ -9222,19 +8305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; QUMO Sirius 101-4G 8GB Black Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Sirius 101-4G 8GB Black
   os_family: Android
   browser_family: Android Browser
@@ -9242,19 +8323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Vega 782) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Vega 782
   os_family: Android
   browser_family: Chrome
@@ -9262,19 +8341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QUMOVega783) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Vega 783
   os_family: Android
   browser_family: Chrome
@@ -9282,19 +8359,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; QUMO Vega 8002 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Vega 8002
   os_family: Android
   browser_family: Android Browser
@@ -9302,19 +8377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QUMO Yooda) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QO
+    brand: Qumo
     model: Yooda
   os_family: Android
   browser_family: Chrome
@@ -9322,19 +8395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SQOOL-V4 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QS
+    brand: SQOOL
     model: V4
   os_family: Android
   browser_family: Chrome
@@ -9342,19 +8413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SQOOL-V41) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: QS
+    brand: SQOOL
     model: V41
   os_family: Android
   browser_family: Chrome
@@ -9362,19 +8431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; CASPER_L10_4.5G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: L10 4.5G
   os_family: Android
   browser_family: Chrome
@@ -9382,19 +8449,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; VIA_L8 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA L8
   os_family: Android
   browser_family: Chrome
@@ -9402,19 +8467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VIA_S10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA S10
   os_family: Android
   browser_family: Chrome
@@ -9422,19 +8485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VIA_S7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA S7
   os_family: Android
   browser_family: Chrome
@@ -9442,19 +8503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VIA_S8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA S8
   os_family: Android
   browser_family: Chrome
@@ -9462,19 +8521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA_T10 Build/VIA_T10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T10
   os_family: Android
   browser_family: Chrome
@@ -9482,19 +8539,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; VIA_T17 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T17
   os_family: Android
   browser_family: Chrome
@@ -9502,19 +8557,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; VIA-T17_M AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T17 M
   os_family: Android
   browser_family: Chrome
@@ -9522,19 +8575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA-T7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T7
   os_family: Android
   browser_family: Chrome
@@ -9542,19 +8593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA_T7-3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T7 3G
   os_family: Android
   browser_family: Chrome
@@ -9562,19 +8611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; VIA-T7D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T7D
   os_family: Android
   browser_family: Chrome
@@ -9582,19 +8629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA_T8B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T8B
   os_family: Android
   browser_family: Chrome
@@ -9602,19 +8647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VIA_T8D-3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R4
+    brand: Casper
     model: VIA T8D 3G
   os_family: Android
   browser_family: Chrome
@@ -9622,19 +8665,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD_600 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YandexSearch/7.16
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: R5
+    brand: 'Ross&Moor'
     model: RMD-600
   os_family: Android
   browser_family: Android Browser
@@ -9642,19 +8683,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-974R Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: R5
+    brand: 'Ross&Moor'
     model: RMD-974R
   os_family: Android
   browser_family: Android Browser
@@ -9662,19 +8701,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 5.1; RoverPad) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 YaBrowser/19.9.6.88.00 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.9.6.88.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: ""
   os_family: Android
   browser_family: Unknown
@@ -9682,19 +8719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; RoverPad 10.4 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.122 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.122"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: "10.4"
   os_family: Android
   browser_family: Chrome
@@ -9702,19 +8737,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; ru-ru; RoverPad 3W A73 Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: 3W A73
   os_family: Android
   browser_family: Android Browser
@@ -9722,19 +8755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; RoverPad 3W7 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: 3W7
   os_family: Android
   browser_family: Android Browser
@@ -9742,19 +8773,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RoverPad 3W9.4 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: 3W9.4
   os_family: Android
   browser_family: Android Browser
@@ -9762,19 +8791,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1; ru-ru; RoverPad 3WT70 Build/MASTER) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: 3WT70
   os_family: Android
   browser_family: Android Browser
@@ -9782,19 +8809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Roverpad 9.7 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: 9.7 3G
   os_family: Android
   browser_family: Opera
@@ -9802,19 +8827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; RoverPad Air S70 Build/JZO54K) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Mobile Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: Air S70
   os_family: Android
   browser_family: Chrome
@@ -9822,19 +8845,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; RoverPad sky 7.85 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: Sky 7.85
   os_family: Android
   browser_family: Chrome
@@ -9842,19 +8863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; RoverPad Sky 9.7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: R6
+    brand: RoverPad
     model: Sky 9.7
   os_family: Android
   browser_family: Chrome
@@ -9862,19 +8881,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Ramosi9 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RA
+    brand: Ramos
     model: i9
   os_family: Android
   browser_family: Android Browser
@@ -9882,7 +8899,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Ramos W27Pro Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.2.17.1009776.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -9891,7 +8907,7 @@
     version: "3.2.17.1009776"
   device:
     type: tablet
-    brand: RA
+    brand: Ramos
     model: W27Pro
   os_family: Android
   browser_family: Unknown
@@ -9899,19 +8915,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Ramos X10 PROæ—¶å°šç‰ˆ Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RA
+    brand: Ramos
     model: X10 PROæ—¶å°šç‰ˆ
   os_family: Android
   browser_family: Android Browser
@@ -9919,19 +8933,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Readboy_F300 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: F300
   os_family: Android
   browser_family: Android Browser
@@ -9939,19 +8951,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Readboy_G100 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: G100
   os_family: Android
   browser_family: Android Browser
@@ -9959,19 +8969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Readboy_G20 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30; 360 Aphone Browser (6.9.9.22)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: 360 Phone Browser
-    short_name: 36
     version: "6.9.9.22"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: G20
   os_family: Android
   browser_family: Unknown

--- a/Tests/fixtures/tablet-4.yml
+++ b/Tests/fixtures/tablet-4.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Readboy_G30 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 baiduboxpad/1.3 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: G30
   os_family: Android
   browser_family: Android Browser
@@ -23,7 +21,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; Readboy_G35 Build/KVT49L) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -32,7 +29,7 @@
     version: "6.7"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: G35
   os_family: Android
   browser_family: Unknown
@@ -40,7 +37,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; zh-cn; Readboy_G50 Build/JDQ39) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.2.2)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
@@ -49,7 +45,7 @@
     version: "6.7"
   device:
     type: tablet
-    brand: RB
+    brand: Readboy
     model: G50
   os_family: Android
   browser_family: Unknown
@@ -57,19 +53,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; RCT6077W2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RC
+    brand: RCA Tablets
     model: RCT6077W2
   os_family: Android
   browser_family: Chrome
@@ -77,19 +71,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RCT6773W22 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RC
+    brand: RCA Tablets
     model: RCT6773W22
   os_family: Android
   browser_family: Chrome
@@ -97,19 +89,17 @@
   user_agent: Mozilla/5.0 (PlayBook; U; RIM Tablet OS 2.1.0; en-US) AppleWebKit/536.2+ (KHTML, like Gecko) Version/7.2.1.0 Safari/536.2+
   os:
     name: BlackBerry Tablet OS
-    short_name: QNX
     version: "2.1.0"
     platform: ""
   client:
     type: browser
     name: BlackBerry Browser
-    short_name: BB
     version: ""
     engine: WebKit
     engine_version: "536.2"
   device:
     type: tablet
-    brand: RM
+    brand: RIM
     model: BlackBerry Playbook
   os_family: BlackBerry
   browser_family: BlackBerry Browser
@@ -117,19 +107,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; Roadrover ChangAn S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RR
+    brand: Roadrover
     model: ChangAn S
   os_family: Android
   browser_family: Android Browser
@@ -137,19 +125,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-1026 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1026
   os_family: Android
   browser_family: Android Browser
@@ -157,19 +143,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-1028 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1028
   os_family: Android
   browser_family: Android Browser
@@ -177,19 +161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; RMD-1029 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1029
   os_family: Android
   browser_family: Opera
@@ -197,19 +179,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.3; RMD-1030 Build/IML74K AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1030
   os_family: Android
   browser_family: Chrome
@@ -217,19 +197,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.4; RMD-1050 Build/IMM76D AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1050
   os_family: Android
   browser_family: Chrome
@@ -237,19 +215,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-1058 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1058
   os_family: Android
   browser_family: Android Browser
@@ -257,19 +233,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-1059 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 YandexSearch/7.16/apad
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1059
   os_family: Android
   browser_family: Android Browser
@@ -277,19 +251,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; RMD-1121 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-1121
   os_family: Android
   browser_family: Chrome
@@ -297,19 +269,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-726 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-726
   os_family: Android
   browser_family: Android Browser
@@ -317,19 +287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; RMD-750 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-750
   os_family: Android
   browser_family: Chrome
@@ -337,19 +305,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RMD-751 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-751
   os_family: Android
   browser_family: Android Browser
@@ -357,19 +323,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; RMD-855 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-855
   os_family: Android
   browser_family: Chrome
@@ -377,19 +341,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; RMD-857 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-857
   os_family: Android
   browser_family: Android Browser
@@ -397,19 +359,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; RMD-870 Build/JDQ39 AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: RX
+    brand: Ritmix
     model: RMD-870
   os_family: Android
   browser_family: Android Browser
@@ -417,19 +377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; ELEMENT10 1 Build/ICS.g08refem611.20121108) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 10.1
   os_family: Android
   browser_family: Android Browser
@@ -437,19 +395,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.4; en-US; ELEMENT7V2) U2/1.0.0 UCBrowser/9.3.0.321 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.0.321"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 7 V2
   os_family: Android
   browser_family: Unknown
@@ -457,19 +413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; ELEMENT 7 V2 BASIC Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.65583
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "16.0.1212.65583"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 7 V2 Basic
   os_family: Android
   browser_family: Opera
@@ -477,19 +431,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; ELEMENT 7V3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 7 V3
   os_family: Android
   browser_family: Android Browser
@@ -497,19 +449,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; cs-cz; ELEMENT8 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 8
   os_family: Android
   browser_family: Android Browser
@@ -517,19 +467,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; SENCOR_ELEMENT_8V2 Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 8 V2
   os_family: Android
   browser_family: Android Browser
@@ -537,19 +485,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; SENCOR ELEMENT 8V2 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 8 V2
   os_family: Android
   browser_family: Android Browser
@@ -557,19 +503,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; hu-hu; ELEMENT 8V3 Build/JRO03H) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "537.16"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 8 V3
   os_family: Android
   browser_family: Android Browser
@@ -577,19 +521,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; hu-hu; SENCOR ELEMENT 9.7V3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S1
+    brand: Sencor
     model: Element 9.7 V3
   os_family: Android
   browser_family: Android Browser
@@ -597,19 +539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SUPRA M726G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: M726G
   os_family: Android
   browser_family: Unknown
@@ -617,19 +557,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; SUPRA M74AG Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: M74AG
   os_family: Android
   browser_family: Android Browser
@@ -637,19 +575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SUPRA M74AG) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: M74AG
   os_family: Android
   browser_family: Chrome
@@ -657,19 +593,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; SUPRA M74JG Build/LMY47D)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: M74JG
   os_family: Android
   browser_family: Android Browser
@@ -677,19 +611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SUPRA_M84D_3G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: M84D 3G
   os_family: Android
   browser_family: Opera
@@ -697,19 +629,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; NVTAB 7.0 3G Build/JRO03C AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: S5
+    brand: Supra
     model: NVTAB 7.0 3G
   os_family: Android
   browser_family: Android Browser
@@ -717,19 +647,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; cs-cz; GT-N8000 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -737,19 +665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-P601 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" 2014 Edition
   os_family: Android
   browser_family: Chrome
@@ -757,19 +683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; tr-tr; SAMSUNG SM-P602 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" 2014 Edition
   os_family: Android
   browser_family: Chrome
@@ -777,19 +701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-P605 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" 2014 Edition LTE
   os_family: Android
   browser_family: Chrome
@@ -797,19 +719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-P607T Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.3 Chrome/38.0.2125.102 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.3"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" 2014 Edition LTE
   os_family: Android
   browser_family: Chrome
@@ -817,19 +737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SM-P600 Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" 2014 Edition WiFi
   os_family: Android
   browser_family: Chrome
@@ -837,19 +755,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; da-dk; GT-N8020 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" LTE
   os_family: Android
   browser_family: Android Browser
@@ -857,19 +773,17 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GT-N8010 Build/IMM76D; 1280*752) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 10.1" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -877,19 +791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-N5100 Build/JZO54K) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.123"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8.0"
   os_family: Android
   browser_family: Chrome
@@ -897,19 +809,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; N5100 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8.0"
   os_family: Android
   browser_family: Android Browser
@@ -917,19 +827,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fi-fi; GT-N5120 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8.0" LTE
   os_family: Android
   browser_family: Android Browser
@@ -937,19 +845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; GT-N5110 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -957,7 +863,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.3; zh-cn; N5110 Build/JLS36C) AppleWebKit/533.1 (KHTML, like Gecko)Version/4.0 MQQBrowser/5.4 TBS/025438 Mobile Safari/533.1 MicroMessenger/6.2.0.52_r1162382.561 NetType/3gnet Language/zh_CN
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
@@ -966,7 +871,7 @@
     version: "6.2.0.52.r1162382.561"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note 8.0" WiFi
   os_family: Android
   browser_family: Unknown
@@ -974,19 +879,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-P902 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Note Pro 12.2"
   os_family: Android
   browser_family: Chrome
@@ -994,19 +897,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-P901 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY NotePRO 12.2"
   os_family: Android
   browser_family: Chrome
@@ -1014,19 +915,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; de-de; SAMSUNG SM-P905 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY NotePRO 12.2" LTE
   os_family: Android
   browser_family: Chrome
@@ -1034,19 +933,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-P900 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY NotePRO 12.2" WiFi
   os_family: Android
   browser_family: Chrome
@@ -1054,19 +951,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2; fr-ca; GT-P1000M Build/FROYO) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab
   os_family: Android
   browser_family: Android Browser
@@ -1074,19 +969,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.5; en-us; SCH-I800 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab
   os_family: Android
   browser_family: Android Browser
@@ -1094,19 +987,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-P1000 Build/JZO54K; CyanogenMod-10) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab
   os_family: Android
   browser_family: Android Browser
@@ -1114,19 +1005,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; GT-P1000 Build/IMM76L; CyanogenMod-9.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab
   os_family: Android
   browser_family: Android Browser
@@ -1134,19 +1023,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; el-gr; GT-P7500 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1154,19 +1041,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; fr-ca; GT-P7500D Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1174,19 +1059,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; sv-se; GT-P7510 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1194,19 +1077,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; ar-il; GT-P7500 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1214,19 +1095,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; cs-cz; GT-P7510 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1234,19 +1113,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; SAMSUNG GT-P7500/P7500BULP5 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1254,19 +1131,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-au; GT-P7500 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1274,19 +1149,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; GT-P7500R Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1294,19 +1167,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ca; GT-P7500M Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1314,19 +1185,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; vi-vn; GT-P7500 Build/JOP40D; CyanogenMod-10.1) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "10.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1334,19 +1203,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; GT-P7100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 10.1v
   os_family: Android
   browser_family: Android Browser
@@ -1354,19 +1221,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; pt-pt; GT-P5100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1374,19 +1239,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; GT-P5100 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1394,19 +1257,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GT-P5100 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1414,19 +1275,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ar-ae; GT-P5100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1434,19 +1293,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; SCH-I915 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1454,19 +1311,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-ch; SAMSUNG GT-P5100/P5100XXDMJ2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1474,19 +1329,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-ch; GT-P5110 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1494,19 +1347,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ko-kr; GT-P5113 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1514,19 +1365,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-hk; GT-P5110 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1534,19 +1383,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-P5110 Build/JDQ39E) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 10.1" WiFi
   os_family: Android
   browser_family: Chrome
@@ -1554,19 +1401,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ca-es; GT-P3100 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Android Browser
@@ -1574,19 +1419,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; GT-P3100B Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Android Browser
@@ -1594,19 +1437,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; th-th; GT-P3100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Android Browser
@@ -1614,19 +1455,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; th-th; GT-P3100B Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Android Browser
@@ -1634,19 +1473,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; en-US; GT-P3100) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Unknown
@@ -1654,19 +1491,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-P3100 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36 OPR/20.0.1396.73172
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "20.0.1396.73172"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7"
   os_family: Android
   browser_family: Opera
@@ -1674,19 +1509,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-nz; GT-P3110 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1694,19 +1527,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; GT-P3113 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1714,19 +1545,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pt-br; GT-P3113 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1734,19 +1563,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; GT-P3110 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 2 7" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1754,19 +1581,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; SAMSUNG GT-P5200/P5200XXUAMI8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1774,19 +1599,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-P5200 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1794,19 +1617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-ch; GT-P5220-ORANGE/P5220XXUAMK2 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 10.1" LTE
   os_family: Android
   browser_family: Android Browser
@@ -1814,19 +1635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; GT-P5210 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 10.1" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -1834,19 +1653,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; GT-P5210 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 10.1" WiFi
   os_family: Android
   browser_family: Chrome
@@ -1854,19 +1671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; az-az; SM-T211 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Android Browser
@@ -1874,19 +1689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; pl-pl; SAMSUNG SM-T211/T211XXAMJ5 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Android Browser
@@ -1894,19 +1707,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.1.2; en-US; SM-T211) U2/1.0.0 UCBrowser/8.8.1.359 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.8.1.359"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Unknown
@@ -1914,19 +1725,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; SAMSUNG-SM-T217A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Android Browser
@@ -1934,19 +1743,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; SM-T215 Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Android Browser
@@ -1954,19 +1761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-T217S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0"
   os_family: Android
   browser_family: Chrome
@@ -1974,19 +1779,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-T217T Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" 4G
   os_family: Android
   browser_family: Chrome
@@ -1994,19 +1797,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.2; tr-tr; SM-T212 Build/JZO54K AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Kids
   os_family: Android
   browser_family: Android Browser
@@ -2014,19 +1815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SM-T2105 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Kids
   os_family: Android
   browser_family: Chrome
@@ -2034,19 +1833,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; SM-T111 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Lite
   os_family: Android
   browser_family: Android Browser
@@ -2054,19 +1851,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pt-br; SM-T111M Build/JDQ39) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 UCBrowser/9.9.2.467 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.9.2.467"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Lite
   os_family: Android
   browser_family: Unknown
@@ -2074,7 +1869,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; pl-pl; SM-T110 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.1.8.914827.arm
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -2083,7 +1877,7 @@
     version: "3.1.8.914827"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Lite WiFi
   os_family: Android
   browser_family: Unknown
@@ -2091,19 +1885,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.4.4; en-US; SM-T113 Build/KTU84P AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.5.1189 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.5.1189"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" Lite WiFi
   os_family: Android
   browser_family: Unknown
@@ -2111,19 +1903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; SM-T210-ORANGE/T210XXAMI9 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -2131,19 +1921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; SM-T210R Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -2151,19 +1939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SM-T210 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 7.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2171,19 +1957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-T311 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 8.0"
   os_family: Android
   browser_family: Chrome
@@ -2191,19 +1975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-T315 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2211,19 +1993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; SM-T310 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2231,19 +2011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T116NY Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 V
   os_family: Android
   browser_family: Chrome
@@ -2251,19 +2029,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T116NU Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 3 V
   os_family: Android
   browser_family: Chrome
@@ -2271,19 +2047,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T536) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" Advanced
   os_family: Android
   browser_family: Chrome
@@ -2291,19 +2065,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; SM-T531 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Android Browser
@@ -2311,19 +2083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SAMSUNG-SM-T537A Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -2331,19 +2101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-T535 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -2351,19 +2119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T537V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -2371,19 +2137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T530NU Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2391,19 +2155,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-T530 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 10.1" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2411,19 +2173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T231 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -2431,19 +2191,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 403SC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -2451,19 +2209,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-T235 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" 3G
   os_family: Android
   browser_family: Android Browser
@@ -2471,19 +2227,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.4.4; en-US; SM-T239 Build/KTU84P AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.5.1146 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.5.1146"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" LTE
   os_family: Android
   browser_family: Unknown
@@ -2491,19 +2245,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG SM-T237P Build/JRO03D) AppleWebKit/537.36 (KHTML, like Gecko)  Chrome/38.0.2125.102 Mobile Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2511,19 +2263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T230NU Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 7.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2531,19 +2281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SAMSUNG-SM-T337A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2551,19 +2299,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-T335 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2571,19 +2317,17 @@
   user_agent: Dalvik/2.1.0 Linux; U; Android 5.1.1; SM-T331 Build/LMY47X
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Android Browser
@@ -2591,19 +2335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T337T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2611,19 +2353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T337V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2631,19 +2371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T332) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2651,19 +2389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T330 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 4 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -2671,19 +2407,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; sr-rs; GT-P6200 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 7" Plus
   os_family: Android
   browser_family: Android Browser
@@ -2691,19 +2425,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; GT-P6200 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 7" Plus
   os_family: Android
   browser_family: Android Browser
@@ -2711,19 +2443,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; de-de; GT-P6201 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 7" Plus N
   os_family: Android
   browser_family: Android Browser
@@ -2731,19 +2461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-gb; GT-P6810 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab 7.7"
   os_family: Android
   browser_family: Android Browser
@@ -2751,19 +2479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T510) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" (2019)
   os_family: Android
   browser_family: Chrome
@@ -2771,19 +2497,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SM-T587P AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" LTE (2016)
   os_family: Android
   browser_family: Chrome
@@ -2791,19 +2515,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SAMSUNG SM-T587 Build/M1AJQ AppleWebKit/537.36 KHTML, like Gecko SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" LTE (2016)
   os_family: Android
   browser_family: Chrome
@@ -2811,19 +2533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-P585) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" WiFi (2016)
   os_family: Android
   browser_family: Chrome
@@ -2831,19 +2551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-T585 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" WiFi (2016)
   os_family: Android
   browser_family: Chrome
@@ -2851,19 +2569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-P587) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.1" with S Pen (2016) LTE
   os_family: Android
   browser_family: Chrome
@@ -2871,19 +2587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SM-T597W Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.5" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -2891,19 +2605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T595 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 10.5" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -2911,19 +2623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T285 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.5 Chrome/38.0.2125.102 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "3.5"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 7.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2931,19 +2641,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-P350 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2951,19 +2659,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T357T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2971,19 +2677,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T357W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -2991,19 +2695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T355Y Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3011,19 +2713,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-T385 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.70 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.70"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3031,19 +2731,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SM-T387VK AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3051,19 +2749,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SM-T387W AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3071,19 +2767,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SM-T387T AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3091,19 +2785,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; SM-T387V AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3111,19 +2803,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T387R4 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3131,19 +2821,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T387AA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2018)
   os_family: Android
   browser_family: Chrome
@@ -3151,19 +2839,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T295 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" LTE (2019)
   os_family: Android
   browser_family: Chrome
@@ -3171,19 +2857,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T380 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3191,19 +2875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T290 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" WiFi (2019)
   os_family: Android
   browser_family: Chrome
@@ -3211,19 +2893,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-P205 Build/PPR1.180610.011) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" with S Pen (2019) LTE
   os_family: Android
   browser_family: Chrome
@@ -3231,19 +2911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-P200) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 8.0" with S Pen (2019) WiFi
   os_family: Android
   browser_family: Chrome
@@ -3251,19 +2929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-P550 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -3271,19 +2947,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SAMSUNG SM-P555M Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.2 Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -3291,19 +2965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-P555 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -3311,19 +2983,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-P355M Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3331,19 +3001,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-P355 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3351,19 +3019,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-P355Y Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab A 9.7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3371,19 +3037,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-T397U Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab Active 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3391,19 +3055,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T395 Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab Active 2 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3411,19 +3073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T365 Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab Active 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3431,19 +3091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T360) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab Active 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3451,19 +3109,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T378L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3471,19 +3127,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T378K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.138"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3491,19 +3145,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T378S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3511,19 +3163,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SM-T377W Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3531,19 +3181,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T378V Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 8.0"
   os_family: Android
   browser_family: Chrome
@@ -3551,19 +3199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T561 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 9.6" 3G
   os_family: Android
   browser_family: Chrome
@@ -3571,19 +3217,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T567V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 9.6" 4G
   os_family: Android
   browser_family: Chrome
@@ -3591,19 +3235,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; SM-T562 Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 9.6" WiFi
   os_family: Android
   browser_family: Android Browser
@@ -3611,19 +3253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-T560 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab E 9.6" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3631,19 +3271,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; bg-bg; SAMSUNG SM-T805 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -3651,19 +3289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T807V Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -3671,19 +3307,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T807) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -3691,19 +3325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T807P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -3711,19 +3343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-T800 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3731,19 +3361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; en-gb; SAMSUNG SM-T705 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 8.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -3751,19 +3379,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SAMSUNG-SM-T707A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 8.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -3771,7 +3397,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T705 Build/LRX22G; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Safari/537.36 Instagram 10.3.2 Android (21/5.0.2; 320dpi; 1600x2560; samsung; SM-T705; klimtlte; universal5420; ar_AE)
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
@@ -3780,7 +3405,7 @@
     version: "10.3.2"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 8.4" LTE
   os_family: Android
   browser_family: Unknown
@@ -3788,19 +3413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T700 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S 8.4" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3808,19 +3431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-T715C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3828,19 +3449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-T715N0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3848,19 +3467,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; SM-T715Y Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Opera
@@ -3868,19 +3485,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T719C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3888,19 +3503,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T719) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3908,19 +3521,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T719Y) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Chrome
@@ -3928,19 +3539,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; ar-SA; SM-T715 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.2.1208 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.2.1208"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" LTE
   os_family: Android
   browser_family: Unknown
@@ -3948,19 +3557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; SM-T710X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" WiFi
   os_family: Android
   browser_family: Chrome
@@ -3968,19 +3575,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-T710 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.3.1218 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.3.1218"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" WiFi
   os_family: Android
   browser_family: Unknown
@@ -3988,19 +3593,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; SM-T713 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.1.8.1295 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.1.8.1295"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 8.0" WiFi
   os_family: Android
   browser_family: Unknown
@@ -4008,19 +3611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-T815 Build/MMB29K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4028,19 +3629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG-SM-T818A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4048,19 +3647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-T818T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4068,19 +3665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SM-T818W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4088,19 +3683,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; SM-T819Y Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Safari/537.36 OPR/37.1.2254.132401
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "37.1.2254.132401"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Opera
@@ -4108,19 +3701,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 7.0; SM-T819 Build/NRD90M; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.67 Safari/537.36 OPR/43.1.2254.140112
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43.1.2254.140112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Opera
@@ -4128,19 +3719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T817A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4148,19 +3737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T817T Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4168,19 +3755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T817) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4188,19 +3773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T817W) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4208,19 +3791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T810 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/9.4 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S2 9.7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4228,19 +3809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SAMSUNG SM-T825 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/6.4 Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "6.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S3 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4248,19 +3827,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.0.0; SM-T827 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S3 9.7" LTE
   os_family: Android
   browser_family: Chrome
@@ -4268,19 +3845,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-T835N AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4288,19 +3863,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-T837A AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4308,19 +3881,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SM-T837T AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4328,19 +3899,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; SM-T835 Build/PPR1.180610.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.157 Safari/537.36 OPR/43.1.2254.140112
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43.1.2254.140112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Opera
@@ -4348,19 +3917,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SAMSUNG SM-T835C Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4368,19 +3935,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T837V) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.1 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.1"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4388,19 +3953,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; SAMSUNG SM-T830X Build/M1AJQ) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.0 Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "8.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4408,19 +3971,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T837R4 Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4428,19 +3989,17 @@
   user_agent: Mozilla/5.0 Linux; Android 9; SAMSUNG SM-T830 Build/PPR1.180610.011 AppleWebKit/537.36 KHTML, like Gecko SamsungBrowser/9.2 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "9.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S4 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4448,19 +4007,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T727A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4468,19 +4025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T720X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4488,19 +4043,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T727V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4508,19 +4061,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T725N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4528,19 +4079,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 9; SM-T725 Build/PPR1.180610.011; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.143 Safari/537.36 OPR/43.2.2254.140293
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43.2.2254.140293"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5"
   os_family: Android
   browser_family: Opera
@@ -4548,19 +4097,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T720) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S5e 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4568,19 +4115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-P615) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.4" Lite
   os_family: Android
   browser_family: Chrome
@@ -4588,19 +4133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 10; SM-P610) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.4" Lite WiFi
   os_family: Android
   browser_family: Chrome
@@ -4608,19 +4151,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T865N) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.0 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4628,19 +4169,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T865) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.5"
   os_family: Android
   browser_family: Chrome
@@ -4648,19 +4187,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T867V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -4668,19 +4205,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SM-T867) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.5" LTE
   os_family: Android
   browser_family: Chrome
@@ -4688,19 +4223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; SAMSUNG SM-T860) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/12.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "12.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY Tab S6 10.5" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4708,19 +4241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T525 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.141 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.141"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY TabPRO 10.1" LTE
   os_family: Android
   browser_family: Chrome
@@ -4728,19 +4259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-T520 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY TabPRO 10.1" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4748,19 +4277,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-T900 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY TabPRO 12.2" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4768,19 +4295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; fr-fr; SAMSUNG SM-T325 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/1.5 Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY TabPRO 8.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4788,19 +4313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SM-T320 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY TabPRO 8.4" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4808,19 +4331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677V Build/LMY47X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4828,19 +4349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG-SM-T677A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4848,19 +4367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677NL) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4868,19 +4385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SM-T677NK) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4888,19 +4403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T677) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" LTE
   os_family: Android
   browser_family: Chrome
@@ -4908,19 +4421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; SAMSUNG SM-T670) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/10.2 Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "10.2"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GALAXY View 18.4" WiFi
   os_family: Android
   browser_family: Chrome
@@ -4928,19 +4439,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; GT-N8013 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-N8013
   os_family: Android
   browser_family: Android Browser
@@ -4948,19 +4457,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; hu-hu; GT-P7300 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7300
   os_family: Android
   browser_family: Android Browser
@@ -4968,19 +4475,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; fr-fr; GT-P7300-ORANGE/P7300BVKJ5 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7300
   os_family: Android
   browser_family: Android Browser
@@ -4988,19 +4493,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; GT-P7300 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7300
   os_family: Android
   browser_family: Unknown
@@ -5008,19 +4511,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; sk-sk; GT-P7310 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7310
   os_family: Android
   browser_family: Android Browser
@@ -5028,19 +4529,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; ru-ru; GT-P7320 Build/MASTER) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7320
   os_family: Android
   browser_family: Android Browser
@@ -5048,19 +4547,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-de; GT-P7501 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7501
   os_family: Android
   browser_family: Android Browser
@@ -5068,19 +4565,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; vi-vn; GT-P7511 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SA
+    brand: Samsung
     model: GT-P7511
   os_family: Android
   browser_family: Android Browser
@@ -5088,19 +4583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; S7 Build/Smartfren.androtab.v25.2) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SC
+    brand: Smartfren
     model: Andromax Tab 7.0
   os_family: Android
   browser_family: Android Browser
@@ -5108,19 +4601,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.1; en-us; Androtab 7 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SC
+    brand: Smartfren
     model: Androtab 7
   os_family: Android
   browser_family: Android Browser
@@ -5128,19 +4619,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ja-jp; SH-08E Build/SB180) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SH
+    brand: Sharp
     model: Sharp Aquos Pad
   os_family: Android
   browser_family: Android Browser
@@ -5148,19 +4637,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; Win64; x64; Trident/6.0; Touch; MASPJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -5168,19 +4655,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; de-de; Sony Tablet P Build/THMD01900) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet P
   os_family: Android
   browser_family: Android Browser
@@ -5188,19 +4673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Sony Tablet P Build/TISU0144) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet P
   os_family: Android
   browser_family: Chrome
@@ -5208,19 +4691,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; es-es; Sony Tablet S Build/THMAS10000) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet S
   os_family: Android
   browser_family: Android Browser
@@ -5228,19 +4709,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Sony Tablet S Build/TISU0124) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet S
   os_family: Android
   browser_family: Android Browser
@@ -5248,19 +4727,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; nl-nl; Sony Tablet S Build/TISU0143) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet S
   os_family: Android
   browser_family: Android Browser
@@ -5268,19 +4745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Sony Tablet S Build/TISU0143) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Tablet S
   os_family: Android
   browser_family: Chrome
@@ -5288,19 +4763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; Xperia Tablet S Build/TID0092) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet S
   os_family: Android
   browser_family: Android Browser
@@ -5308,19 +4781,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; SGPT12 Build/TISU0122) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet S
   os_family: Android
   browser_family: Android Browser
@@ -5328,19 +4799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; SGPT13 Build/TJDS0170) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet S
   os_family: Android
   browser_family: Chrome
@@ -5348,19 +4817,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.2; SGP311 Build/10.1.C.0.344) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z
   os_family: Android
   browser_family: Chrome
@@ -5368,19 +4835,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.2; SGP312 Build/10.1.C.0.370) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z
   os_family: Android
   browser_family: Chrome
@@ -5388,19 +4853,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.2; SGP321 Build/10.1.1.A.1.253) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z
   os_family: Android
   browser_family: Chrome
@@ -5408,19 +4871,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SO-03E Build/10.1.E.0.305) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z
   os_family: Android
   browser_family: Chrome
@@ -5428,19 +4889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; SGP311 Build/10.4.1.B.0.109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "19.0.1340.69721"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z
   os_family: Android
   browser_family: Opera
@@ -5448,19 +4907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SGP512 Build/17.1.A.2.36) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z2
   os_family: Android
   browser_family: Chrome
@@ -5468,19 +4925,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SGP511 Build/17.1.A.2.36) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z2
   os_family: Android
   browser_family: Chrome
@@ -5488,19 +4943,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SO-05F Build/17.1.1.B.1.53) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z2
   os_family: Android
   browser_family: Chrome
@@ -5508,19 +4961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SGP621 Build/23.0.1.A.0.167) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -5528,19 +4979,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SGP611) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -5548,19 +4997,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SGP612) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z3 Compact
   os_family: Android
   browser_family: Chrome
@@ -5568,19 +5015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; SGP712) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Tablet Z4
   os_family: Android
   browser_family: Chrome
@@ -5588,19 +5033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Xperia Z2 Tablet Wifi) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Z2 Tablet WiFi
   os_family: Android
   browser_family: Chrome
@@ -5608,19 +5051,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SO-05G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -5628,19 +5069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SOT31) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -5648,19 +5087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; SGP771) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SO
+    brand: Sony
     model: Xperia Z4
   os_family: Android
   browser_family: Chrome
@@ -5668,19 +5105,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.1.1; eZee'Tab1001 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.116 Safari/537.36 OPR/21.0.1437.74904"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "21.0.1437.74904"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab1001"
   os_family: Android
   browser_family: Opera
@@ -5688,19 +5123,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; eZeeTab1003 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab1003"
   os_family: Android
   browser_family: Android Browser
@@ -5708,7 +5141,6 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'Tab1004 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -5717,7 +5149,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab1004"
   os_family: Android
   browser_family: Unknown
@@ -5725,19 +5157,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.0.4; eZee'Tab10c Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab10c"
   os_family: Android
   browser_family: Chrome
@@ -5745,19 +5175,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.2.2; eZee'Tab10D11-M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab10D11-M"
   os_family: Android
   browser_family: Chrome
@@ -5765,19 +5193,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; eZee' Tab702 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab702"
   os_family: Android
   browser_family: Android Browser
@@ -5785,19 +5211,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; eZee'Tab705 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab705"
   os_family: Android
   browser_family: Android Browser
@@ -5805,19 +5229,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZee'TAB706 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab706"
   os_family: Android
   browser_family: Android Browser
@@ -5825,19 +5247,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZee'TAB707 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab707"
   os_family: Android
   browser_family: Android Browser
@@ -5845,7 +5265,6 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'TAB707 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.4.16.1149292.arm"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -5854,7 +5273,7 @@
     version: "3.4.16.1149292"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab707"
   os_family: Android
   browser_family: Unknown
@@ -5862,19 +5281,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZee'Tab785 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab785"
   os_family: Android
   browser_family: Android Browser
@@ -5882,7 +5299,6 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'Tab785D11-S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.4.16.1149292.arm"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -5891,7 +5307,7 @@
     version: "3.4.16.1149292"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab785D11-S"
   os_family: Android
   browser_family: Unknown
@@ -5899,19 +5315,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.2.2; eZee'Tab785Q11-M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab785Q11-M"
   os_family: Android
   browser_family: Chrome
@@ -5919,19 +5333,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZee'Tab7D10-S Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab7D10-S"
   os_family: Android
   browser_family: Android Browser
@@ -5939,19 +5351,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.2.2; eZee'TAB7D12-S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab7D12-S"
   os_family: Android
   browser_family: Chrome
@@ -5959,19 +5369,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.2.2; eZee'Tab7D13-S Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab7D13-S"
   os_family: Android
   browser_family: Chrome
@@ -5979,19 +5387,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; eZeeTab7D15-M Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab7D15-M"
   os_family: Android
   browser_family: Chrome
@@ -5999,19 +5405,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; eZee'Tab802 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab802"
   os_family: Android
   browser_family: Android Browser
@@ -6019,19 +5423,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZee'Tab803 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab803"
   os_family: Android
   browser_family: Android Browser
@@ -6039,7 +5441,6 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'Tab804 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -6048,7 +5449,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab804"
   os_family: Android
   browser_family: Unknown
@@ -6056,19 +5457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; eZee Tab805 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab805"
   os_family: Android
   browser_family: Chrome
@@ -6076,19 +5475,17 @@
   user_agent: "Mozilla/5.0 (Linux; Android 4.4.2; eZee'Tab8D11-S Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36"
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab8D11-S"
   os_family: Android
   browser_family: Chrome
@@ -6096,19 +5493,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Ezee'TAB901 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab901"
   os_family: Android
   browser_family: Android Browser
@@ -6116,7 +5511,6 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'Tab903 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ARM
   client:
@@ -6125,7 +5519,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab903"
   os_family: Android
   browser_family: Unknown
@@ -6133,19 +5527,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'Tab904 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab904"
   os_family: Android
   browser_family: Android Browser
@@ -6153,19 +5545,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; eZeeâ€™Tab 971 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab971"
   os_family: Android
   browser_family: Android Browser
@@ -6173,19 +5563,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; eZee Tab973 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab973"
   os_family: Android
   browser_family: Chrome
@@ -6193,19 +5581,17 @@
   user_agent: "Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; eZee'TAB973 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab973"
   os_family: Android
   browser_family: Android Browser
@@ -6213,19 +5599,17 @@
   user_agent: "Dalvik/1.6.0 (Linux; U; Android 4.2.2; eZee'Tab97D11-S Build/JDQ39)"
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: ST
+    brand: Storex
     model: "eZee'Tab97D11-S"
   os_family: Android
   browser_family: Android Browser
@@ -6233,19 +5617,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ko-kr; SC-06D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SU
+    brand: SuperSonic
     model: SC-06D
   os_family: Android
   browser_family: Android Browser
@@ -6253,19 +5635,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; SC-74JB Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SU
+    brand: SuperSonic
     model: SC-74JB
   os_family: Android
   browser_family: Android Browser
@@ -6273,19 +5653,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; SC-91MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SU
+    brand: SuperSonic
     model: SC-91MID
   os_family: Android
   browser_family: Android Browser
@@ -6293,19 +5671,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; fr-FR; SFR StarTab Build/V71BV1.1.0B10) AppleWebKit/534.13 (KHTML,like Gecko) Version/4.0 Mobile Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: SX
+    brand: SFR
     model: StarTab
   os_family: Android
   browser_family: Android Browser
@@ -6313,19 +5689,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; Cyclone Voyager Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SZ
+    brand: Sumvision
     model: Cyclone Voyager
   os_family: Android
   browser_family: Android Browser
@@ -6333,19 +5707,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Cyclone Voyager Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: SZ
+    brand: Sumvision
     model: Cyclone Voyager
   os_family: Android
   browser_family: Android Browser
@@ -6353,19 +5725,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Cyclone Voyager 2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: SZ
+    brand: Sumvision
     model: Cyclone Voyager 2
   os_family: Android
   browser_family: Chrome
@@ -6373,19 +5743,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; tolino tab 7 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T1
+    brand: Tolino
     model: Tolino Tab 7
   os_family: Android
   browser_family: Chrome
@@ -6393,19 +5761,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; tolino tab 8.9 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T1
+    brand: Tolino
     model: Tolino Tab 8.9
   os_family: Android
   browser_family: Chrome
@@ -6413,19 +5779,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; it-it; TAB 10 3G V16 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T3
+    brand: Trevi
     model: TAB 10 3G V16
   os_family: Android
   browser_family: Android Browser
@@ -6433,19 +5797,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; it-it; TAB 7 3G V8 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T3
+    brand: Trevi
     model: TAB 7 3G V8
   os_family: Android
   browser_family: Android Browser
@@ -6453,19 +5815,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; TAB 8 3G V8 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T3
+    brand: Trevi
     model: TAB 8 3G V8
   os_family: Android
   browser_family: Chrome
@@ -6473,19 +5833,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; TAB9 3G Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T3
+    brand: Trevi
     model: TAB 9 3G
   os_family: Android
   browser_family: Chrome
@@ -6493,19 +5851,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-au; TAB9 3G V8 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T3
+    brand: Trevi
     model: TAB 9 3G V8
   os_family: Android
   browser_family: Android Browser
@@ -6513,19 +5869,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Ignis 8 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.57 Safari/537.36 OPR/18.0.1290.67495
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "18.0.1290.67495"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T5
+    brand: TB Touch
     model: Ignis 8
   os_family: Android
   browser_family: Opera
@@ -6533,19 +5887,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; TrekStor PrimeTab P10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: PrimeTab P10
   os_family: Android
   browser_family: Chrome
@@ -6553,19 +5905,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-de; ST10216-2A Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab 10.1
   os_family: Android
   browser_family: Android Browser
@@ -6573,19 +5923,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; VT10416-1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab 10.1
   os_family: Android
   browser_family: Android Browser
@@ -6593,19 +5941,17 @@
   user_agent: Mozilla/5.0 (Linux;U; Android 4.0.4; engb; Build/IMM76D) AppleWebKit/534.30 (KHTML,like Gecko) Version/4.0 Safari/534.30;SurfTab_7.0
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab 7.0
   os_family: Android
   browser_family: Android Browser
@@ -6613,19 +5959,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SurfTab breeze 10.1 quad 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab breeze 10.1 quad 3G
   os_family: Android
   browser_family: Chrome
@@ -6633,19 +5977,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SurfTab breeze 10.1 quad plus Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab breeze 10.1 quad plus
   os_family: Android
   browser_family: Chrome
@@ -6653,19 +5995,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SurfTab breeze 7.0 quad Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab breeze 7.0 quad
   os_family: Android
   browser_family: Chrome
@@ -6673,19 +6013,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; TrekStor SurfTab breeze 9.6 quad 3G Build/LMY48Y) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab breeze 9.6 quad 3G
   os_family: Android
   browser_family: Chrome
@@ -6693,19 +6031,17 @@
   user_agent: Mozilla/5.0 (Windows NT 10.0; Trident/7.0; Touch; SurfTab duo W1 10.1; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "10"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab duo W1 10.1
   os_family: Windows
   browser_family: Internet Explorer
@@ -6713,19 +6049,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; TFMTKAW01232) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab L15
   os_family: Android
   browser_family: Chrome
@@ -6733,19 +6067,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TrekStor SurfTab theatre 13.3 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab theatre 13.3
   os_family: Android
   browser_family: Chrome
@@ -6753,19 +6085,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Trekstor Surftab theatre K13) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab theatre K13
   os_family: Android
   browser_family: Chrome
@@ -6773,19 +6103,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; TrekStor SurfTab xiron 10.1 3G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab xiron 10.1 3G
   os_family: Android
   browser_family: Android Browser
@@ -6793,19 +6121,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; TrekStor SurfTab xiron 10.1 pure Build/LMY47V)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab xiron 10.1 pure
   os_family: Android
   browser_family: Android Browser
@@ -6813,19 +6139,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; TrekStor SurfTab xiron 10.1 pure Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T6
+    brand: TrekStor
     model: SurfTab xiron 10.1 pure
   os_family: Android
   browser_family: Chrome
@@ -6833,19 +6157,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P10S(N4H5) Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P10S
   os_family: Android
   browser_family: Chrome
@@ -6853,19 +6175,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P80X_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P80X EEA
   os_family: Android
   browser_family: Chrome
@@ -6873,19 +6193,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; P80X_ROW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: P80X ROW
   os_family: Android
   browser_family: Chrome
@@ -6893,19 +6211,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; T10(E3C6)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.119"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: T10
   os_family: Android
   browser_family: Chrome
@@ -6913,19 +6229,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; T30_EEA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: T30 EEA
   os_family: Android
   browser_family: Chrome
@@ -6933,19 +6247,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; T30_ROW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/81.0.4044.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "81.0.4044.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: T30 ROW
   os_family: Android
   browser_family: Chrome
@@ -6953,19 +6265,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TbooK 16 Power(M5F8) Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36 OPR/43
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "43"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: Tbook 16 Power(M5F8)
   os_family: Android
   browser_family: Opera
@@ -6973,19 +6283,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M3E3)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -6993,19 +6301,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M1E9)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -7013,19 +6319,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M1E7)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -7033,19 +6337,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M1E4)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -7053,19 +6355,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M1E5)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -7073,19 +6373,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 98(M1E8)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: TPad 98 10.1" 4G
   os_family: Android
   browser_family: Chrome
@@ -7093,19 +6391,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; X98 Air II(HG5N) Build/KTU84P)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: X98 Air II
   os_family: Android
   browser_family: Android Browser
@@ -7113,19 +6409,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; X98 Air III Build/LRX21V)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: X98 Air III
   os_family: Android
   browser_family: Android Browser
@@ -7133,19 +6427,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1; X80 Power(B2N4) Build/LMY47I)
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: T7
+    brand: Teclast
     model: X98 Power
   os_family: Android
   browser_family: Android Browser
@@ -7153,19 +6445,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; TM-MID1020A Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T8
+    brand: Touchmate
     model: TM-MID1020A
   os_family: Android
   browser_family: Chrome
@@ -7173,19 +6463,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; TM-MID710 Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T8
+    brand: Touchmate
     model: TM-MID710
   os_family: Android
   browser_family: Android Browser
@@ -7193,19 +6481,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-MID788D Build/TOUCHMATE AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T8
+    brand: Touchmate
     model: TM-MID788D
   os_family: Android
   browser_family: Chrome
@@ -7213,19 +6499,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; TM-MID792 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: T8
+    brand: Touchmate
     model: TM-MID792
   os_family: Android
   browser_family: Android Browser
@@ -7233,19 +6517,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; TM-MID798 Build/NRD90M AppleWebKit/537.36 KHTML, like Gecko Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T8
+    brand: Touchmate
     model: TM-MID798
   os_family: Android
   browser_family: Chrome
@@ -7253,19 +6535,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; COTO_T117 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T9
+    brand: Top House
     model: Coto T117
   os_family: Android
   browser_family: Chrome
@@ -7273,19 +6553,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; X1013 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "47.0.2526.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: T9
+    brand: Top House
     model: X1013
   os_family: Android
   browser_family: Chrome
@@ -7293,19 +6571,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TECNO DP10A Pro Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TB
+    brand: Tecno Mobile
     model: DroidPad 10A Pro
   os_family: Android
   browser_family: Chrome
@@ -7313,19 +6589,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; TECNO P904 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.83 Safari/537.36 OPR/28.0.2254.119213
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "28.0.2254.119213"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TB
+    brand: Tecno Mobile
     model: DroidPad 10D 4G
   os_family: Android
   browser_family: Opera
@@ -7333,19 +6607,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.0; TECNO 7C Build/LRX21M)
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: TB
+    brand: Tecno Mobile
     model: DroidPad 7C
   os_family: Android
   browser_family: Android Browser
@@ -7353,19 +6625,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TECNO DP7C Pro-SGA1 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TB
+    brand: Tecno Mobile
     model: DroidPad 7C Pro
   os_family: Android
   browser_family: Chrome
@@ -7373,19 +6643,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TECNO DP8D Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TB
+    brand: Tecno Mobile
     model: DroidPad 8D
   os_family: Android
   browser_family: Chrome
@@ -7393,19 +6661,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Hudl 2 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TD
+    brand: Tesco
     model: Hudl 2
   os_family: Android
   browser_family: Chrome
@@ -7413,19 +6679,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Hudl HT7S3 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TD
+    brand: Tesco
     model: Hudl HT7S3
   os_family: Android
   browser_family: Chrome
@@ -7433,19 +6697,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; W032i-C3 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TD
+    brand: Tesco
     model: Op3n Dott
   os_family: Android
   browser_family: Chrome
@@ -7453,19 +6715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; MID211H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TK
+    brand: Takara
     model: MID211H
   os_family: Android
   browser_family: Chrome
@@ -7473,19 +6733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TEL-1013GIQA Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: Giqa 10.1 3G
   os_family: Android
   browser_family: Chrome
@@ -7493,19 +6751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TF-MID1010G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: TF-MID1010G
   os_family: Android
   browser_family: Chrome
@@ -7513,19 +6769,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; TF-MID702G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: TF-MID702G
   os_family: Android
   browser_family: Android Browser
@@ -7533,19 +6787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TF-MID7805G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: TF-MID7805G
   os_family: Android
   browser_family: Chrome
@@ -7553,19 +6805,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; TF-MID802G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: TF-MID802G
   os_family: Android
   browser_family: Android Browser
@@ -7573,19 +6823,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TF-MID9705RG Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.64 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.64"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TL
+    brand: Telefunken
     model: TF-MID9705RG
   os_family: Android
   browser_family: Chrome
@@ -7593,19 +6841,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-CN; 8950 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: TN
+    brand: Thomson
     model: 3G 8950
   os_family: Android
   browser_family: Unknown
@@ -7613,7 +6859,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PRIMO7 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -7622,7 +6867,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: TN
+    brand: Thomson
     model: Primo 7
   os_family: Android
   browser_family: Unknown
@@ -7630,19 +6875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; PRIMO8 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TN
+    brand: Thomson
     model: Primo 8
   os_family: Android
   browser_family: Android Browser
@@ -7650,19 +6893,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; QM734-8G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TN
+    brand: Thomson
     model: QM734-8G
   os_family: Android
   browser_family: Android Browser
@@ -7670,19 +6911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QM735-8G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TN
+    brand: Thomson
     model: QM735-8G
   os_family: Android
   browser_family: Chrome
@@ -7690,19 +6929,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; S813G Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/60.0.3112.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: S813G
   os_family: Android
   browser_family: Chrome
@@ -7710,7 +6947,6 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.4; Xtab 7 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36 [FB_IAB/FB4A;FBAV/42.0.0.27.114;]'
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
@@ -7719,7 +6955,7 @@
     version: "42.0.0.27.114"
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB 7
   os_family: Android
   browser_family: Unknown
@@ -7727,19 +6963,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; hu-hu; xTAB-70dc Build/xTAB-70dc.8GB.20121102) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB 70dc
   os_family: Android
   browser_family: Android Browser
@@ -7747,19 +6981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; XTAB 781+ Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB 781+
   os_family: Android
   browser_family: Chrome
@@ -7767,19 +6999,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-la; Xtab-781+ Build/JDQ39) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB 781+
   os_family: Android
   browser_family: Unknown
@@ -7787,19 +7017,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Dual C1081HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Safari/537.36 OPR/24.0.1565.82529
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "24.0.1565.82529"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB C1081HD
   os_family: Android
   browser_family: Opera
@@ -7807,19 +7035,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-us; Xtab Dual C1081+ Build/GT11K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB Dual C1081+
   os_family: Android
   browser_family: Android Browser
@@ -7827,19 +7053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Xtab i700 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TP
+    brand: TechPad
     model: XTAB i700
   os_family: Android
   browser_family: Chrome
@@ -7847,19 +7071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Hive V 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TR
+    brand: Turbo-X
     model: Hive V 3G
   os_family: Android
   browser_family: Chrome
@@ -7867,19 +7089,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ro-ro; Turbo-X Ice Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TR
+    brand: Turbo-X
     model: Ice
   os_family: Android
   browser_family: Android Browser
@@ -7887,19 +7107,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; bg-bg; Turbo-X Tablet Spice III Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TR
+    brand: Turbo-X
     model: Tablet Spice III
   os_family: Android
   browser_family: Android Browser
@@ -7907,19 +7125,17 @@
   user_agent: Mozilla/5.0 (Windows NT 6.3; Win64; x64; Trident/7.0; Touch; TAJB; rv:11.0) like Gecko
   os:
     name: Windows
-    short_name: WIN
     version: "8.1"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "11.0"
     engine: Trident
     engine_version: "7.0"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -7927,19 +7143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AT7-C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Excite
   os_family: Android
   browser_family: Chrome
@@ -7947,19 +7161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AT10-A Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Excite AT10-A
   os_family: Android
   browser_family: Chrome
@@ -7967,19 +7179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AT10LE-A Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Excite AT10L-A
   os_family: Android
   browser_family: Chrome
@@ -7987,19 +7197,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AT10PE-A Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Excite AT10P-A
   os_family: Android
   browser_family: Chrome
@@ -8007,19 +7215,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; zh-tw; AT100 Build/HMJ37) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT100
   os_family: Android
   browser_family: Android Browser
@@ -8027,19 +7233,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; fr-fr; AT1S0 Build/HTK55D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT1S0
   os_family: Android
   browser_family: Android Browser
@@ -8047,19 +7251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; AT200 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT200
   os_family: Android
   browser_family: Android Browser
@@ -8067,19 +7269,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; AT270 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT270
   os_family: Android
   browser_family: Chrome
@@ -8087,19 +7287,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; AT300 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT300
   os_family: Android
   browser_family: Chrome
@@ -8107,19 +7305,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.1; AT300SE Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT300SE
   os_family: Android
   browser_family: Chrome
@@ -8127,19 +7323,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AT330 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT330
   os_family: Android
   browser_family: Android Browser
@@ -8147,19 +7341,17 @@
   user_agent: mozilla/5.0 (linux; android 4.2.2; at374 build/jdq39) applewebkit/537.36 (khtml, like gecko) chrome/33.0.1750.166 safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT374
   os_family: Android
   browser_family: Chrome
@@ -8167,19 +7359,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; AT400 Build/JRO03C) AppleWebKit/535.19 (KHTML like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT400
   os_family: Android
   browser_family: Chrome
@@ -8187,19 +7377,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; AT470 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT470
   os_family: Android
   browser_family: Chrome
@@ -8207,19 +7395,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ja-jp; AT500 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT500
   os_family: Android
   browser_family: Android Browser
@@ -8227,19 +7413,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; AT500a Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT500a
   os_family: Android
   browser_family: Android Browser
@@ -8247,19 +7431,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AT503 Build/JOP40D) AppleWebKit/537.36 (KHTML, Like Gecko) Chrome/30.0.1599.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT503
   os_family: Android
   browser_family: Chrome
@@ -8267,19 +7449,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; AT570 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT570
   os_family: Android
   browser_family: Android Browser
@@ -8287,19 +7467,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; AT703 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT703
   os_family: Android
   browser_family: Chrome
@@ -8307,19 +7485,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ja-jp; AT830 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TS
+    brand: Toshiba
     model: Regza AT830
   os_family: Android
   browser_family: Android Browser
@@ -8329,13 +7505,12 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.4.3.532"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad 3G
   os_family: Unknown
   browser_family: Unknown
@@ -8343,19 +7518,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.2; ru-ru; NaviPad TM-7049 3Grevision 1 AppleWebKit/537.16 KHTML, like Gecko Version/4.0 Safari/537.16 Chrome/33.0.0.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad TM-7049 3G
   os_family: Android
   browser_family: Chrome
@@ -8363,19 +7536,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; NaviPad TM-7055HD 3G Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad TM-7055HD 3G
   os_family: Android
   browser_family: Android Browser
@@ -8383,19 +7554,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; NaviPad TM-7855 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad TM-7855 3G
   os_family: Android
   browser_family: Chrome
@@ -8403,19 +7572,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; NaviPad TM-7858 3G (revision 1) Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad TM-7858 3G (revision 1)
   os_family: Android
   browser_family: Android Browser
@@ -8423,19 +7590,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; NaviPad TM-7887 3G (revision 1) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16 Chrome/33.0.0.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: NaviPad TM-7887 3G
   os_family: Android
   browser_family: Chrome
@@ -8443,19 +7608,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android Android-2.2.1; ru-ru; TB-711A Build/FROYO AppleWebKit/533.1 KHTML, like Gecko Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TB-711A
   os_family: Android
   browser_family: Android Browser
@@ -8463,19 +7626,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; TB-771A Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TB-771A
   os_family: Android
   browser_family: Chrome
@@ -8483,19 +7644,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 5.1; en-US; TM-1057 Build/LMY47I AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/11.4.5.1005 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.4.5.1005"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-1057
   os_family: Android
   browser_family: Unknown
@@ -8503,19 +7662,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-1067 Build/LMY47I AppleWebKit/537.36 KHTML, like Gecko Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-1067
   os_family: Android
   browser_family: Chrome
@@ -8523,19 +7680,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-6906 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-6906
   os_family: Android
   browser_family: Chrome
@@ -8543,19 +7698,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; ru-ru; TM-7021 Build/MID) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7021
   os_family: Android
   browser_family: Android Browser
@@ -8563,19 +7716,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; TM-7023 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7023
   os_family: Android
   browser_family: Android Browser
@@ -8583,19 +7734,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.4; TM-7024 Build/IMM76D AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7024
   os_family: Android
   browser_family: Chrome
@@ -8603,19 +7752,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.0.4; ru-ru; TM-7026 revision 4 Build/IMM76D AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7026
   os_family: Android
   browser_family: Android Browser
@@ -8623,19 +7770,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.3; TM-7037W Build/IML74K AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7037W
   os_family: Android
   browser_family: Chrome
@@ -8643,19 +7788,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; TM-7041 Build/V1.1.ICECREAMSANDWICH.rus.teXet.20120913.172341) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7041
   os_family: Android
   browser_family: Chrome
@@ -8663,19 +7806,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; en-US; TM-7043XD Build/JRO03C AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/11.0.8.855 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.0.8.855"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7043XD
   os_family: Android
   browser_family: Unknown
@@ -8683,7 +7824,6 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; TM-7047HD 3G Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.102 Crosswalk/20.50.533.12 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -8692,7 +7832,7 @@
     version: "20.50.533.12"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7047HD 3G
   os_family: Android
   browser_family: Unknown
@@ -8700,19 +7840,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.1.1; TM-7047HD 3G Build/JRO03H; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/59.0.3071.117 Safari/537.36 Puffin/7.1.2.18064AT
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.1.2.18064"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7047HD 3G
   os_family: Android
   browser_family: Unknown
@@ -8720,19 +7858,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-7052 Build/LMY47D AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7052
   os_family: Android
   browser_family: Chrome
@@ -8740,19 +7876,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-7053 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-7053
   os_family: Android
   browser_family: Chrome
@@ -8760,19 +7894,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.1; TM-8041HD Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-8041HD
   os_family: Android
   browser_family: Chrome
@@ -8780,19 +7912,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; TM-8041HD Build/JRO03C) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-8041HD
   os_family: Android
   browser_family: Chrome
@@ -8800,19 +7930,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; TM-8043 Build/LMY47D; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/48.0.2564.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2564.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-8043
   os_family: Android
   browser_family: Chrome
@@ -8820,19 +7948,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TM-8044 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-8044
   os_family: Android
   browser_family: Chrome
@@ -8840,19 +7966,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; TM-9720 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9720
   os_family: Android
   browser_family: Android Browser
@@ -8860,19 +7984,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; TM-9737W Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9737W
   os_family: Android
   browser_family: Android Browser
@@ -8880,19 +8002,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.3; TM-9738W Build/IML74K AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9738W
   os_family: Android
   browser_family: Chrome
@@ -8900,19 +8020,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; TM-9740 Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9740
   os_family: Android
   browser_family: Android Browser
@@ -8920,19 +8038,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; TM-9741 Build/V1.1.ICECREAMSANDWICH.rus.teXet.20120829.211009) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9741
   os_family: Android
   browser_family: Android Browser
@@ -8940,19 +8056,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.0.3; TM-9743W Build/V1.1.ICECREAMSANDWICH.rus.teXet.20121105.112937 AppleWebKit/537.36 KHTML, like Gecko Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9743W
   os_family: Android
   browser_family: Chrome
@@ -8960,19 +8074,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; TM-9747 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9747
   os_family: Android
   browser_family: Opera
@@ -8980,19 +8092,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; TM-9747BT Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9747BT
   os_family: Android
   browser_family: Android Browser
@@ -9000,19 +8110,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TM-9748 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.126 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9748 3G
   os_family: Android
   browser_family: Chrome
@@ -9020,19 +8128,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; en-US; TM-9750HD Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 UCBrowser/11.2.0.915 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "11.2.0.915"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9750HD
   os_family: Android
   browser_family: Unknown
@@ -9040,19 +8146,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; TM-9751HD Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9751HD
   os_family: Android
   browser_family: Android Browser
@@ -9060,19 +8164,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-9757 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: TM-9757
   os_family: Android
   browser_family: Chrome
@@ -9080,19 +8182,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; TM-1058 Build/V1.1.JELLYBEAN.rus.teXet AppleWebKit/537.22 KHTML, like Gecko Chrome/25.0.1364.123 Safari/537.22Mozilla/5.0 Linux; Android 4.2.2; TM-1058 Build/V1.1.JELLYBEAN.rus.teXet AppleWebKit/537.22 KHTML, like Gecko Chrome/25.0.1364.123 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.123"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-Force 10 3G
   os_family: Android
   browser_family: Chrome
@@ -9100,19 +8200,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; X-pad AIR 8 3G (revision 1) Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad AIR 8 3G
   os_family: Android
   browser_family: Chrome
@@ -9120,19 +8218,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TM-8048_revision1 Build/V1.1.JELLYBEAN.rus.teXet) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Force 8 3G
   os_family: Android
   browser_family: Chrome
@@ -9140,19 +8236,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TM-8051 Build/TM-8051) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.123 Safari/537.22
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "25.0.1364.123"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Force 8i 3G
   os_family: Android
   browser_family: Chrome
@@ -9160,19 +8254,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad HIT 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Hit 3G
   os_family: Android
   browser_family: Chrome
@@ -9180,19 +8272,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; X-pad iX 7 3G(revision 5) Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad iX 7 3G
   os_family: Android
   browser_family: Chrome
@@ -9200,19 +8290,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad LITE 7.1 (revision 2)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.1.2672.49808
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.1.2672.49808"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Lite 7.1"
   os_family: Android
   browser_family: Opera
@@ -9220,19 +8308,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad LITE 7.2 (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Lite 7.2"
   os_family: Android
   browser_family: Chrome
@@ -9240,19 +8326,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad NAVI 10 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 10.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -9260,19 +8344,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-1046 Build/RU_TEXET AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 10.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -9280,19 +8362,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-7096 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Chrome/66.0.3359.126 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.126"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 7.3" 3G
   os_family: Android
   browser_family: Chrome
@@ -9300,19 +8380,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad NAVI 7.3 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 7.3" 3G
   os_family: Android
   browser_family: Chrome
@@ -9320,19 +8398,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; TM-7099 Build/KOT49H AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 7.4" 3G
   os_family: Android
   browser_family: Chrome
@@ -9340,19 +8416,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad NAVI 7.5 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 7.5" 3G
   os_family: Android
   browser_family: Chrome
@@ -9360,19 +8434,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-7859 3G(revision 1) Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.78 Safari/537.36 OPR/30.0.1856.93524
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "30.0.1856.93524"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad NAVI 8.2" 3G
   os_family: Android
   browser_family: Opera
@@ -9380,19 +8452,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad PLUS 7 3G/TM-9746 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Plus 7 3G
   os_family: Android
   browser_family: Chrome
@@ -9400,19 +8470,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad PLUS 7.1 3G/TM-9749 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Plus 7.1 3G
   os_family: Android
   browser_family: Chrome
@@ -9420,19 +8488,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad QUAD 10 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Quad 10.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -9440,19 +8506,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad QUAD 7 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Quad 7.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -9460,19 +8524,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad QUAD 7.2 3G (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Quad 7.2" 3G
   os_family: Android
   browser_family: Chrome
@@ -9480,19 +8542,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TM-8066 (revision1) Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Rapid 8.2" 4G
   os_family: Android
   browser_family: Chrome
@@ -9500,19 +8560,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad SHINE 8.1 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Shine 8.1" 3G
   os_family: Android
   browser_family: Chrome
@@ -9520,19 +8578,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.4.2; X-pad SKY 8.1 3G  (revision 1)) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Sky 8.1" 3G
   os_family: Android
   browser_family: Chrome
@@ -9540,19 +8596,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TM-9758 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Safari/537.36 OPR/47.3.2249.130976
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "47.3.2249.130976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Style 10.0"
   os_family: Android
   browser_family: Opera
@@ -9560,19 +8614,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TM-9767 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Style 10.0" 3G
   os_family: Android
   browser_family: Chrome
@@ -9580,19 +8632,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad STYLE 10.1 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Style 10.1" 3G
   os_family: Android
   browser_family: Chrome
@@ -9600,19 +8650,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; X-pad STYLE 8 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36 OPR/56.0.2780.51441
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "56.0.2780.51441"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: TZ
+    brand: teXet
     model: X-pad Style 8.0" 3G
   os_family: Android
   browser_family: Opera
@@ -9620,19 +8668,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VisionBook_10Qi_3G Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.84 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "62.0.3202.84"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 10Qi 3G
   os_family: Android
   browser_family: Chrome
@@ -9640,19 +8686,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Visionbook 7Q Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: Visionbook 7Q Plus
   os_family: Android
   browser_family: Chrome
@@ -9660,19 +8704,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 7Qa_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 7Qa 3G
   os_family: Android
   browser_family: Chrome
@@ -9680,19 +8722,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VisionBook 7Qi 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 7Qi 3G
   os_family: Android
   browser_family: Chrome
@@ -9700,19 +8740,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VisionBook 8Q LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Q LTE
   os_family: Android
   browser_family: Chrome
@@ -9720,19 +8758,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VisionBook_8Q_Plus Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Q Plus
   os_family: Android
   browser_family: Chrome
@@ -9740,19 +8776,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 8Qa_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Qa 3G
   os_family: Android
   browser_family: Chrome
@@ -9760,19 +8794,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; VisionBook_8Qe_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Qe 3G
   os_family: Android
   browser_family: Chrome
@@ -9780,19 +8812,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VisionBook_8Qi_3G Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Qi 3G
   os_family: Android
   browser_family: Chrome
@@ -9800,19 +8830,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VisionBook_8Qi_3G_Plus Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook 8Qi 3G Plus
   os_family: Android
   browser_family: Chrome
@@ -9820,19 +8848,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VisionBook P70 LTE Build/LMY47V; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UA
+    brand: Umax
     model: VisionBook P70 LTE
   os_family: Android
   browser_family: Chrome
@@ -9840,19 +8866,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QOOQ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: UN
+    brand: Unowhy
     model: QOOQ
   os_family: Android
   browser_family: Chrome
@@ -9860,19 +8884,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Epic E8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Epic E8
   os_family: Android
   browser_family: Chrome
@@ -9880,19 +8902,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Epic P7 Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/43.0.2357.121 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "43.0.2357.121"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Epic P7
   os_family: Android
   browser_family: Chrome
@@ -9900,19 +8920,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Magnet M1 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Magnet M1
   os_family: Android
   browser_family: Chrome
@@ -9920,19 +8938,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Navo_QS Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Navo QS
   os_family: Android
   browser_family: Chrome
@@ -9940,19 +8956,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Onyx_QS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Onyx QS
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/tablet-5.yml
+++ b/Tests/fixtures/tablet-5.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; Onyx_Z Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Onyx Z
   os_family: Android
   browser_family: Android Browser
@@ -23,19 +21,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Orin_QS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Orin QS
   os_family: Android
   browser_family: Chrome
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0(Linux; Android 5.1; Pluri_M7 Build/LMY47I)AppleWebKit/537.36(KHTML, like Gecko)Chrome/53.0.2785.124Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Pluri M7
   os_family: Android
   browser_family: Chrome
@@ -63,19 +57,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Pluri_Q8 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Pluri Q8
   os_family: Android
   browser_family: Chrome
@@ -83,19 +75,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; Sirius_QS Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Sirius QS
   os_family: Android
   browser_family: Android Browser
@@ -103,19 +93,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; XAVY_L8 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Xavy L8
   os_family: Android
   browser_family: Chrome
@@ -123,19 +111,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Xavy_T7 Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V2
+    brand: Vonino
     model: Xavy T7
   os_family: Android
   browser_family: Chrome
@@ -143,19 +129,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1; QTAIR7 AppleWebKit/537.36 KHTML, like Gecko Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 10
   os_family: Android
   browser_family: Chrome
@@ -163,19 +147,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; QTAXIA1 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 10
   os_family: Android
   browser_family: Chrome
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; QMV7B Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 7
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; QTAQZ3 Build/LMY47V AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 8
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; QTASUN1 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 8 HD
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; QTASUN2 AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis 8 HD 4G LTE
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; QTAQZ3KID Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: V4
+    brand: Verizon
     model: Ellipsis Kids LTE
   os_family: Android
   browser_family: Chrome
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; ru-ru; M1072R-3G Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VA
+    brand: Vastking
     model: M1072R-3G
   os_family: Android
   browser_family: Android Browser
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.2.2; M783K Build/JDQ39 AppleWebKit/537.36 KHTML, like Gecko Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VA
+    brand: Vastking
     model: M783K
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; M783K-16G Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VA
+    brand: Vastking
     model: M783K-16G
   os_family: Android
   browser_family: Android Browser
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; M910A Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: VA
+    brand: Vastking
     model: M910A
   os_family: Android
   browser_family: Android Browser
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; VT75C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VD
+    brand: Videocon
     model: VT75C
   os_family: Android
   browser_family: Android Browser
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-gb; SmartTab10 Build/MASTER) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 10
   os_family: Android
   browser_family: Android Browser
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; fr-fr; SmartTab10-MSM8260-V03b-Apr162012-Vodafone-IT) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 10
   os_family: Android
   browser_family: Android Browser
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; SmartTab10 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.107 Safari/537.36 OPR/29.0.1809.92697
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "29.0.1809.92697"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 10
   os_family: Android
   browser_family: Opera
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Vodafone Smart Tab 4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Mobile Safari/534.30 SVN/040FDG1
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 4
   os_family: Android
   browser_family: Android Browser
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Vodafone Smart Tab 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 4
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Vodafone Smart Tab 4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 4
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; it-it; Vodafone Smart Tab 4G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36 SVN/090FYG1
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 4G
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; Vodafone Smart Tab 4G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.74 Safari/537.36 OPR/28.0.1764.89981
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "28.0.1764.89981"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 4G
   os_family: Android
   browser_family: Opera
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; fr-fr; SmartTab7-MSM8260-V03b-Apr162012-Vodafone-ES) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab 7
   os_family: Android
   browser_family: Android Browser
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; Vodafone SmartTab II 10 Build/SmartTabII10_A403_V72_121009) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab II 10
   os_family: Android
   browser_family: Android Browser
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; SmartTabII10 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab II 10
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be, SmartTabII7 Build/A2107A_A404_004_043_120927_VODA) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab II 7
   os_family: Android
   browser_family: Android Browser
@@ -623,19 +561,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Vodafone Smart Tab III 10 Build/S6000_A422_000_028_130816_VF) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab III 10
   os_family: Android
   browser_family: Android Browser
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; Vodafone Smart Tab III 7 Build/A3000_A422_000_027_130814_VF) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab III 7
   os_family: Android
   browser_family: Android Browser
@@ -663,19 +597,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 7.0; VFD 1300 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36 [air.com.A888poker/1.0]'
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Smart Tab N8
   os_family: Android
   browser_family: Chrome
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; VFD 1100 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Tab Mini 7
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; VF-1497) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Tab Prime 6
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VFD 1400 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Tab Prime 7
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VF-1397) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VF
+    brand: Vodafone
     model: Tab Speed 6
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Vodacom Power Tab 10 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "51.0.2704.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VM
+    brand: Vodacom
     model: Power Tab 10
   os_family: Android
   browser_family: Chrome
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; ViewPad 10e Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VS
+    brand: ViewSonic
     model: ViewPad 10e
   os_family: Android
   browser_family: Android Browser
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-ca; ViewPad7 Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: VS
+    brand: ViewSonic
     model: ViewPad 7
   os_family: Android
   browser_family: Android Browser
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3;en-us; ViewSonic-ViewPad7e build/ERE27) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: VS
+    brand: ViewSonic
     model: ViewPad 7e
   os_family: Android
   browser_family: Android Browser
@@ -843,19 +759,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; VTAB10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab 10
   os_family: Android
   browser_family: Android Browser
@@ -863,19 +777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; V_TAB_7_ECO_III Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab 7 Eco 3
   os_family: Android
   browser_family: Chrome
@@ -883,19 +795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; V_TAB_7020A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab 7020A
   os_family: Android
   browser_family: Chrome
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; V_TAB_7025 Build/V_TAB_7025) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab 7025
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VT97PRO Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab 9.7 Pro
   os_family: Android
   browser_family: Chrome
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VP74 Build/T7V16) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/44.0.2403.133 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "44.0.2403.133"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VT
+    brand: Vestel
     model: VTab Lite II
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; V709X Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: VX
+    brand: Vertex
     model: V709X
   os_family: Android
   browser_family: Android Browser
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; VOYO A15 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: VY
+    brand: Voyo
     model: A15
   os_family: Android
   browser_family: Chrome
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; ru-ru; VTAB1008 Build/HTK55) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: VZ
+    brand: Vizio
     model: VTAB1008
   os_family: Android
   browser_family: Android Browser
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Primo Walpad 7 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/27.0.1453.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "27.0.1453.90"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: WA
+    brand: Walton
     model: Primo Walpad 7
   os_family: Android
   browser_family: Chrome
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Walpad 8b Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WA
+    brand: Walton
     model: Primo Walpad 8b
   os_family: Android
   browser_family: Android Browser
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Primo Walpad 8W Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.122 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.122"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WA
+    brand: Walton
     model: Primo Walpad 8W
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; miTab ALABAMA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab ALABAMA
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; miTab BROOKLYN Build/IMM76D) AppleWebKit/530.17 (KHTML, like Gecko) FlyFlow/2.1 Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "2.1"
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab BROOKLYN
   os_family: Android
   browser_family: Baidu
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; miTab-EPSILON Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab EPSILON
   os_family: Android
   browser_family: Android Browser
@@ -1143,19 +1029,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; miTab FUNK Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab FUNK
   os_family: Android
   browser_family: Android Browser
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; miTab HERO Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab HERO
   os_family: Android
   browser_family: Android Browser
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; miTab JUMP Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab JUMP
   os_family: Android
   browser_family: Android Browser
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; miTab_Seattle) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WL
+    brand: Wolder
     model: miTab Seattle
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TERRA PAD 1004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WR
+    brand: Wortmann
     model: Terra Pad 1004
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Woxter_N100 Build/N9F27F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: N100
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Woxter Nimbus 97Q Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: Nimbus 97Q
   os_family: Android
   browser_family: Android Browser
@@ -1283,19 +1155,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; Woxter QX 70 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: QX 70
   os_family: Android
   browser_family: Android Browser
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; Woxter Tablet PC 76CXi Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Mobile Safari/537.36 OPR/16.0.1212.65583
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "16.0.1212.65583"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: Tablet PC 76CXi
   os_family: Android
   browser_family: Opera
@@ -1323,19 +1191,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; Woxter Tablet PC 90BL Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: Tablet PC 90BL
   os_family: Android
   browser_family: Android Browser
@@ -1343,19 +1209,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; Woxter Tablet PC 97IPS Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: Tablet PC 97IPS
   os_family: Android
   browser_family: Android Browser
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; Woxter Zielo D15 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WX
+    brand: Woxter
     model: Zielo D15
   os_family: Android
   browser_family: Android Browser
@@ -1383,19 +1245,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; WEXLER.BOOK_T7008 Build/20120515) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WY
+    brand: Wexler
     model: BOOK T7008
   os_family: Android
   browser_family: Android Browser
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TAB 10Q Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 YaBrowser/14.12.2125.9740.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.12.2125.9740.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WY
+    brand: Wexler
     model: TAB 10Q
   os_family: Android
   browser_family: Unknown
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; WEXLER-TAB-7T Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WY
+    brand: Wexler
     model: TAB-7T
   os_family: Android
   browser_family: Android Browser
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; WEXLER_TAB7ID Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: WY
+    brand: Wexler
     model: TAB7ID
   os_family: Android
   browser_family: Android Browser
@@ -1463,19 +1317,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ULTIMA 7 TWIST PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: WY
+    brand: Wexler
     model: ULTIMA 7 TWIST PLUS
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MI PAD MIUI/KXFCNBF2.0)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: XI
+    brand: Xiaomi
     model: Mi Pad
   os_family: Android
   browser_family: Android Browser
@@ -1503,19 +1353,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MI PAD 2 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.124 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.124"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XI
+    brand: Xiaomi
     model: Mi Pad 2
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MI PAD 3 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XI
+    brand: Xiaomi
     model: Mi Pad 3
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; MI PAD 4 PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XI
+    brand: Xiaomi
     model: Mi Pad 4 Plus
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TelePAD10A3 4G Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XR
+    brand: Xoro
     model: TelePad 10 A3 4G
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-; TelePAD1032 Build/JZO54K) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16 Chrome/33.0.0.0
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XR
+    brand: Xoro
     model: TelePad 1032
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TelePAD7A3 4G Build/LMY47D; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XR
+    brand: Xoro
     model: TelePad 7 A3 4G
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ro-ro; TelePAD731 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: XR
+    brand: Xoro
     model: TelePad 731
   os_family: Android
   browser_family: Android Browser
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TelePAD795 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XR
+    brand: Xoro
     model: TelePad 795
   os_family: Android
   browser_family: Chrome
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Hope7_Mate) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/84.0.4147.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XT
+    brand: X-TIGI
     model: Hope 7 Mate
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-TIGI_JOY10_PRO Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.81 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.81"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XT
+    brand: X-TIGI
     model: Joy 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-TIGI_JOY7_MAX Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: XT
+    brand: X-TIGI
     model: Joy 7 Max
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; Luna TAB474 Build/LunaTAB474) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 10
   os_family: Android
   browser_family: Android Browser
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; nl-nl; Luna TAB10-150 Build/Luna TAB10-150) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 10c
   os_family: Android
   browser_family: Android Browser
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Luna TAB07-920N Build/JRO03C) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 7
   os_family: Android
   browser_family: Android Browser
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; Luna TAB274 Build/LunaTAB274) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 7c
   os_family: Android
   browser_family: Android Browser
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; Luna TAB07-100 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 7c
   os_family: Android
   browser_family: Android Browser
@@ -1823,19 +1641,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.4; fr-be; Luna TAB07-101 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Luna 7c
   os_family: Android
   browser_family: Android Browser
@@ -1843,19 +1659,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; TAB10-410 Build/Noble TAB10-410) AppleWebKit/534.30 (KHTML, like Gecko)Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Noble 10.1
   os_family: Android
   browser_family: Android Browser
@@ -1863,19 +1677,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; TAB09-410 Build/Noble TAB09-410) AppleWebKit/534.30 (KHTML, like Gecko)Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Noble 9.7
   os_family: Android
   browser_family: Android Browser
@@ -1883,19 +1695,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Noble TAB07-485 Build/Noble TAB07-485) AppleWebKit/537.36 (KHTML like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Noble Mini
   os_family: Android
   browser_family: Chrome
@@ -1903,19 +1713,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; TAB10-201 Build/Xenta) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 10ic
   os_family: Android
   browser_family: Android Browser
@@ -1923,19 +1731,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Xenta TAB10-211 Build/Xenta TAB10-211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 10ic
   os_family: Android
   browser_family: Android Browser
@@ -1943,19 +1749,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Xenta TAB13-201 Build/Xenta TAB13-201) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 13c
   os_family: Android
   browser_family: Android Browser
@@ -1963,19 +1767,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; Xenta-TAB07-210 Build/Xenta-TAB07-210) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 7c
   os_family: Android
   browser_family: Android Browser
@@ -1983,19 +1785,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; nl-be; Xenta-TAB07-211 Build/Xenta-TAB07-211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 7c
   os_family: Android
   browser_family: Android Browser
@@ -2003,19 +1803,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; TAB07-200 Build/Xenta) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 7ic
   os_family: Android
   browser_family: Android Browser
@@ -2023,19 +1821,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Xenta TAB08-201-3G Build/Xenta TAB08-201-3G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 8c
   os_family: Android
   browser_family: Android Browser
@@ -2043,19 +1839,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-be; Xenta TAB08-200 Build/Xenta TAB08-200) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 8ic
   os_family: Android
   browser_family: Android Browser
@@ -2063,19 +1857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; Xenta TAB9-200 Build/Xenta TAB9-200) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 9.7ic
   os_family: Android
   browser_family: Android Browser
@@ -2083,19 +1875,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; bg-bg; Xenta TAB09-211 Build/XentaTAB09-211) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YA
+    brand: Yarvik
     model: Xenta 9.7ic+
   os_family: Android
   browser_family: Android Browser
@@ -2103,19 +1893,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; N101 DUAL CORE2 V11 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: YU
+    brand: Yuandao
     model: N101
   os_family: Android
   browser_family: Android Browser
@@ -2123,19 +1911,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZFINERY900 Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ZF
+    brand: Zfiner
     model: Y900
   os_family: Android
   browser_family: Chrome
@@ -2143,19 +1929,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; th-tk; ZYQ-Q88 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZQ
+    brand: ZYQ
     model: Q88
   os_family: Android
   browser_family: Android Browser
@@ -2163,19 +1947,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; ZYNC CLOUD 605 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Cloud 605
   os_family: Android
   browser_family: Android Browser
@@ -2183,19 +1965,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Cloud Z5 Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.1.362 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.1.362"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Cloud Z5
   os_family: Android
   browser_family: Unknown
@@ -2203,19 +1983,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Zync Dual 7+ Build/JRO03C) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.7.5.418 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.7.5.418"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Dual 7+
   os_family: Android
   browser_family: Unknown
@@ -2223,19 +2001,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; ZYNC Dual 7i Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30/4.05d.1002.m7
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Dual 7i
   os_family: Android
   browser_family: Android Browser
@@ -2243,19 +2019,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ar-eg; Z1000 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z1000
   os_family: Android
   browser_family: Android Browser
@@ -2263,19 +2037,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Z1000 3D Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z1000 3D
   os_family: Android
   browser_family: Android Browser
@@ -2283,19 +2055,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-nz; Z18 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z18
   os_family: Android
   browser_family: Android Browser
@@ -2303,19 +2073,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Zync Z7i 3G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z7i 3G
   os_family: Android
   browser_family: Chrome
@@ -2323,19 +2091,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ZYNC Z81 Build/V800HM) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z81
   os_family: Android
   browser_family: Chrome
@@ -2343,19 +2109,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; Z900_Plus) U2/1.0.0 UCBrowser/10.9.2.962 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.9.2.962"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z900 Plus
   os_family: Android
   browser_family: Unknown
@@ -2363,19 +2127,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; en-au; Z909 Build/GRI40) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z909
   os_family: Android
   browser_family: Android Browser
@@ -2383,19 +2145,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-US; Z930 Build/JRO03R) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.1.344"
     engine: WebKit
     engine_version: "534.31"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z930
   os_family: Android
   browser_family: Unknown
@@ -2403,19 +2163,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; Z930+ Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z930+
   os_family: Android
   browser_family: Android Browser
@@ -2423,19 +2181,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; Z99 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z99
   os_family: Android
   browser_family: Android Browser
@@ -2443,19 +2199,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Z992 Build/JRO03C) AppleWebKit/535.19 (KHTML, Like Gecko) Chrome/18.0.1025.166 Mobile Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z99
   os_family: Android
   browser_family: Chrome
@@ -2463,19 +2217,17 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.4.2; en-US; Z99_3G) U2/1.0.0 UCBrowser/10.7.5.785 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.7.5.785"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z99 3G
   os_family: Android
   browser_family: Unknown
@@ -2483,19 +2235,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; en-us; Z99 Dual Core Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: ZY
+    brand: Zync
     model: Z99 Dual Core
   os_family: Android
   browser_family: Android Browser
@@ -2503,19 +2253,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Presto Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: Presto
   os_family: Android
   browser_family: Chrome
@@ -2523,19 +2271,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; S72-B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: S72-B
   os_family: Android
   browser_family: Android Browser
@@ -2543,19 +2289,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SX2W Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: SX2W
   os_family: Android
   browser_family: Chrome
@@ -2563,19 +2307,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; TangoTab AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: TangoTab
   os_family: Android
   browser_family: Chrome
@@ -2583,19 +2325,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Ultimax Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: Ultimax
   os_family: Android
   browser_family: Chrome
@@ -2603,19 +2343,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Valumax Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 10
+    brand: Simbans
     model: Valumax
   os_family: Android
   browser_family: Chrome
@@ -2623,19 +2361,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Access_Q784C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 20
+    brand: Alcor
     model: Access Q784C
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/tablet.yml
+++ b/Tests/fixtures/tablet.yml
@@ -3,13 +3,11 @@
   user_agent: Mozilla/5.0 (Android; Tablet; rv:20.0) Gecko/20.0 Firefox/20.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "20.0"
     engine: Gecko
     engine_version: "20.0"
@@ -23,13 +21,11 @@
   user_agent: Mozilla/5.0 (Android; Tablet; rv:26.0) Gecko/26.0 Firefox/26.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Firefox Mobile
-    short_name: FM
     version: "26.0"
     engine: Gecko
     engine_version: "26.0"
@@ -43,13 +39,11 @@
   user_agent: Opera/9.80 (Android 2.2.1; Linux; Opera Tablet/ADR-1301080958) Presto/2.11.355 Version/12.10
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "12.10"
     engine: Presto
     engine_version: "2.11.355"
@@ -63,13 +57,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.1; pl-pl; K1 Build/K1_A301_03_03_110919_SG) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
@@ -83,13 +75,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; it-it; MediaPad Build/orange_Tahiti-LS) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
@@ -103,13 +93,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; cs-cz; K1 Build/HTK75C) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
@@ -123,13 +111,11 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.4; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10990AP Mobile'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "2.10990"
     engine: WebKit
     engine_version: "534.35"
@@ -143,13 +129,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Florida Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
@@ -163,13 +147,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; ARM; Trident/6.0; Touch; ARMBJS)
   os:
     name: Windows RT
-    short_name: WRT
     version: ""
     platform: ARM
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
@@ -183,19 +165,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Senkatel_T1009 Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "01"
+    brand: Senkatel
     model: T1009
   os_family: Android
   browser_family: Chrome
@@ -203,19 +183,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Senkatel_T7011 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "01"
+    brand: Senkatel
     model: T7011
   os_family: Android
   browser_family: Chrome
@@ -223,19 +201,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Senkatel T7012 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "01"
+    brand: Senkatel
     model: T7012
   os_family: Android
   browser_family: Chrome
@@ -243,19 +219,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; Senkatel_T8002 Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "01"
+    brand: Senkatel
     model: T8002
   os_family: Android
   browser_family: Chrome
@@ -263,19 +237,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Senkatel_T9702 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36 OPR/50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "50.3.2426.136976"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "01"
+    brand: Senkatel
     model: T9702
   os_family: Android
   browser_family: Opera
@@ -283,19 +255,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; meanIT X10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: "09"
+    brand: meanIT
     model: X10
   os_family: Android
   browser_family: Chrome
@@ -303,19 +273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Techno 7.0 LTE TQ763I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 0B
+    brand: BB Mobile
     model: Techno 7.0" Kalash LTE TQ763I
   os_family: Android
   browser_family: Chrome
@@ -323,19 +291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Techno I700AJ Build/I700AJ) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 0B
+    brand: BB Mobile
     model: Techno 7.0" Mozg LTE I700AJ
   os_family: Android
   browser_family: Chrome
@@ -343,19 +309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Techno_TQ863Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 0B
+    brand: BB Mobile
     model: Techno 8.0" Poplar LTE TQ863Q
   os_family: Android
   browser_family: Chrome
@@ -363,19 +327,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; CRONY-7021 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 0C
+    brand: Crony
     model: "7021"
   os_family: Android
   browser_family: Android Browser
@@ -383,19 +345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB2323GMQC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 0H
+    brand: Sunstech
     model: TAB2323GMQC
   os_family: Android
   browser_family: Chrome
@@ -403,19 +363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi10 plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi10 Plus
   os_family: Android
   browser_family: Chrome
@@ -423,19 +381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi10 pro Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi10 Pro
   os_family: Android
   browser_family: Chrome
@@ -443,19 +399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CW-Hi10 pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi10 Pro
   os_family: Android
   browser_family: Chrome
@@ -463,19 +417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; CW-Hi12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi12
   os_family: Android
   browser_family: Chrome
@@ -483,19 +435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; CW-Hi8-super) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi8
   os_family: Android
   browser_family: Chrome
@@ -503,19 +453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi8 Air) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi8 Air
   os_family: Android
   browser_family: Chrome
@@ -523,19 +471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Hi8 pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Hi8 Pro
   os_family: Android
   browser_family: Chrome
@@ -543,19 +489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; HiBook pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: HiBook Pro
   os_family: Android
   browser_family: Chrome
@@ -563,19 +507,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; CW-V17HD3G Build/CW-V17HD_3G) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: V17HD 3G
   os_family: Android
   browser_family: Android Browser
@@ -583,19 +525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; CW-V88-QUAD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: V88 Quad
   os_family: Android
   browser_family: Chrome
@@ -603,19 +543,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; CW-V88S Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: V88S
   os_family: Android
   browser_family: Android Browser
@@ -623,19 +561,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.0.4; CW-V9-DUAL Build/IMM76D
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: V9 Dual
   os_family: Android
   browser_family: Android Browser
@@ -643,19 +579,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; CW-V99 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 OPR/44.1.2254.142553
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "44.1.2254.142553"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: V99
   os_family: Android
   browser_family: Opera
@@ -663,19 +597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CW-Vi10 plus Build/LMY47V; ru-ru) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36 Puffin/7.8.3.40913AT
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.3.40913"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Vi10 Plus
   os_family: Android
   browser_family: Unknown
@@ -683,19 +615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; CW-Vi7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Vi7
   os_family: Android
   browser_family: Chrome
@@ -703,19 +633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; CW-Vi8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: Vi8
   os_family: Android
   browser_family: Chrome
@@ -723,19 +651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; CW-VX8-3G Build/CHUWI-CW-VX8) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1C
+    brand: Chuwi
     model: VX8 3G
   os_family: Android
   browser_family: Chrome
@@ -743,19 +669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ETL-T752G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1E
+    brand: Etuline
     model: ETL-T752G
   os_family: Android
   browser_family: Chrome
@@ -763,19 +687,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; ETL-T882G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.11.8.1186 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.11.8.1186"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1E
+    brand: Etuline
     model: ETL-T882G
   os_family: Android
   browser_family: Unknown
@@ -783,19 +705,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; en-US; ETL-T970 Build/ETL-T970 AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.9.9.1155 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.9.9.1155"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1E
+    brand: Etuline
     model: ETL-T970
   os_family: Android
   browser_family: Unknown
@@ -803,19 +723,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.1.1; ETL-T980 Build/MASTER; ru-ru AppleWebKit/537.36 KHTML, like Gecko Chrome/69.0.3497.81 Safari/537.36 Puffin/7.8.1.40497AT
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.1.40497"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1E
+    brand: Etuline
     model: ETL-T980
   os_family: Android
   browser_family: Unknown
@@ -823,19 +741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MYPAD7s Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1M
+    brand: MYFON
     model: My Pad 7s
   os_family: Android
   browser_family: Chrome
@@ -843,19 +759,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; M7-3G-PLUS Build/V18_20200413)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 1R
+    brand: Multilaser
     model: M7 3G Plus
   os_family: Android
   browser_family: Android Browser
@@ -863,19 +777,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; M7_3G_PLUS Build/V4_20191031)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 1R
+    brand: Multilaser
     model: M7 3G Plus
   os_family: Android
   browser_family: Android Browser
@@ -883,19 +795,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; M7-3G QUAD CORE Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 1R
+    brand: Multilaser
     model: M7 3G Quad Core
   os_family: Android
   browser_family: Android Browser
@@ -903,19 +813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0;M7sLite Build/V7_20200616; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1R
+    brand: Multilaser
     model: M7s Lite
   os_family: Android
   browser_family: Chrome
@@ -923,19 +831,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 8.1.0; M7SQC_Plus Build/V3_20190603)
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 1R
+    brand: Multilaser
     model: M7SQC Plus
   os_family: Android
   browser_family: Android Browser
@@ -943,19 +849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; X-Style Tab A101 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1S
+    brand: Sigma
     model: X-Style Tab A101
   os_family: Android
   browser_family: Chrome
@@ -963,19 +867,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; X-StyleTab_A102 AppleWebKit/537.36 KHTML, like Gecko Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1S
+    brand: Sigma
     model: X-Style Tab A102
   os_family: Android
   browser_family: Chrome
@@ -983,19 +885,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; X_Style_Tab_A103 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.8.1291 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.8.1291"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1S
+    brand: Sigma
     model: X-Style Tab A103
   os_family: Android
   browser_family: Unknown
@@ -1003,19 +903,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0; X-StyleTab_A81 Build/MRA58K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/75.0.3770.67 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1S
+    brand: Sigma
     model: X-Style Tab A81
   os_family: Android
   browser_family: Chrome
@@ -1023,19 +921,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.0; en-US; X_Style_Tab_A82 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/13.0.8.1291 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "13.0.8.1291"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 1S
+    brand: Sigma
     model: X-Style Tab A82
   os_family: Android
   browser_family: Unknown
@@ -1043,19 +939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MiXzo ME1030_3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1Z
+    brand: MiXzo
     model: ME1030 3G
   os_family: Android
   browser_family: Chrome
@@ -1063,19 +957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MiXzo MX1037 4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1Z
+    brand: MiXzo
     model: MX1037 4G
   os_family: Android
   browser_family: Chrome
@@ -1083,19 +975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MX1037_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1Z
+    brand: MiXzo
     model: MX1037 4G
   os_family: Android
   browser_family: Chrome
@@ -1103,19 +993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; MX1041_4G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1Z
+    brand: MiXzo
     model: MX1041 4G
   os_family: Android
   browser_family: Chrome
@@ -1123,19 +1011,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Mixzo MX1041 4g) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 1Z
+    brand: MiXzo
     model: MX1041 4G
   os_family: Android
   browser_family: Chrome
@@ -1143,19 +1029,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.4; CT9716 Build/KTU84Q)
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 2E
+    brand: E-Ceros
     model: Revolution
   os_family: Android
   browser_family: Android Browser
@@ -1163,19 +1047,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; es-es; CEROS CT9716-B Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 2E
+    brand: E-Ceros
     model: Revolution HD
   os_family: Android
   browser_family: Android Browser
@@ -1183,19 +1065,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ITELL_K3500N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2I
+    brand: iLife
     model: ITELL K3500N
   os_family: Android
   browser_family: Chrome
@@ -1203,19 +1083,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Masstel_Tab7LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2M
+    brand: Masstel
     model: Tab 7 LTE
   os_family: Android
   browser_family: Chrome
@@ -1223,19 +1101,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; vi-vn; Masstel Tab 700i Build/KOT49H) AppleWebKit/537.16 (KHTML, like Gecko) Version/4.0 Safari/537.16 Chrome/33.0.0.0
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2M
+    brand: Masstel
     model: Tab 700i
   os_family: Android
   browser_family: Chrome
@@ -1243,19 +1119,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Masstel Tab 840 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2M
+    brand: Masstel
     model: Tab 840
   os_family: Android
   browser_family: Chrome
@@ -1263,19 +1137,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T7012Q Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2P
+    brand: Prixton
     model: T7012Q
   os_family: Android
   browser_family: Chrome
@@ -1283,19 +1155,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; Andromeda S707 Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 2S
+    brand: Starway
     model: Andromeda S707
   os_family: Android
   browser_family: Android Browser
@@ -1303,19 +1173,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-gb; Andromeda S8 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 2S
+    brand: Starway
     model: Andromeda S8
   os_family: Android
   browser_family: Android Browser
@@ -1323,19 +1191,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; Andromeda S840 Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 2S
+    brand: Starway
     model: Andromeda S840
   os_family: Android
   browser_family: Android Browser
@@ -1343,19 +1209,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; Andromeda S845 Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 2S
+    brand: Starway
     model: Andromeda S845
   os_family: Android
   browser_family: Android Browser
@@ -1363,19 +1227,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Andromeda S850) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 2S
+    brand: Starway
     model: Andromeda S850
   os_family: Android
   browser_family: Chrome
@@ -1383,19 +1245,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 9; U1006 Build/PPR1.180610.011)
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 3A
+    brand: AllDocube
     model: iPlay 10 Pro 10.1"
   os_family: Android
   browser_family: Android Browser
@@ -1403,19 +1263,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 10; zh-CN; iPlay_20 Build/QP1A.190711.020) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 Quark/4.2.0.137 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "10"
     platform: ""
   client:
     type: browser
     name: Quark
-    short_name: QU
     version: "4.2.0.137"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 3A
+    brand: AllDocube
     model: iPlay 20
   os_family: Android
   browser_family: Chrome
@@ -1423,19 +1281,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; T1001X Build/O00623; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/58.0.3029.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "58.0.3029.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3A
+    brand: AllDocube
     model: M5X
   os_family: Android
   browser_family: Chrome
@@ -1443,19 +1299,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; en-US; T1001XS Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.4.1214 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.4.1214"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 3A
+    brand: AllDocube
     model: M5XS
   os_family: Android
   browser_family: Unknown
@@ -1463,19 +1317,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 6.0; Contixo  B105) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36'
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: B105 3G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1483,19 +1335,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO B108) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: B108 4G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1503,19 +1353,17 @@
   user_agent: mozilla/5.0 (linux; android 6.0; contixo cx-1045 3g) applewebkit/537.36 (khtml, like gecko) chrome/83.0.4103.106 safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: CX-1045 3G
   os_family: Android
   browser_family: Chrome
@@ -1523,19 +1371,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO GX 1035 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/76.0.3809.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: GX-1035 4G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1543,19 +1389,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO KT107 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: KT107 3G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1563,19 +1407,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO KT107) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: KT107 3G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1583,19 +1425,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO KT715 3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: KT715 3G 7.0"
   os_family: Android
   browser_family: Chrome
@@ -1603,19 +1443,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; CONTIXO KT995) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3C
+    brand: Contixo
     model: KT995 3G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1623,19 +1461,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.1.1; uk-ua; Enot-E102 Build/JRO03H AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 3E
+    brand: Enot
     model: E102
   os_family: Android
   browser_family: Android Browser
@@ -1643,19 +1479,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; ENOT J101 Build/MID) AppleWebKit/534.30 (KHTML like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 3E
+    brand: Enot
     model: J101
   os_family: Android
   browser_family: Android Browser
@@ -1663,19 +1497,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; aosonM707TG Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: M707TG
   os_family: Android
   browser_family: Chrome
@@ -1683,19 +1515,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonR101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: R101 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1703,19 +1533,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonR102) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: R102 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1723,19 +1551,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonR103) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: R103 10.1"
   os_family: Android
   browser_family: Chrome
@@ -1743,19 +1569,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonS7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: S7 7.0"
   os_family: Android
   browser_family: Chrome
@@ -1763,19 +1587,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonS7_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: S7 Pro 7.0"
   os_family: Android
   browser_family: Chrome
@@ -1783,19 +1605,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; aosonS8Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3N
+    brand: Aoson
     model: S8 Pro 8.0"
   os_family: Android
   browser_family: Chrome
@@ -1803,19 +1623,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; Twist Tab Build/OC; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/83.0.4103.106 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "83.0.4103.106"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3P
+    brand: Positivo BGH
     model: Twist Tab
   os_family: Android
   browser_family: Chrome
@@ -1823,19 +1641,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.1; Positivo Ypy L1050E Build/JRO03H)
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 3P
+    brand: Positivo BGH
     model: Ypy L1050E
   os_family: Android
   browser_family: Android Browser
@@ -1843,13 +1659,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; AC0732C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1863,13 +1677,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ua; AC7803C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1883,13 +1695,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2; fr-fr; RC7802F Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1903,13 +1713,11 @@
   user_agent: Mozilla/5.0(Linux; U; Android 4.2.2; en-us; MT0812E Build/JDQ39) AppleWebKit/534.30 (KHTML, Like Gescko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1923,13 +1731,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; LC0808B Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -1943,13 +1749,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android; en-us; LC0809B Build/FRF91) AppleWebKit/533.1
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -1963,13 +1767,11 @@
   user_agent: Mozilla/5.0 (Linux; U;Android4.1.1;en-ru; LC0816C Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 4.1.1; fr-sa; Build/JRO03CSafari/534.30
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1983,13 +1785,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; En-us; LC0804B Build/MID.3Q.q.pad.20130125) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2003,13 +1803,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-us; MT0724B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2023,13 +1821,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; LC0725B Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2043,13 +1839,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; hr-us; LC0723B Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2063,13 +1857,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LC0725B Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
@@ -2083,13 +1875,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; MT0724B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "29.0.1547.72"
     engine: Blink
     engine_version: ""
@@ -2103,13 +1893,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; LC0810C Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
@@ -2123,13 +1911,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; LC0901D Build/20131211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2143,13 +1929,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-es; LC0901D Build/20131211) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2163,13 +1947,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; 3Q_ER71B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2183,13 +1965,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; id-id; EL72B Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2203,13 +1983,11 @@
   user_agent: Android 4.0.3;AppleWebKit/534.30;Build/IML74K;QS0716D Build/IML74K
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2223,13 +2001,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; Cs-cz; RC9711B Build/IML74K) AppleWebKit/534.30 (KHTML, Like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2243,13 +2019,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-au; VM1017A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2263,13 +2037,11 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.0.3; en-au; VM1017A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile '
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2283,13 +2055,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; BC9710AM Build/IMM76D) AppleWebKit/531.21.10 (KHTML, like Gecko) Version/4.0.4 Mobile/7B367 Safari/531.21.10
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "531.21.10"
@@ -2303,13 +2073,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-; TS0807B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2323,13 +2091,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; RC0710B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2343,13 +2109,11 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.3; BC9710AM Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
@@ -2363,13 +2127,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; RC0710B Build/IML74K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166 Safari/535.19
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
@@ -2383,13 +2145,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-US; QS0716D Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 UCBrowser/10.2.0.535 U3/0.8.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "10.2.0.535"
     engine: WebKit
     engine_version: "534.30"
@@ -2403,13 +2163,11 @@
   user_agent: UCWEB/2.0 (MIDP-2.0; U; Adr 4.0.3; en-US; RC0726B) U2/1.0.0 UCBrowser/9.6.0.514 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.514"
     engine: ""
     engine_version: ""
@@ -2423,13 +2181,11 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.0.4; QS0815C Build/IMM76I)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -2443,13 +2199,11 @@
   user_agent: Mozilla/5.0 (Linux; u; Android 4.0.4; cs-cz; RC9717b build/imm76d) Applewebkit/534.30 (khtml, like gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2463,13 +2217,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-rh; RC0709B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2483,13 +2235,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; QS0715C Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2503,13 +2253,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; RC9724C Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2523,13 +2271,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; QS0717D Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 (Mobile; afma-sdk-a-v5084000.4452000.1)
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2543,13 +2289,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; RC9716B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2563,13 +2307,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; sl-si; LC0720C Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2583,13 +2325,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; QS0730C Build/IMM76D) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/53
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
@@ -2603,13 +2343,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TS1013B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.82 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.82"
     engine: Blink
     engine_version: ""
@@ -2623,13 +2361,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; QS9715F Build/0.0.2271.0225) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.59"
     engine: Blink
     engine_version: ""
@@ -2643,13 +2379,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; QS0728C Build/IMM76I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
@@ -2663,13 +2397,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us ; RC0721B Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.5.2.240/145/355
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.5.2.240"
     engine: WebKit
     engine_version: "533.1"
@@ -2683,13 +2415,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; RC9717B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.131 YaBrowser/14.5.1847.18432.00 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.5.1847.18432.00"
     engine: Blink
     engine_version: ""
@@ -2703,13 +2433,11 @@
   user_agent: Android 4.1.1;AppleWebKit/534.31;Build/JRO03H;RC9730C Build/JRO03H
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.31"
@@ -2723,13 +2451,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ar-eg; RC0817C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2743,13 +2469,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; de-us; RC9730C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2763,13 +2487,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-us; RC9712C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2783,13 +2505,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; AC0731B Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2803,13 +2523,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; LC1016C Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2823,13 +2541,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; RC1018C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2843,13 +2559,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; RC0813C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2863,13 +2577,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ua; RC9726C Build/3Q) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2883,13 +2595,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ua; RC9731C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2903,13 +2613,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-us; RC0718C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2923,13 +2631,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-us; RC1301C Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2943,13 +2649,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MT0729B Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
@@ -2963,13 +2667,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; RC0722C Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.40 Safari/537.31 OPR/14.0.1074.54070
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "14.0.1074.54070"
     engine: Presto
     engine_version: ""
@@ -2983,13 +2685,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-CN; RC9731C Build/JRO03H) AppleWebKit/534.31 (KHTML, like Gecko) UCBrowser/9.3.1.344 U3/0.8.0 Mobile Safari/534.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.3.1.344"
     engine: WebKit
     engine_version: "534.31"
@@ -3003,13 +2703,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; QS1023H Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.138 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.138"
     engine: Blink
     engine_version: ""
@@ -3023,13 +2721,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.2; MT0811B Build/JZO54K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.124 YaBrowser/14.10.2062.12160.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "14.10.2062.12160.01"
     engine: Blink
     engine_version: ""
@@ -3043,13 +2739,11 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; AC1024C Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
@@ -3063,13 +2757,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; cs-cz; RC1025F Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3083,13 +2775,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; RC0719H Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3103,13 +2793,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; RC0734H Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3123,13 +2811,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; el-gr; RC1019G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3143,13 +2829,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; tr-tr; RC9727F Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3163,13 +2847,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-us; MT0729D Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) FlyFlow/1.4 Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Baidu Browser
-    short_name: BD
     version: "1.4"
     engine: WebKit
     engine_version: "534.30"
@@ -3183,13 +2865,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; RC0743H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
@@ -3203,13 +2883,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MT0739D Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.138 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "35.0.1916.138"
     engine: Blink
     engine_version: ""
@@ -3223,13 +2901,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; RC0719H Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.114 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "38.0.2125.114"
     engine: Blink
     engine_version: ""
@@ -3243,13 +2919,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; fr-ma; RC0734H Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3263,13 +2937,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; OC1020A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3283,13 +2955,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; VM0711A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3303,13 +2973,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; de-at; QS9719D Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3323,13 +2991,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; vi-vn; QS9718C Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3343,13 +3009,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-us; MT7801C Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3363,13 +3027,11 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; MT7801C Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
@@ -3383,13 +3045,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; TS9708B Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3403,19 +3063,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; PNT-7040 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3S
+    brand: Shuttle
     model: PNT-7040
   os_family: Android
   browser_family: Chrome
@@ -3423,19 +3081,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PNT-7042) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3S
+    brand: Shuttle
     model: PNT-7042
   os_family: Android
   browser_family: Chrome
@@ -3443,19 +3099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; PNT-7045 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/43.0.2357.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "43.0.2357.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 3S
+    brand: Shuttle
     model: PNT-7045
   os_family: Android
   browser_family: Chrome
@@ -3463,19 +3117,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; MyTAB 8 MINI Dual Core Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 3T
+    brand: MyTab
     model: 8 Mini Dual Core
   os_family: Android
   browser_family: Android Browser
@@ -3483,19 +3135,17 @@
   user_agent: Mozilla / 5.0 (Linux; Android 4.2.2; Mytab-U55GT Build / JDQ39) AppleWebKit / 537.36 (KHTML, как Gecko) Chrome / 71.0.3578.99 Safari / 537.36 OPR / 50.3.2426.136976
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 3T
+    brand: MyTab
     model: U55GT
   os_family: Android
   browser_family: Chrome
@@ -3503,19 +3153,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; People GT300) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4G
+    brand: 4Good
     model: People GT300
   os_family: Android
   browser_family: Chrome
@@ -3523,19 +3171,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; T700i_3G Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/48.0.2564.95 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "48.0.2564.95"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4G
+    brand: 4Good
     model: T700i 3G
   os_family: Android
   browser_family: Chrome
@@ -3543,19 +3189,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TAB A4010) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4N
+    brand: NextTab
     model: A4010
   os_family: Android
   browser_family: Chrome
@@ -3563,19 +3207,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TAB A4030) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4N
+    brand: NextTab
     model: A4030
   os_family: Android
   browser_family: Chrome
@@ -3583,19 +3225,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; PTB7R Build/PPR1.180610.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/84.0.4147.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "84.0.4147.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4P
+    brand: Philco
     model: PTB7R
   os_family: Android
   browser_family: Chrome
@@ -3603,19 +3243,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SYX-T101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4S
+    brand: Syrox
     model: SYX-T101
   os_family: Android
   browser_family: Chrome
@@ -3623,19 +3261,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; SYX-T102) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4S
+    brand: Syrox
     model: SYX-T102
   os_family: Android
   browser_family: Chrome
@@ -3643,19 +3279,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; SYX-T700) Build/KVT49L AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4S
+    brand: Syrox
     model: SYX-T700
   os_family: Android
   browser_family: Chrome
@@ -3663,19 +3297,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; SYX-T704) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 4S
+    brand: Syrox
     model: SYX-T704
   os_family: Android
   browser_family: Chrome
@@ -3683,19 +3315,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Turbokids3G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 5T
+    brand: TurboKids
     model: 3G
   os_family: Android
   browser_family: Chrome
@@ -3703,19 +3333,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; TurboKids S4 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 5T
+    brand: TurboKids
     model: S4
   os_family: Android
   browser_family: Chrome
@@ -3723,19 +3351,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; Turbokids-TMNT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 5T
+    brand: TurboKids
     model: TMNT
   os_family: Android
   browser_family: Chrome
@@ -3743,19 +3369,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; MID-123G Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-123G
   os_family: Android
   browser_family: Chrome
@@ -3763,19 +3387,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; MID-703G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 OPR/38.1.2254.136033
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "38.1.2254.136033"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-703G
   os_family: Android
   browser_family: Opera
@@ -3783,19 +3405,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; MID-713G Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-713G
   os_family: Android
   browser_family: Android Browser
@@ -3803,19 +3423,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; MID-721 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-721
   os_family: Android
   browser_family: Android Browser
@@ -3823,19 +3441,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; MID-722 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-722
   os_family: Android
   browser_family: Android Browser
@@ -3843,19 +3459,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; ru-ru; MYSTERY MID-733G Build/MID) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-733G
   os_family: Android
   browser_family: Android Browser
@@ -3863,19 +3477,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; ru-ru; MID-743G Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-743G
   os_family: Android
   browser_family: Android Browser
@@ -3883,19 +3495,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; MID-753G Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 YaBrowser/19.1.0.130 (lite)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Yandex Browser Lite
-    short_name: YL
     version: "19.1.0.130"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-753G
   os_family: Android
   browser_family: Unknown
@@ -3903,19 +3513,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; MID-783G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.12.8.1206 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.12.8.1206"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-783G
   os_family: Android
   browser_family: Unknown
@@ -3923,19 +3531,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-US; MID-833G Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: 6M
+    brand: Mystery
     model: MID-833G
   os_family: Android
   browser_family: Unknown
@@ -3943,19 +3549,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ANRY-RS10 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.1.2569.142848
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.1.2569.142848"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7A
+    brand: Anry
     model: RS10
   os_family: Android
   browser_family: Opera
@@ -3963,19 +3567,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; ANRY-S20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7A
+    brand: Anry
     model: S20
   os_family: Android
   browser_family: Chrome
@@ -3983,19 +3585,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; ANRY-X20) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7A
+    brand: Anry
     model: X20
   os_family: Android
   browser_family: Chrome
@@ -4003,19 +3603,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TOREX-PS12) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 7T
+    brand: Torex
     model: PS12
   os_family: Android
   browser_family: Chrome
@@ -4023,19 +3621,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO T10 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: T10
   os_family: Android
   browser_family: Android Browser
@@ -4043,19 +3639,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; MITO t300 Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: t300
   os_family: Android
   browser_family: Android Browser
@@ -4063,19 +3657,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; MITO T330 Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: T330
   os_family: Android
   browser_family: Android Browser
@@ -4083,19 +3675,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; MITO T35 Build/LMY48G)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: T35
   os_family: Android
   browser_family: Android Browser
@@ -4103,19 +3693,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.1.2; MITO t510 Build/JZO54K)
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: t510
   os_family: Android
   browser_family: Android Browser
@@ -4123,19 +3711,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MITO T888 Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 8M
+    brand: Mito
     model: T888
   os_family: Android
   browser_family: Android Browser
@@ -4143,19 +3729,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TC1050G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 8T
+    brand: Time2
     model: TC1050G 10.1"
   os_family: Android
   browser_family: Chrome
@@ -4163,19 +3747,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 5.1.1; MT7-442D Build/LMY47V)
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: 9M
+    brand: Mobo
     model: MT7-442D
   os_family: Android
   browser_family: Android Browser
@@ -4183,19 +3765,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; CASEBOOK_3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: 9T
+    brand: Tetratab
     model: Casebook 3
   os_family: Android
   browser_family: Chrome
@@ -4203,19 +3783,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; Allview2SpeedDuo Build/SV1.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Alldro 2 Speed Duo
   os_family: Android
   browser_family: Chrome
@@ -4223,19 +3801,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; Allview3SpeedQuad Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Alldro 3 Speed Quad
   os_family: Android
   browser_family: Chrome
@@ -4243,19 +3819,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; AX2_Frenzy Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: AX2 Frenzy
   os_family: Android
   browser_family: Android Browser
@@ -4263,19 +3837,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; AllviewAX2Frenzy Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: AX2 Frenzy
   os_family: Android
   browser_family: Chrome
@@ -4283,19 +3855,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AX5NanoQ Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: AX5 Nano Q
   os_family: Android
   browser_family: Chrome
@@ -4303,19 +3873,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; AllviewCity Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: City
   os_family: Android
   browser_family: Chrome
@@ -4323,19 +3891,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; AllviewCityPlus Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: City Plus
   os_family: Android
   browser_family: Chrome
@@ -4343,19 +3909,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ALLVIEWSPEED Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Speed
   os_family: Android
   browser_family: Android Browser
@@ -4363,19 +3927,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us ; ALLVIEW SPEEDI Build/IMM76D) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1/UCBrowser/8.5.3.246/145/355
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.5.3.246"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Speed I
   os_family: Android
   browser_family: Unknown
@@ -4383,19 +3945,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; Viva_1001G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Viva 1001G
   os_family: Android
   browser_family: Chrome
@@ -4403,19 +3963,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Viva_1003G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Viva 1003G
   os_family: Android
   browser_family: Chrome
@@ -4423,19 +3981,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Viva_H1001_LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Viva H1001 LTE
   os_family: Android
   browser_family: Chrome
@@ -4443,19 +3999,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Viva_H801 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A2
+    brand: Allview
     model: Viva H801
   os_family: Android
   browser_family: Chrome
@@ -4463,19 +4017,17 @@
   user_agent: Mozilla/5.0 (Linux;Android 5.0;ASK 791SP 3G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A4
+    brand: Ask
     model: 791SP 3G
   os_family: Android
   browser_family: Chrome
@@ -4483,19 +4035,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; QUAD-CORE A64 p3 Build/NMF26X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A7
+    brand: Allwinner
     model: A64 QUAD-CORE p3
   os_family: Android
   browser_family: Chrome
@@ -4503,19 +4053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZY-07B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A7
+    brand: Allwinner
     model: ZY-07B
   os_family: Android
   browser_family: Chrome
@@ -4523,19 +4071,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; AP-106 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-106 Force
   os_family: Android
   browser_family: Android Browser
@@ -4543,19 +4089,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; en-US; AP-107G Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.5.1209 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.5.1209"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-107G
   os_family: Android
   browser_family: Unknown
@@ -4563,19 +4107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; AP-109) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.3.2672.50220
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.3.2672.50220"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-109
   os_family: Android
   browser_family: Opera
@@ -4583,19 +4125,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AP-110N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-110N
   os_family: Android
   browser_family: Chrome
@@ -4603,19 +4143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; AP-115G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-115G
   os_family: Android
   browser_family: Chrome
@@ -4623,19 +4161,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.2.2; AP-719 Build/JDQ39)
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-719
   os_family: Android
   browser_family: Android Browser
@@ -4643,19 +4179,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4; AP-721N Build/A86V_SY) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-721N Force
   os_family: Android
   browser_family: Chrome
@@ -4663,19 +4197,17 @@
   user_agent: Dalvik/1.6.0 Linux; U; Android 4.2.2; AP-727G Build/JDQ39
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-727G
   os_family: Android
   browser_family: Android Browser
@@ -4683,19 +4215,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; AP-753G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Safari/537.36 OPR/54.2.2672.49907
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "54.2.2672.49907"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-753G
   os_family: Android
   browser_family: Opera
@@ -4703,19 +4233,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AP-757G Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "54.0.2840.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-757G
   os_family: Android
   browser_family: Chrome
@@ -4723,19 +4251,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ru-ru; AP-941 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: AP-941
   os_family: Android
   browser_family: Android Browser
@@ -4743,19 +4269,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.0.0; en-US; AP-108 Build/O00623) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: A8
+    brand: Assistant
     model: Cetus
   os_family: Android
   browser_family: Unknown
@@ -4763,19 +4287,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; ARIAN Space 70 ST7001RW AppleWebKit/537.36 KHTML, like Gecko Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AB
+    brand: Arian Space
     model: "70"
   os_family: Android
   browser_family: Chrome
@@ -4783,19 +4305,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ARIAN Space 71 ST7002PG Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2749.0 Safari/537.36 YandexSearch/7.45/apad YandexSearchBrowser/7.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2749.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AB
+    brand: Arian Space
     model: "71"
   os_family: Android
   browser_family: Chrome
@@ -4803,19 +4323,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.0; ARIAN Space 80 SS8003PG AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.112 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.112"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AB
+    brand: Arian Space
     model: "80"
   os_family: Android
   browser_family: Chrome
@@ -4823,19 +4341,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ARIAN Space 100 ST1004PG Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/53.0.2749.0 Safari/537.36 YandexSearch/7.45/apad YandexSearchBrowser/7.45
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "53.0.2749.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AB
+    brand: Arian Space
     model: "100"
   os_family: Android
   browser_family: Chrome
@@ -4843,19 +4359,17 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 10.0; Windows NT 6.2; WOW64; Trident/6.0; Touch; MAARJS)
   os:
     name: Windows
-    short_name: WIN
     version: "8"
     platform: x64
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "10.0"
     engine: Trident
     engine_version: "6.0"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: ""
   os_family: Windows
   browser_family: Internet Explorer
@@ -4863,19 +4377,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; A1-810 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia A
   os_family: Android
   browser_family: Chrome
@@ -4883,19 +4395,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; A1-811 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia A
   os_family: Android
   browser_family: Chrome
@@ -4903,19 +4413,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; A1-830 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia A1
   os_family: Android
   browser_family: Chrome
@@ -4923,19 +4431,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; A3-A10 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia A3
   os_family: Android
   browser_family: Android Browser
@@ -4943,19 +4449,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; A3-A11 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia A3
   os_family: Android
   browser_family: Chrome
@@ -4963,19 +4467,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-US; B1-710 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia B1
   os_family: Android
   browser_family: Android Browser
@@ -4983,19 +4485,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.2; B1-A71 Build/JZO54K) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia B1
   os_family: Android
   browser_family: Chrome
@@ -5003,19 +4503,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-US; b1-720 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.2 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia B1
   os_family: Android
   browser_family: Android Browser
@@ -5023,19 +4521,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-US; B1-711 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.1 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia B1
   os_family: Android
   browser_family: Android Browser
@@ -5043,19 +4539,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; b1-721 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia B1
   os_family: Android
   browser_family: Chrome
@@ -5063,19 +4557,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; B3-A20 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5083,19 +4575,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; B3-A10 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5103,19 +4593,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B3-A32 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5123,19 +4611,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B3-A30 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5143,19 +4629,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B3-A40FHD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5163,19 +4647,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B3-A40) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5183,19 +4665,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B3-A42) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5203,19 +4683,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; B3-A50) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 10
   os_family: Android
   browser_family: Chrome
@@ -5223,19 +4701,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; B1-730HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.102 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.102"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5243,19 +4719,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; B1-750 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5263,19 +4737,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; B1-770 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5283,19 +4755,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; B1-760HD Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5303,19 +4773,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B1-780 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5323,19 +4791,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B1-7A0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 7
   os_family: Android
   browser_family: Chrome
@@ -5343,19 +4809,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; B1-820 Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 8
   os_family: Android
   browser_family: Chrome
@@ -5363,19 +4827,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; B1-850 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 8
   os_family: Android
   browser_family: Chrome
@@ -5383,19 +4845,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; B1-830 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 8
   os_family: Android
   browser_family: Chrome
@@ -5403,19 +4863,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B1-870 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 8
   os_family: Android
   browser_family: Chrome
@@ -5423,19 +4881,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; B1-860A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia One 8
   os_family: Android
   browser_family: Chrome
@@ -5443,19 +4899,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; A3-A30 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 10
   os_family: Android
   browser_family: Chrome
@@ -5463,19 +4917,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; A3-A40 Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 10
   os_family: Android
   browser_family: Chrome
@@ -5483,19 +4935,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; A1-713 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 7
   os_family: Android
   browser_family: Chrome
@@ -5503,19 +4953,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; A1-713HD AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 7
   os_family: Android
   browser_family: Chrome
@@ -5523,19 +4971,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; A1-841 AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.75 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.75"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 8
   os_family: Android
   browser_family: Chrome
@@ -5543,19 +4989,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; A1-840FHD AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab 8
   os_family: Android
   browser_family: Chrome
@@ -5563,19 +5007,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; A210 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A210
   os_family: Android
   browser_family: Android Browser
@@ -5583,19 +5025,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; A210 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A210
   os_family: Android
   browser_family: Chrome
@@ -5603,19 +5043,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; zh-tw; A510 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A510
   os_family: Android
   browser_family: Android Browser
@@ -5623,19 +5061,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; de-de; A511 Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A511
   os_family: Android
   browser_family: Android Browser
@@ -5643,19 +5079,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-ca; A700 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A700
   os_family: Android
   browser_family: Android Browser
@@ -5663,19 +5097,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; A701 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Tab A701
   os_family: Android
   browser_family: Android Browser
@@ -5683,19 +5115,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; B1-723 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Talk 7
   os_family: Android
   browser_family: Chrome
@@ -5703,19 +5133,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; B1-733 Build/LMY47I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/59.0.3071.125 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Iconia Talk 7
   os_family: Android
   browser_family: Chrome
@@ -5723,19 +5151,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.0.1; zh-tw; A501 Build/HRI66) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.0.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Android Browser
@@ -5743,19 +5169,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-gb; A501 Build/HTJ85B) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Android Browser
@@ -5763,19 +5187,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; ru-ru; A500 Build/HTK55D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Android Browser
@@ -5783,19 +5205,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; A500 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Android Browser
@@ -5803,19 +5223,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-tw; A501 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Android Browser
@@ -5823,19 +5241,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; A500 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso
   os_family: Android
   browser_family: Chrome
@@ -5843,19 +5259,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; A200 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Picasso E
   os_family: Android
   browser_family: Android Browser
@@ -5863,19 +5277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; th-th; A101 Build/HTK55D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AC
+    brand: Acer
     model: Vangogh
   os_family: Android
   browser_family: Android Browser
@@ -5883,19 +5295,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-la; IntroTr3544) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.4.0.347 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.4.0.347"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AD
+    brand: Advance
     model: Intro
   os_family: Android
   browser_family: Unknown
@@ -5903,19 +5313,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Tr3845 Build/LMY47O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Safari/537.36Mozilla/5.0 (Linux; Android 5.1; Tr3845 Build/LMY47O; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AD
+    brand: Advance
     model: Intro
   os_family: Android
   browser_family: Chrome
@@ -5923,19 +5331,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Excer_10_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.110 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AH
+    brand: AVH
     model: Excer 10 Pro
   os_family: Android
   browser_family: Chrome
@@ -5943,19 +5349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Excer G5 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36 Mobile UCBrowser/3.4.3.532
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "3.4.3.532"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: AH
+    brand: AVH
     model: Excer G5
   os_family: Android
   browser_family: Unknown
@@ -5963,19 +5367,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; Excer G5.3 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AH
+    brand: AVH
     model: Excer G5.3
   os_family: Android
   browser_family: Chrome
@@ -5983,19 +5385,17 @@
   user_agent: Mozilla/5.0 Linux; U; Android 4.2.2; ru-ru; AKTB-703MZ Build/JDQ39 AppleWebKit/534.30 KHTML, like Gecko Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AK
+    brand: Akai
     model: AKTB-703MZ
   os_family: Android
   browser_family: Android Browser
@@ -6003,19 +5403,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; TAB-7800 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Safari/537.36 OPR/24.0.1565.82529
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "24.0.1565.82529"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AK
+    brand: Akai
     model: TAB 7800
   os_family: Android
   browser_family: Opera
@@ -6023,19 +5421,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; TAB-7830 Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AK
+    brand: Akai
     model: TAB 7830
   os_family: Android
   browser_family: Chrome
@@ -6043,19 +5439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.4; TAB-9800 Build/IMM76D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AK
+    brand: Akai
     model: TAB 9800
   os_family: Android
   browser_family: Chrome
@@ -6063,19 +5457,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; TAB-9800Q Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AK
+    brand: Akai
     model: TAB 9800Q
   os_family: Android
   browser_family: Chrome
@@ -6083,19 +5475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 9027F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: 3T 8.0"
   os_family: Android
   browser_family: Chrome
@@ -6103,19 +5493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 9027W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.116"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: 3T 8.0"
   os_family: Android
   browser_family: Chrome
@@ -6123,19 +5511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 9027X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: 3T 8.0"
   os_family: Android
   browser_family: Chrome
@@ -6143,19 +5529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; 9027T) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.149 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.149"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: 3T 8.0"
   os_family: Android
   browser_family: Chrome
@@ -6163,19 +5547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 9026X) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: A3 10"
   os_family: Android
   browser_family: Chrome
@@ -6183,19 +5565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 9203A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: A3 7" 3G
   os_family: Android
   browser_family: Chrome
@@ -6203,19 +5583,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; onetouch EVO7 Build/MAIN_01) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch EVO7
   os_family: Android
   browser_family: Android Browser
@@ -6223,19 +5601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ONE TOUCH EVO7HD Build/JRO03H) AppleWebKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.58 Safari/537.31
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.58"
     engine: WebKit
     engine_version: "537.31"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch EVO7HD
   os_family: Android
   browser_family: Chrome
@@ -6243,19 +5619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ONE TOUCH EVO8HD Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch EVO8HD
   os_family: Android
   browser_family: Chrome
@@ -6263,19 +5637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; de-de; 9010X Build/LMY47I; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/59.0.3071.125 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "59.0.3071.125"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 10"
   os_family: Android
   browser_family: Chrome
@@ -6283,19 +5655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 9007A Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 7"
   os_family: Android
   browser_family: Chrome
@@ -6303,19 +5673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 9007X Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.76 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "46.0.2490.76"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 7" 4G
   os_family: Android
   browser_family: Chrome
@@ -6323,19 +5691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; 9007T Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 3 7" 4G
   os_family: Android
   browser_family: Chrome
@@ -6343,19 +5709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 9003X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 7" 3G
   os_family: Android
   browser_family: Chrome
@@ -6363,19 +5727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 9003A Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 7" 3G
   os_family: Android
   browser_family: Chrome
@@ -6383,19 +5745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 8063 Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 4 7" WiFi
   os_family: Android
   browser_family: Chrome
@@ -6403,19 +5763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 9024O Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 5
   os_family: Android
   browser_family: Chrome
@@ -6423,19 +5781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; I213 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 7
   os_family: Android
   browser_family: Chrome
@@ -6443,19 +5799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ar-eg; I216X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Mobile Safari/537.36 SVN/01001
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 7
   os_family: Android
   browser_family: Chrome
@@ -6463,19 +5817,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; 9005X Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch Pixi 8
   os_family: Android
   browser_family: Chrome
@@ -6483,19 +5835,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH P310X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch POP 7
   os_family: Android
   browser_family: Chrome
@@ -6503,19 +5853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ALCATEL ONE TOUCH P320X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch POP 8
   os_family: Android
   browser_family: Chrome
@@ -6523,19 +5871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; one touch T10 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch T10
   os_family: Android
   browser_family: Android Browser
@@ -6543,19 +5889,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; one touch T20 Build/MAIN) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch T20
   os_family: Android
   browser_family: Android Browser
@@ -6563,19 +5907,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.1.1; ONE TOUCH TAB 7 Build/GSDT011) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch TAB 7
   os_family: Android
   browser_family: Chrome
@@ -6583,19 +5925,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ONE TOUCH TAB 7HD Build/SDT016) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AL
+    brand: Alcatel
     model: One Touch TAB 7HD
   os_family: Android
   browser_family: Android Browser
@@ -6603,19 +5943,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.2.1; fr-fr; A101B Build/MASTER) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: "10"
   os_family: Android
   browser_family: Android Browser
@@ -6623,19 +5961,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.1.20; fr-fr; A101C Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "1.1.20"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10 G2
   os_family: Android
   browser_family: Android Browser
@@ -6643,19 +5979,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.1.5; fr-fr; A101B2-LZ Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "1.1.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10 G2
   os_family: Android
   browser_family: Android Browser
@@ -6663,19 +5997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; AN10G2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10 G2
   os_family: Android
   browser_family: Android Browser
@@ -6683,19 +6015,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; AN10G2-LZ Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10 G2
   os_family: Android
   browser_family: Android Browser
@@ -6703,19 +6033,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARNOVA 101 G4 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 101 G4
   os_family: Android
   browser_family: Chrome
@@ -6723,19 +6051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; AN10BG2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10b G2
   os_family: Android
   browser_family: Android Browser
@@ -6743,19 +6069,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; AN10BG2DT Build/GINGERBREAD) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10b G2
   os_family: Android
   browser_family: Android Browser
@@ -6763,19 +6087,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN10BG2I Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10b G2
   os_family: Android
   browser_family: Android Browser
@@ -6783,19 +6105,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-gb; AN10BG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10b G3
   os_family: Android
   browser_family: Android Browser
@@ -6803,19 +6123,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN10BG3-LZ Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10b G3
   os_family: Android
   browser_family: Android Browser
@@ -6823,19 +6141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; AN10CG3 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10c G3
   os_family: Android
   browser_family: Chrome
@@ -6843,19 +6159,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN10DG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 10d G3
   os_family: Android
   browser_family: Android Browser
@@ -6863,19 +6177,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; en-gb; AN7G2DTE Build/GINGERBREAD) AppleWebKit/533.1 (KHTML like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7 G2
   os_family: Android
   browser_family: Android Browser
@@ -6883,19 +6195,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-be; AN7G2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7 G2
   os_family: Android
   browser_family: Android Browser
@@ -6903,19 +6213,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; af-za; AN7G2I Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7 G2
   os_family: Android
   browser_family: Android Browser
@@ -6923,19 +6231,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; AN7G3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7 G3
   os_family: Android
   browser_family: Android Browser
@@ -6943,19 +6249,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN7BG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7b G3
   os_family: Android
   browser_family: Android Browser
@@ -6963,19 +6267,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.3; fr-fr; AN7CG2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7c G2
   os_family: Android
   browser_family: Android Browser
@@ -6983,19 +6285,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN7CG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7c G3
   os_family: Android
   browser_family: Android Browser
@@ -7003,19 +6303,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; AN7DG3B Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7d G3
   os_family: Android
   browser_family: Android Browser
@@ -7023,19 +6321,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN7DG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7d G3
   os_family: Android
   browser_family: Android Browser
@@ -7043,19 +6339,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN7FG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7f G3
   os_family: Android
   browser_family: Android Browser
@@ -7063,19 +6357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; AN7HG3 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 7h G3
   os_family: Android
   browser_family: Chrome
@@ -7083,19 +6375,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.0.3; fr-fr; A80KSC Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "1.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: "8"
   os_family: Android
   browser_family: Android Browser
@@ -7103,19 +6393,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN8G2I Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 8 G2
   os_family: Android
   browser_family: Android Browser
@@ -7123,19 +6411,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN8G3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 8 G3
   os_family: Android
   browser_family: Android Browser
@@ -7143,19 +6429,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN8BG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 8b G3
   os_family: Android
   browser_family: Android Browser
@@ -7163,19 +6447,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN8BG3-LZ Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 8b G3
   os_family: Android
   browser_family: Android Browser
@@ -7183,19 +6465,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN8CG3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 8c G3
   os_family: Android
   browser_family: Android Browser
@@ -7203,19 +6483,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.1; fr-fr; AN9G2 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 9 G2
   os_family: Android
   browser_family: Android Browser
@@ -7223,19 +6501,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; de-de; AN9G3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 9 G3
   os_family: Android
   browser_family: Android Browser
@@ -7243,19 +6519,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; ARNOVA 90G3 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 90 G3
   os_family: Android
   browser_family: Android Browser
@@ -7263,19 +6537,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; it-ch; ARNOVA 90 G4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 90 G4
   os_family: Android
   browser_family: Android Browser
@@ -7283,19 +6555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARNOVA 97G4 Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 97 G4
   os_family: Android
   browser_family: Chrome
@@ -7303,19 +6573,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; AN9G2I Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: 9i G2
   os_family: Android
   browser_family: Android Browser
@@ -7323,19 +6591,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ar-eg; AN7DG3-CP Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: Childpad
   os_family: Android
   browser_family: Android Browser
@@ -7343,19 +6609,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.0.0; fr-fr; ARCHM901 Build/ECLAIR) AppleWebKit/530.17 (KHTML, like Gecko) Version/4.0 Mobile Safari/530.17
   os:
     name: Android
-    short_name: AND
     version: "1.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "530.17"
   device:
     type: tablet
-    brand: AN
+    brand: Arnova
     model: M901
   os_family: Android
   browser_family: Android Browser
@@ -7363,19 +6627,17 @@
   user_agent: Mozilla/5.0 (iPad; U; CPU OS 4_3_2 like Mac OS X; en-us) AppleWebKit/533.17.9 (KHTML, like Gecko) Mobile/8H8
   os:
     name: iOS
-    short_name: IOS
     version: "4.3.2"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: "533.17.9"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Safari
@@ -7383,19 +6645,17 @@
   user_agent: Mozilla/5.0 (iPad; U; CPU iPhone OS 5_1_1 like Mac OS X; en-us)
   os:
     name: iOS
-    short_name: IOS
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Safari
@@ -7403,19 +6663,17 @@
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/31.0.1650.18 Mobile/10A523 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile iOS
-    short_name: CI
     version: "31.0.1650.18"
     engine: WebKit
     engine_version: "536.26"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Chrome
@@ -7423,19 +6681,17 @@
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mercury/8.0.1 Mobile/10A523 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Mercury
-    short_name: ME
     version: "8.0.1"
     engine: WebKit
     engine_version: "536.26"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Unknown
@@ -7443,19 +6699,17 @@
   user_agent: Mozilla/5.0 (iPad; CPU OS 6_0_1 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Mercury/8.1 Mobile/10A523 Safari/8536.25
   os:
     name: iOS
-    short_name: IOS
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Mercury
-    short_name: ME
     version: "8.1"
     engine: WebKit
     engine_version: "536.26"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Unknown
@@ -7463,19 +6717,17 @@
   user_agent: Mozilla/5.0 (iPad; CPU OS 7_0 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) CriOS/32.0.1700.20 Mobile/11A465 Safari/9537.53
   os:
     name: iOS
-    short_name: IOS
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile iOS
-    short_name: CI
     version: "32.0.1700.20"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Chrome
@@ -7483,19 +6735,17 @@
   user_agent: Mozilla/5.0 (iPad; CPU OS 7_0_4 like Mac OS X) AppleWebKit/537.51.1 (KHTML, like Gecko) Version/7.0 Mobile/11B554a Safari/9537.53
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: "7.0"
     engine: WebKit
     engine_version: "537.51.1"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad
   os_family: iOS
   browser_family: Safari
@@ -7503,7 +6753,6 @@
   user_agent: Mozilla/5.0 (iPad2,1; iPad; U; CPU OS 7_0_4 like Mac OS X; pl_PL) com.google.GooglePlus/29676 (KHTML, like Gecko) Mobile/K93AP (gzip)
   os:
     name: iOS
-    short_name: IOS
     version: "7.0.4"
     platform: ""
   client:
@@ -7512,7 +6761,7 @@
     version: ""
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad 2
   os_family: iOS
   browser_family: Unknown
@@ -7520,7 +6769,6 @@
   user_agent: iTunes-iPad/5.1.1 (4; 32GB; dt:77)
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
@@ -7529,7 +6777,7 @@
     version: "5.1.1"
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad 4
   os_family: iOS
   browser_family: Unknown
@@ -7537,19 +6785,17 @@
   user_agent: com.google.GoogleMobile/37.1.0 iPad/11.0.3 hw/iPad4_2
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Mobile Safari
-    short_name: MF
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad Air
   os_family: iOS
   browser_family: Safari
@@ -7557,13 +6803,12 @@
   user_agent: Apple-iPad2C7/1002.329
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client: null
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad Mini
   os_family: iOS
   browser_family: Unknown
@@ -7571,13 +6816,12 @@
   user_agent: Apple-iPad4C7/1201.365
   os:
     name: iOS
-    short_name: IOS
     version: ""
     platform: ""
   client: null
   device:
     type: tablet
-    brand: AP
+    brand: Apple
     model: iPad Mini 3
   os_family: iOS
   browser_family: Unknown
@@ -7585,19 +6829,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-be; Archos 101 Cobalt Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 Cobalt
   os_family: Android
   browser_family: Android Browser
@@ -7605,19 +6847,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Archos 101 Neon Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 Neon
   os_family: Android
   browser_family: Android Browser
@@ -7625,19 +6865,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 101 PLATINUM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 PLATINUM
   os_family: Android
   browser_family: Chrome
@@ -7645,19 +6883,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 101 Titanium Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 Titanium
   os_family: Android
   browser_family: Android Browser
@@ -7665,19 +6901,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Archos 101 Xenon Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 Xenon
   os_family: Android
   browser_family: Chrome
@@ -7685,19 +6919,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 101 XS 2 Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101 XS 2
   os_family: Android
   browser_family: Chrome
@@ -7705,19 +6937,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; AC101BHE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101B Helium 4G
   os_family: Android
   browser_family: Chrome
@@ -7725,19 +6955,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS 101G10 Build/JRO03L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "32.0.1700.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101G10
   os_family: Android
   browser_family: Chrome
@@ -7745,19 +6973,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; fr-fr; ARCHOS 101G9 Build/HTK75D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 101G9
   os_family: Android
   browser_family: Android Browser
@@ -7765,19 +6991,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 1.6; fr-fr; Archos5 Build/Donut) AppleWebKit/528.5+ (KHTML, like Gecko) Version/3.1.2 Mobile Safari/525.20.1
   os:
     name: Android
-    short_name: AND
     version: "1.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "528.5"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: "5"
   os_family: Android
   browser_family: Android Browser
@@ -7785,19 +7009,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; ARCHOS 70 Cobalt Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 70 Cobalt
   os_family: Android
   browser_family: Android Browser
@@ -7805,19 +7027,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 70 Titanium Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 70 Titanium
   os_family: Android
   browser_family: Android Browser
@@ -7825,19 +7045,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; de-de; Archos 70 Xenon Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 70 Xenon
   os_family: Android
   browser_family: Android Browser
@@ -7845,19 +7063,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 70b TITANIUM Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 70b TITANIUM
   os_family: Android
   browser_family: Android Browser
@@ -7865,19 +7081,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; fr-fr; ARCHOS 70it2 Build/HTK75D) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 70it2
   os_family: Android
   browser_family: Android Browser
@@ -7885,19 +7099,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 79 Platinum Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 79 Platinum
   os_family: Android
   browser_family: Chrome
@@ -7905,19 +7117,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 80 Carbon Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 Carbon
   os_family: Android
   browser_family: Android Browser
@@ -7925,19 +7135,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS 80 CHILDPAD Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 CHILDPAD
   os_family: Android
   browser_family: Chrome
@@ -7945,19 +7153,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; ARCHOS 80 COBALT Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 COBALT
   os_family: Android
   browser_family: Chrome
@@ -7965,19 +7171,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 80 Platinum Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 Platinum
   os_family: Android
   browser_family: Android Browser
@@ -7985,7 +7189,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; it-it; ARCHOS 80 TITANIUM Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 GSA/2.0.0.438695
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -7994,7 +7197,7 @@
     version: "2.0.0.438695"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 TITANIUM
   os_family: Android
   browser_family: Unknown
@@ -8002,19 +7205,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.2; fr-fr; Archos 80 Xenon Build/JZO54K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80 Xenon
   os_family: Android
   browser_family: Android Browser
@@ -8022,19 +7223,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 80b PLATINUM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80b PLATINUM
   os_family: Android
   browser_family: Chrome
@@ -8042,19 +7241,17 @@
   user_agent: 'Mozilla/5.0 (Linux; Android 4.0.4; ARCHOS 80G9 Build/IMM76D) AppleWebKit/535.19 (KHTML, like Gecko) Chrome/18.0.1025.166  Safari/535.19'
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "18.0.1025.166"
     engine: WebKit
     engine_version: "535.19"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80G9
   os_family: Android
   browser_family: Chrome
@@ -8062,19 +7259,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; ARCHOS 80XSK Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 80XSK
   os_family: Android
   browser_family: Chrome
@@ -8082,19 +7277,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; ARCHOS 97 CARBON Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97 CARBON
   os_family: Android
   browser_family: Android Browser
@@ -8102,19 +7295,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Archos 97 Cobalt Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97 Cobalt
   os_family: Android
   browser_family: Chrome
@@ -8122,19 +7313,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 97 TITANIUMHD Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97 TITANIUMHD
   os_family: Android
   browser_family: Android Browser
@@ -8142,19 +7331,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; ARCHOS 97 XENON Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97 XENON
   os_family: Android
   browser_family: Android Browser
@@ -8162,19 +7349,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ARCHOS 97b PLATINUM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/31.0.1650.59 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.59"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97b PLATINUM
   os_family: Android
   browser_family: Chrome
@@ -8182,19 +7367,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ARCHOS 97B TITANIUM Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: 97B TITANIUM
   os_family: Android
   browser_family: Android Browser
@@ -8202,19 +7385,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Archos Chefpad Build/JRO03H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: Chefpad
   os_family: Android
   browser_family: Chrome
@@ -8222,19 +7403,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ro-ro; ARCHOS FAMILYPAD 2 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AR
+    brand: Archos
     model: FAMILYPAD 2
   os_family: Android
   browser_family: Android Browser
@@ -8242,19 +7421,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-tw; ME171 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Eee Pad MeMO 171
   os_family: Android
   browser_family: Android Browser
@@ -8262,19 +7439,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Slider SL101 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Eee Pad Slider SL101
   os_family: Android
   browser_family: Chrome
@@ -8282,19 +7457,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; vi-vn; ME172V Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad
   os_family: Android
   browser_family: Android Browser
@@ -8302,19 +7475,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; K00F Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 10
   os_family: Android
   browser_family: Chrome
@@ -8322,19 +7493,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K01E Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 10 ME103K
   os_family: Android
   browser_family: Chrome
@@ -8342,19 +7511,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K01A Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 7
   os_family: Android
   browser_family: Chrome
@@ -8362,19 +7529,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K013 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 7
   os_family: Android
   browser_family: Chrome
@@ -8382,19 +7547,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; ASUS MeMO Pad 7 Build/KTU84P) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 7
   os_family: Android
   browser_family: Chrome
@@ -8402,19 +7565,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; K007 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "52.0.2743.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 7
   os_family: Android
   browser_family: Chrome
@@ -8422,19 +7583,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; K00R Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "58.0.3029.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 7
   os_family: Android
   browser_family: Chrome
@@ -8442,19 +7601,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; K00L Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.131 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.131"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 8
   os_family: Android
   browser_family: Chrome
@@ -8462,19 +7619,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K011 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 8
   os_family: Android
   browser_family: Chrome
@@ -8482,19 +7637,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K014 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad 8.9
   os_family: Android
   browser_family: Chrome
@@ -8502,19 +7655,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ME302C Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.72 Safari/537.36 OPR/16.0.1212.65583
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "16.0.1212.65583"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad FHD 10
   os_family: Android
   browser_family: Opera
@@ -8522,19 +7673,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ME302KL Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.136"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad FHD 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -8542,19 +7691,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; MeMo Pad FHD 10 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad FHD 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -8562,19 +7709,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; K00U Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/28.0.1500.94 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "28.0.1500.94"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad HD 7
   os_family: Android
   browser_family: Chrome
@@ -8582,19 +7727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; ME173X Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.92"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad HD 7
   os_family: Android
   browser_family: Chrome
@@ -8602,19 +7745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; ASUS K00S Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/34.0.1847.114 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "34.0.1847.114"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad HD 7 Dual SIM
   os_family: Android
   browser_family: Chrome
@@ -8622,19 +7763,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; ME301T Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: MeMO Pad Smart 10
   os_family: Android
   browser_family: Android Browser
@@ -8642,19 +7781,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K010 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/36.0.1985.135 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "36.0.1985.135"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF103C
   os_family: Android
   browser_family: Chrome
@@ -8662,19 +7799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; K018 Build/KVT49L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "40.0.2214.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF103CG
   os_family: Android
   browser_family: Chrome
@@ -8682,19 +7817,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-us; ASUS Transformer Pad TF300T Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF300T
   os_family: Android
   browser_family: Android Browser
@@ -8702,19 +7835,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; fr-fr; ASUS Pad TF300T Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF300T
   os_family: Android
   browser_family: Android Browser
@@ -8722,19 +7853,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3.1; TF300T Build/JLS36I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.117 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "35.0.1916.117"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF300T
   os_family: Android
   browser_family: Chrome
@@ -8742,19 +7871,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fa-ir; ASUS Transformer Pad TF300TG Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF300TG
   os_family: Android
   browser_family: Android Browser
@@ -8762,19 +7889,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; ASUS Transformer Pad TF300TL Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF300TL
   os_family: Android
   browser_family: Chrome
@@ -8782,19 +7907,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; K01B Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF303K
   os_family: Android
   browser_family: Chrome
@@ -8802,19 +7925,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; ASUS Transformer Pad TF700KL Build/JRO03L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF700KL
   os_family: Android
   browser_family: Android Browser
@@ -8822,19 +7943,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pt-pt; ASUS Transformer Pad TF700T Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF700T
   os_family: Android
   browser_family: Android Browser
@@ -8842,19 +7961,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.3; K00C Build/JSS15J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/33.0.1750.166 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.3"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "33.0.1750.166"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Pad TF701T
   os_family: Android
   browser_family: Chrome
@@ -8862,19 +7979,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; Transformer Prime TF201 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer Prime TF201
   os_family: Android
   browser_family: Android Browser
@@ -8882,19 +7997,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2.1; es-es; Transformer TF101 Build/HTK75) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer TF101
   os_family: Android
   browser_family: Android Browser
@@ -8902,19 +8015,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.0.3; Transformer TF101 Build/IML74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/32.0.1700.72 Safari/537.36 OPR/19.0.1340.69721
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "19.0.1340.69721"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer TF101
   os_family: Android
   browser_family: Opera
@@ -8922,19 +8033,17 @@
   user_agent: UCWEB/2.0 (Linux; U; Adr 4.0.3; fr-FR; Transformer TF101) U2/1.0.0 UCBrowser/9.2.0.308 U2/1.0.0 Mobile
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.2.0.308"
     engine: ""
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer TF101
   os_family: Android
   browser_family: Unknown
@@ -8942,19 +8051,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; cs-cz; Transformer TF101G Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Transformer TF101G
   os_family: Android
   browser_family: Android Browser
@@ -8962,19 +8069,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ASUS X Pad 10 LTE) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: X Pad 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -8982,19 +8087,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; ASUS Z101) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Z101
   os_family: Android
   browser_family: Chrome
@@ -9002,19 +8105,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; ASUS Z906) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: Z906 10.1"
   os_family: Android
   browser_family: Chrome
@@ -9022,19 +8123,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.1; P01T_1 Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9042,19 +8141,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P021 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9062,19 +8159,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P023 Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9082,19 +8177,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P023) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9102,19 +8195,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P00L Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "68.0.3440.85"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9122,19 +8213,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P028 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.86 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.86"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9142,19 +8231,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P00C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9162,19 +8249,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P028) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9182,19 +8267,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P00C Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 10
   os_family: Android
   browser_family: Chrome
@@ -9202,19 +8285,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P027 Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "66.0.3359.158"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 3S 10
   os_family: Android
   browser_family: Chrome
@@ -9222,19 +8303,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P027) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 3S 10
   os_family: Android
   browser_family: Chrome
@@ -9242,19 +8321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; P00I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 3S 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -9262,19 +8339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; P00I Build/MMB29M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/50.0.2661.86 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "50.0.2661.86"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 3S 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -9282,19 +8357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_P00I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.83 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.83"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 3S 10 LTE
   os_family: Android
   browser_family: Chrome
@@ -9302,19 +8375,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P01V Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.107 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "60.0.3112.107"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 7.0
   os_family: Android
   browser_family: Chrome
@@ -9322,19 +8393,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P01W Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 7.0
   os_family: Android
   browser_family: Chrome
@@ -9342,19 +8411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; P024 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.94 YaBrowser/17.11.1.628.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "17.11.1.628.01"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 8.0
   os_family: Android
   browser_family: Unknown
@@ -9362,19 +8429,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P00A Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "69.0.3497.100"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 8.0
   os_family: Android
   browser_family: Chrome
@@ -9382,19 +8447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; P00A) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad 8.0
   os_family: Android
   browser_family: Chrome
@@ -9402,19 +8465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P01Y Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad C 7.0
   os_family: Android
   browser_family: Chrome
@@ -9422,19 +8483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P01Z Build/LRX22G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad C 7.0
   os_family: Android
   browser_family: Chrome
@@ -9442,19 +8501,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0.2; P01Z) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad C 7.0
   os_family: Android
   browser_family: Chrome
@@ -9462,19 +8519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; P01MA Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad S 8.0
   os_family: Android
   browser_family: Chrome
@@ -9482,19 +8537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; P01M Build/LRX21V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad S 8.0
   os_family: Android
   browser_family: Chrome
@@ -9502,19 +8555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; P01MA) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.105 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad S 8.0
   os_family: Android
   browser_family: Chrome
@@ -9522,19 +8573,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; P01M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "70.0.3538.80"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad S 8.0
   os_family: Android
   browser_family: Chrome
@@ -9542,19 +8591,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.0; P001 Build/LRX21M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad Z10
   os_family: Android
   browser_family: Chrome
@@ -9562,19 +8609,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; P008 Build/MMB29M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/61.0.3163.98 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "61.0.3163.98"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad Z8
   os_family: Android
   browser_family: Chrome
@@ -9582,19 +8627,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ASUS_P00J Build/NRD90M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.137 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "64.0.3282.137"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AU
+    brand: Asus
     model: ZenPad Z8s
   os_family: Android
   browser_family: Chrome
@@ -9602,7 +8645,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-mx; Avvio PAD Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30 GSA/3.3.11.1069658.arm
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ARM
   client:
@@ -9611,7 +8653,7 @@
     version: "3.3.11.1069658"
   device:
     type: tablet
-    brand: AV
+    brand: Avvio
     model: PAD
   os_family: Android
   browser_family: Unknown
@@ -9619,19 +8661,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; Axxion ATAB-701 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AY
+    brand: Axxion
     model: ATAB-701
   os_family: Android
   browser_family: Android Browser
@@ -9639,19 +8679,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-be; Axxion ATAB-902 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AY
+    brand: Axxion
     model: ATAB-902
   os_family: Android
   browser_family: Android Browser
@@ -9659,19 +8697,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; fr-fr; Novo10 Hero Build/20121219) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 10 Hero
   os_family: Android
   browser_family: Android Browser
@@ -9679,19 +8715,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.1.1; Novo 10 Hero QuadCore Build/JRO03C) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "42.0.2311.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 10 Hero QuadCore
   os_family: Android
   browser_family: Chrome
@@ -9699,19 +8733,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; NOVO10 Spark) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 10 Spark
   os_family: Android
   browser_family: Chrome
@@ -9719,19 +8751,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NOVO7 Build/KTU84Q) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/33.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "33.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 7
   os_family: Android
   browser_family: Chrome
@@ -9739,19 +8769,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-gb; Novo7 Flame Build/JOP40D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 7 Flame
   os_family: Android
   browser_family: Android Browser
@@ -9759,19 +8787,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.1; Numy 3G AX1 Build/JOP40D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "41.0.2272.96"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 7 Numy AX1 3G
   os_family: Android
   browser_family: Chrome
@@ -9779,19 +8805,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Numy 3G AX10t Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 7 Numy AX1 3G
   os_family: Android
   browser_family: Android Browser
@@ -9799,7 +8823,6 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; novo9-Spark Build/MASTER) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 baiduboxapp/023_7.3_diordna_2591_6351/nwonknu_61_1.1.4_krapS-9ovon/1000232f/11797C217E2631E6E48B99FE22F146FB%7C15274284'
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
@@ -9808,7 +8831,7 @@
     version: "023"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Novo 9 Spark
   os_family: Android
   browser_family: Unknown
@@ -9816,19 +8839,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-gb; Numy_3G_AW1 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy 3G AW1
   os_family: Android
   browser_family: Android Browser
@@ -9836,19 +8857,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; NUMY3GAX9 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy 3G AX9
   os_family: Android
   browser_family: Android Browser
@@ -9856,19 +8875,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; Numy3GTalos Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36 OPR/46.3.2246.127744
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "46.3.2246.127744"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy 3G Talos
   os_family: Android
   browser_family: Opera
@@ -9876,19 +8893,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.1; en-us; Numy_3G_BW1 Build/MID) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 UCBrowser/9.6.0.378 U3/0.8.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.2.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "9.6.0.378"
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy 3G Talos 2
   os_family: Android
   browser_family: Unknown
@@ -9896,19 +8911,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; Numy_3G_Vegas Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy 3G Vegas
   os_family: Android
   browser_family: Android Browser
@@ -9916,19 +8929,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 5.1; en-US; AX10PRO Build/LMY47D) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.2.0.1089 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.2.0.1089"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy AX10 Pro
   os_family: Android
   browser_family: Unknown
@@ -9936,19 +8947,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; Numy_3G_AX3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy AX3 Sword
   os_family: Android
   browser_family: Android Browser
@@ -9956,19 +8965,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Numy_Note_9 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tablet
-    brand: AZ
+    brand: Ainol
     model: Numy Note 9
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/tv.yml
+++ b/Tests/fixtures/tv.yml
@@ -5,7 +5,6 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.0.4"
     engine: WebKit
     engine_version: "531.2"
@@ -19,73 +18,65 @@
   user_agent: HbbTV/1.1.1 (;;;;) Mozilla/5.0 (compatible; ANTGalio/3.0.2.1.22.43.08; Linux2.6.18-7.1/7405d0-smp)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.0.2.1.22.43.08"
     engine: ""
     engine_version: ""
   device:
     type: tv
     brand: ""
-    model: null
+    model: ""
   os_family: GNU/Linux
   browser_family: Unknown
 - 
   user_agent: Opera/9.80 (Linux sh4 ; U; HBBTV/1.0 (; LOH/1.00; -----;;;) CE-HTML/1.0 Config(L:de,CC:AT); en) Presto/2.5.21 Version/10.30
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.30"
     engine: Presto
     engine_version: "2.5.21"
   device:
     type: tv
     brand: ""
-    model: null
+    model: ""
   os_family: GNU/Linux
   browser_family: Opera
 - 
   user_agent: Opera/10.60 (Linux sh4 ; U; HBBTV/1.0 (; LOH/2.01; -----;;;) CE-HTML/1.0 Config(Hotel,L:de,CC:DE); en) Presto/2.6.33 Version/10.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.60"
     engine: Presto
     engine_version: "2.6.33"
   device:
     type: tv
     brand: ""
-    model: null
+    model: ""
   os_family: GNU/Linux
   browser_family: Opera
 - 
   user_agent: Mozilla/5.0 (Windows; U; Windows NT 5.1; en-US; rv:1.9.2) Gecko/20100222 Firefox/3.6 Kylo/0.6.1.70394
   os:
     name: Windows
-    short_name: WIN
     version: "XP"
     platform: ""
   client:
     type: browser
     name: Kylo
-    short_name: KY
     version: "0.6.1.70394"
     engine: Gecko
     engine_version: "1.9.2"
@@ -99,13 +90,11 @@
   user_agent: Mozilla/3.0 WebTV/1.2 (compatible; MSIE 2.0)
   os:
     name: WebTV
-    short_name: WTV
     version: "1.2"
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "2.0"
     engine: Trident
     engine_version: ""
@@ -119,19 +108,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; BB2 PRO Build/NHG47L; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: BB2 Pro
   os_family: Android
   browser_family: Chrome
@@ -139,19 +126,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; KII PRO Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: KII Pro
   os_family: Android
   browser_family: Chrome
@@ -159,19 +144,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KM9PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: KM9 Pro
   os_family: Android
   browser_family: Chrome
@@ -179,19 +162,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; KM9_TV_BOX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: KM9 TV Box
   os_family: Android
   browser_family: Chrome
@@ -199,19 +180,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S MAX) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Max
   os_family: Android
   browser_family: Chrome
@@ -219,19 +198,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PLUS DVB) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Plus DVB
   os_family: Android
   browser_family: Chrome
@@ -239,19 +216,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PLUS L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Plus L
   os_family: Android
   browser_family: Chrome
@@ -259,19 +234,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PLUS W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Plus W
   os_family: Android
   browser_family: Chrome
@@ -279,19 +252,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Pro
   os_family: Android
   browser_family: Chrome
@@ -299,19 +270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PRO L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.45 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.45"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Pro L
   os_family: Android
   browser_family: Chrome
@@ -319,19 +288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PRO PLUS) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Pro Plus
   os_family: Android
   browser_family: Chrome
@@ -339,19 +306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8S PRO W) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.68 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.68"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Pro W
   os_family: Android
   browser_family: Chrome
@@ -359,19 +324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; M8SPROW) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/83.0.4103.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "83.0.4103.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 0M
+    brand: Mecool
     model: M8S Pro W
   os_family: Android
   browser_family: Chrome
@@ -379,19 +342,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HK1 Max) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: HK1 Max
   os_family: Android
   browser_family: Chrome
@@ -399,19 +360,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HK1 MINI) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.99"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: HK1 Mini
   os_family: Android
   browser_family: Chrome
@@ -419,19 +378,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; HK1 PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: HK1 Pro
   os_family: Android
   browser_family: Chrome
@@ -439,19 +396,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Vontar-KIII) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.73 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.73"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: KIII
   os_family: Android
   browser_family: Chrome
@@ -459,19 +414,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VONTAR MX-4K Build/LMY49F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: MX-4K
   os_family: Android
   browser_family: Chrome
@@ -479,19 +432,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; VONTAR V1 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36 OPR/46.0.2246.126998
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "46.0.2246.126998"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: V1
   os_family: Android
   browser_family: Opera
@@ -499,19 +450,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; VONTAR Z5 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/63.0.3239.111 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "63.0.3239.111"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: Z5
   os_family: Android
   browser_family: Chrome
@@ -519,19 +468,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; VONTAR Z8 Arc Build/NMF26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1V
+    brand: Vontar
     model: Z8
   os_family: Android
   browser_family: Chrome
@@ -539,19 +486,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; NEO-U1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO U1
   os_family: Android
   browser_family: Chrome
@@ -559,19 +504,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; NEO-U9-H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO U9H
   os_family: Android
   browser_family: Chrome
@@ -579,19 +522,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; he-il; NEO-X5-116A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X5
   os_family: Android
   browser_family: Android Browser
@@ -599,19 +540,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; NEO-X5-mini Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X5 Mini
   os_family: Android
   browser_family: Android Browser
@@ -619,19 +558,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NEO-X6 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X6
   os_family: Android
   browser_family: Chrome
@@ -639,19 +576,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; NEO-X7-216A Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X7
   os_family: Android
   browser_family: Android Browser
@@ -659,19 +594,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; en-us; NEO-X7-mini Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X7 Mini
   os_family: Android
   browser_family: Android Browser
@@ -679,19 +612,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; NEO-X88-I Build/LMY49F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/63.0.3239.60 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "63.0.3239.60"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X88i
   os_family: Android
   browser_family: Chrome
@@ -699,19 +630,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NEO-X8-H Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X8H
   os_family: Android
   browser_family: Chrome
@@ -719,19 +648,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; NEO-X8H-PLUS Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "49.0.2623.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO X8H Plus
   os_family: Android
   browser_family: Chrome
@@ -739,19 +666,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NEO-Z64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 1X
+    brand: Minix
     model: NEO Z64
   os_family: Android
   browser_family: Chrome
@@ -759,19 +684,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; ATOM-108AM Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 2A
+    brand: Atom
     model: 108AM
   os_family: Android
   browser_family: Chrome
@@ -779,19 +702,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; Vorke Z1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 2V
+    brand: Vorke
     model: Z1
   os_family: Android
   browser_family: Chrome
@@ -799,19 +720,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; VORKE Z5 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 2V
+    brand: Vorke
     model: Z5
   os_family: Android
   browser_family: Chrome
@@ -819,19 +738,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; VORKE Z6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 2V
+    brand: Vorke
     model: Z6
   os_family: Android
   browser_family: Chrome
@@ -839,19 +756,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; VORKE Z6 Plus) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 2V
+    brand: Vorke
     model: Z6 Plus
   os_family: Android
   browser_family: Chrome
@@ -859,19 +774,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; A95X_R1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 3L
+    brand: Alfawise
     model: A95X R1
   os_family: Android
   browser_family: Chrome
@@ -879,19 +792,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NV501) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4E
+    brand: Eltex
     model: NV-501
   os_family: Android
   browser_family: Chrome
@@ -899,19 +810,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NV501WAC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4E
+    brand: Eltex
     model: NV-501-Wac
   os_family: Android
   browser_family: Chrome
@@ -919,19 +828,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; INVIN-KM6 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4I
+    brand: Invin
     model: KM6
   os_family: Android
   browser_family: Chrome
@@ -939,19 +846,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; INVIN X2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4I
+    brand: Invin
     model: X2
   os_family: Android
   browser_family: Chrome
@@ -959,19 +864,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 9; INVIN_X4 Build/PPR1.181005.003; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Safari/537.36 OPR/46.0.2254.145391
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "46.0.2254.145391"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4I
+    brand: Invin
     model: X4
   os_family: Android
   browser_family: Opera
@@ -979,19 +882,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Draco AW80) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3921.2 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3921.2"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Draco AW80
   os_family: Android
   browser_family: Chrome
@@ -999,19 +900,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Draco H3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Draco H3
   os_family: Android
   browser_family: Chrome
@@ -1019,19 +918,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Orion R68G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Orion R68G
   os_family: Android
   browser_family: Chrome
@@ -1039,19 +936,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Vega S95_Meta) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Vega S95 Meta
   os_family: Android
   browser_family: Chrome
@@ -1059,19 +954,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Vega S95_Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "72.0.3626.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Vega S95 Pro
   os_family: Android
   browser_family: Chrome
@@ -1079,19 +972,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Vega S95_Telos) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 4T
+    brand: Tronsmart
     model: Vega S95 Telos
   os_family: Android
   browser_family: Chrome
@@ -1099,19 +990,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; Transpeed_6K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: 6K
   os_family: Android
   browser_family: Chrome
@@ -1119,19 +1008,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TR99) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: TR99
   os_family: Android
   browser_family: Chrome
@@ -1139,19 +1026,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; TR99 MINI+) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 5R
+    brand: Transpeed
     model: TR99 Mini Plus
   os_family: Android
   browser_family: Chrome
@@ -1159,19 +1044,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 7.1.2; en-US; T95ZPLUS Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.2.1208 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.2.1208"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: 5S
+    brand: Sunvell
     model: T95Z Plus
   os_family: Android
   browser_family: Unknown
@@ -1179,19 +1062,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; 32LF7130S Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: 8A
+    brand: Asano
     model: 32LF7130S 32.0"
   os_family: Android
   browser_family: Chrome
@@ -1199,19 +1080,17 @@
   user_agent: Opera/9.80 (Linux mips; Opera TV Store/6162; HbbTV/1.2.1 (; Altech UEC; PVR9600; ; ; )) Presto/2.12.407 Version/12.51 Model/AltechMultimedia-TestingDevice
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.51"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: A1
+    brand: Altech UEC
     model: PVR9600
   os_family: GNU/Linux
   browser_family: Opera
@@ -1219,19 +1098,17 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 5.23; Macintosh; PPC) Escape 5.1.8
   os:
     name: Mac
-    short_name: MAC
     version: ""
     platform: ""
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "5.1.8"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: AP
+    brand: Apple
     model: ""
   os_family: Mac
   browser_family: Unknown
@@ -1244,7 +1121,7 @@
     version: ""
   device:
     type: tv
-    brand: AP
+    brand: Apple
     model: Apple TV
   os_family: Unknown
   browser_family: Unknown
@@ -1252,13 +1129,12 @@
   user_agent: AppleCoreMedia/1.0.0.12B466 (Apple TV; U; CPU OS 8_1_3 like Mac OS X; en_us)
   os:
     name: iOS
-    short_name: IOS
     version: "8.1.3"
     platform: ""
   client: null
   device:
     type: tv
-    brand: AP
+    brand: Apple
     model: Apple TV
   os_family: iOS
   browser_family: Unknown
@@ -1266,7 +1142,6 @@
   user_agent: XBMC/PRE-11.0 Git:20110623-62171b3 (iOS; 11.0.0 AppleTV2,1; http://www.xbmc.org)
   os:
     name: Apple TV
-    short_name: ATV
     version: ""
     platform: ""
   client:
@@ -1275,7 +1150,7 @@
     version: ""
   device:
     type: tv
-    brand: AP
+    brand: Apple
     model: Apple TV 2
   os_family: Apple TV
   browser_family: Unknown
@@ -1285,13 +1160,12 @@
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.2.12.29"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: AS
+    brand: ARRIS
     model: IPC1100
   os_family: Unknown
   browser_family: Opera
@@ -1301,13 +1175,12 @@
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.1.4.54"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: AS
+    brand: ARRIS
     model: IPC1100P2
   os_family: Unknown
   browser_family: Opera
@@ -1315,19 +1188,17 @@
   user_agent: Opera/9.80 (Linux mips) Presto/2.12.407 Version/12.50 , KreaTV/12.36.2.2 (ARRIS, VMS1100, wired)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: AS
+    brand: ARRIS
     model: VMS1100
   os_family: GNU/Linux
   browser_family: Opera
@@ -1335,19 +1206,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (+PVR+RTSP;Airties;Air7210;16999168;;); xx) Presto/2.10.287 Version/12.00
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: AT
+    brand: Airties
     model: Air7210
   os_family: GNU/Linux
   browser_family: Opera
@@ -1355,19 +1224,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Beelink A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: B0
+    brand: Beelink
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -1375,19 +1242,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Beelink GT1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: B0
+    brand: Beelink
     model: GT1
   os_family: Android
   browser_family: Chrome
@@ -1395,19 +1260,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Beelink LAKE I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: B0
+    brand: Beelink
     model: LAKE I
   os_family: Android
   browser_family: Chrome
@@ -1415,19 +1278,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Beelink SEA I) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: B0
+    brand: Beelink
     model: SEA I
   os_family: Android
   browser_family: Chrome
@@ -1435,19 +1296,17 @@
   user_agent: Opera/9.80 (Linux i686; U; HbbTV/1.1.1 (+PVR+DL; BANGOLUFSEN; A3; ; ; ) CE-HTML/1.0 NETTV/1.0; en) Presto/2.10.287 Version/12.00 A3/1.0.3.30552 (BANGOLUFSEN, A3, wired)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: BO
+    brand: BangOlufsen
     model: BeoVision
   os_family: GNU/Linux
   browser_family: Opera
@@ -1455,19 +1314,17 @@
   user_agent: Opera/9.80 (Linux i686; U; HbbTV/1.1.1 (; BANGOLUFSEN; A3; ; ; ) CE-HTML/1.0 NETTV/1.0; en) Presto/2.10.287 Version/12.00 A3/1.0.2.28884 (BANGOLUFSEN, A3, wired)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: BO
+    brand: BangOlufsen
     model: BeoVision
   os_family: GNU/Linux
   browser_family: Opera
@@ -1475,19 +1332,17 @@
   user_agent: Opera/9.80 (Linux mips; Opera TV Store/5477) Presto/2.12.362 Version/12.10 Model/Changhong-MST6328
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: C2
+    brand: Changhong
     model: MST6328
   os_family: GNU/Linux
   browser_family: Opera
@@ -1495,19 +1350,17 @@
   user_agent: Mozilla/5.0 (Linux i686; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/30.0.1599.114 Safari/537.36 SRAF/3.0 HbbTV/1.1.1 (CHANGHONG; TV55; sw-v1.0;) CE-HTML/1.0 NETRANGEMMH
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "30.0.1599.114"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: C2
+    brand: Changhong
     model: TV55
   os_family: GNU/Linux
   browser_family: Chrome
@@ -1515,19 +1368,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; ; en; CreNova Build) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1 HbbTV/1.1.1 (;CreNova;CNV001;1.0;1.0; FXM-U2FsdGVkX1/VHpIx4++T5dr9nrGwg2lrTv3h0bv5wA819tf9ZWJf5kbW8psLCFgl-END; en) Presto/2.9.167 Ve
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "4.0"
     engine: Elektra
     engine_version: ""
   device:
     type: tv
-    brand: CR
+    brand: CreNova
     model: CNV001
   os_family: GNU/Linux
   browser_family: Opera
@@ -1535,19 +1386,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; CNV001; en;) HbbTV/1.1.1 (;CreNova;CNV001;1.0;1.0; FXM-U2FsdGVkX1/Oiw1OD4kjnYIMtRrxMWUbzbPMsylGXvFEN7YI7l5UInvIDEkFxQa5-END; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: CR
+    brand: CreNova
     model: CNV001
   os_family: GNU/Linux
   browser_family: Opera
@@ -1555,19 +1404,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; CVTE_MSD338_1G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: CV
+    brand: CVTE
     model: MSD338 1G
   os_family: Android
   browser_family: Chrome
@@ -1575,19 +1422,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; CVTE_MSD338_512M) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.70 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.70"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: CV
+    brand: CVTE
     model: MSD338 512M
   os_family: Android
   browser_family: Chrome
@@ -1595,19 +1440,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Daewoo Android TV 638 Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/68.0.3440.91 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "68.0.3440.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: D5
+    brand: Daewoo
     model: Android TV 638
   os_family: Android
   browser_family: Chrome
@@ -1615,19 +1458,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; DIVISAT J-Link) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: D6
+    brand: Divisat
     model: J-Link
   os_family: Android
   browser_family: Chrome
@@ -1635,19 +1476,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Dolamee D5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: D9
+    brand: Dolamee
     model: D5
   os_family: Android
   browser_family: Chrome
@@ -1655,19 +1494,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; Dolamee-D6 Build/Dolamee-D6-RTL8723BS; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: D9
+    brand: Dolamee
     model: D6
   os_family: Android
   browser_family: Chrome
@@ -1675,19 +1512,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 24DHS54 Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: DF
+    brand: Doffler
     model: 24DHS54
   os_family: Android
   browser_family: Chrome
@@ -1695,13 +1530,12 @@
   user_agent: Mozilla/5.0 (Linux mips; U;HbbTV/1.1.1 (+RTSP;DMM;Dreambox;0.1a;1.0;) CE-HTML/1.0; en) AppleWebKit/535.19 no/Volksbox QtWebkit/2.2
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client: null
   device:
     type: tv
-    brand: DM
+    brand: DMM
     model: Dreambox
   os_family: GNU/Linux
   browser_family: Unknown
@@ -1709,19 +1543,17 @@
   user_agent: Opera/9.80 (Linux mips; U; xx) Presto/2.10.287 Version/12.00 DuneHD/1.0 (connect; 140223_0132_b6) CE-HTML/1.0 NETRANGEMMH
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: DU
+    brand: Dune HD
     model: connect
   os_family: GNU/Linux
   browser_family: Opera
@@ -1729,19 +1561,17 @@
   user_agent: Opera/9.80 (Linux mips; U; xx) Presto/2.10.287 Version/12.00 DuneHD/1.0 (polskytv__tv102; 130527_1328_b5) CE-HTML/1.0 NETRANGEMMH
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: DU
+    brand: Dune HD
     model: tv102
   os_family: GNU/Linux
   browser_family: Opera
@@ -1749,19 +1579,17 @@
   user_agent: Opera/9.80 (Linux mips; U; xx) Presto/2.10.287 Version/12.00 DuneHD/1.0 (tv102; 130515_2104_b6) CE-HTML/1.0 NETRANGEMMH
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: DU
+    brand: Dune HD
     model: tv102
   os_family: GNU/Linux
   browser_family: Opera
@@ -1769,19 +1597,17 @@
   user_agent: Opera/9.80 (Linux mips; U; xx) Presto/2.10.287 Version/12.00 DuneHD/1.0 (tv303d; 130515_2104_b6) CE-HTML/1.0 NETRANGEMMH
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: DU
+    brand: Dune HD
     model: tv303d
   os_family: GNU/Linux
   browser_family: Opera
@@ -1789,19 +1615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F43D8000K PNL_72043311) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: DX
+    brand: DEXP
     model: F43D8000K
   os_family: Android
   browser_family: Chrome
@@ -1809,19 +1633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; F48D8000K PNL_72048303_LSC480HN08_8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: DX
+    brand: DEXP
     model: F48D8000K
   os_family: Android
   browser_family: Chrome
@@ -1829,19 +1651,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; cs-cz; EVOLVEO Smart TV box Q4 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30 Maxthon/4.1.4.2000
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: "4.1.4.2000"
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: EO
+    brand: Evolveo
     model: Smart TV box Q4
   os_family: Android
   browser_family: Unknown
@@ -1851,13 +1671,12 @@
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "31.0.1650.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: GO
+    brand: Google
     model: Chromecast
   os_family: Unknown
   browser_family: Chrome
@@ -1865,19 +1684,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/41.0.2272.75 Safari/537.36 CrKey/1.14.32904
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "41.0.2272.75"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: GO
+    brand: Google
     model: Chromecast
   os_family: Android
   browser_family: Chrome
@@ -1885,19 +1702,17 @@
   user_agent: Mozilla/5.0 (X11; Linux i686) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Large Screen Safari/534.24 GoogleTV/092754
   os:
     name: Google TV
-    short_name: GTV
     version: "092754"
     platform: x86
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "11.0.696.77"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: tv
-    brand: GO
+    brand: Google
     model: GoogleTV
   os_family: Google TV
   browser_family: Chrome
@@ -1905,19 +1720,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AFTEUFF014 Build/PMAIN1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: GU
+    brand: Grundig
     model: OLED 4K (2019)
   os_family: Android
   browser_family: Chrome
@@ -1925,19 +1738,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AFTEU011) AppleWebKit/537.36 (KHTML, like Gecko) Silk/80.1.145 like Chrome/80.0.3987.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "80.1.145"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: GU
+    brand: Grundig
     model: Vision 6 HD (2019)
   os_family: Android
   browser_family: Chrome
@@ -1945,19 +1756,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AFTEU014 Build/PMAIN1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: GU
+    brand: Grundig
     model: Vision 7 4K (2019)
   os_family: Android
   browser_family: Chrome
@@ -1965,19 +1774,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; HAT4KDTV Build/OTT1.180130.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.99 Safari/537.36 OPR/46.0.2207.0 OMI/4.13.2.294.Martell-5.19 Model/Hisense-MT5660
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.13.2.294"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: HI
+    brand: Hisense
     model: HAT4KDTV
   os_family: Android
   browser_family: Opera
@@ -1985,19 +1792,17 @@
   user_agent: Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Hisense; SmartTV_2015; V00.01.00a.G0816; HE65M7000UWTSG; )) Presto/2.12.407 Version/12.51 year/2016
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.51"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: HI
+    brand: Hisense
     model: HE65M7000UWTS
   os_family: GNU/Linux
   browser_family: Opera
@@ -2005,19 +1810,17 @@
   user_agent: Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Hisense; SmartTV; V00.01.00a.E0923; LHD32K370WTEU; )) Presto/2.12.407 Version/12.51
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.51"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: HI
+    brand: Hisense
     model: LHD32K370WTEU
   os_family: GNU/Linux
   browser_family: Opera
@@ -2025,19 +1828,17 @@
   user_agent: Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Hisense; SmartTV_2015; V00.01.00a.G0806; LTDN58K700XWTSEU3D_1; )) Presto/2.12.407 Version/12.51 year/2016
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.51"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: HI
+    brand: Hisense
     model: LTDN58K700XWTSEU3D
   os_family: GNU/Linux
   browser_family: Opera
@@ -2045,19 +1846,17 @@
   user_agent: Opera/9.80 (Linux 7405b0-smp; U; HbbTV/1.1.1 (; Humax; CXHD-5100C; 1.00.23; 1.0; ); ce-html/1.0; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: CXHD-5100C
   os_family: GNU/Linux
   browser_family: Opera
@@ -2067,13 +1866,12 @@
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.1.1.23.04.09"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: HD FOX+
   os_family: Unknown
   browser_family: Unknown
@@ -2081,19 +1879,17 @@
   user_agent: Opera/9.80 (Linux 7325b0; U; HbbTV/1.1.1 (; Humax; HD NANO; 1.00.16; 1.0; ); ce-html/1.0; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: HD NANO
   os_family: GNU/Linux
   browser_family: Opera
@@ -2101,19 +1897,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Humax; hdr1000s; 1.0.0; 1.0.0; ); ce-html/1.0; xx) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: hdr1000s
   os_family: GNU/Linux
   browser_family: Opera
@@ -2121,19 +1915,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Humax; HM-9504HD; 0.01.06; 1.0; scrlgnnew; ); ce-html/1.0; xx) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: HM-9504HD
   os_family: GNU/Linux
   browser_family: Opera
@@ -2141,19 +1933,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Humax; hms1000s; 1.0.0; 1.0.0; ); ce-html/1.0; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: HMS-1000S
   os_family: GNU/Linux
   browser_family: Opera
@@ -2161,19 +1951,17 @@
   user_agent: Opera/9.80 (Linux mips; Opera TV Store/5896; HbbTV/1.2.1 (PVR; freesat/1.0; hms1000sph2; 1.0.0; 1.0.0; UX-PRISM--OP-NONE); ce-html/1.0) Presto/2.12.407 Version/12.50 Model/Humax-TestingDevice
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: HMS-1000S
   os_family: GNU/Linux
   browser_family: Opera
@@ -2183,13 +1971,12 @@
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.1.1.23.04.09"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: iCord Cable
   os_family: Unknown
   browser_family: Unknown
@@ -2199,13 +1986,12 @@
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.1.1.23.04"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: iCord HD+
   os_family: Unknown
   browser_family: Unknown
@@ -2213,19 +1999,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Humax; iCord HD+; 1.0.0; 1.0.0; ); ce-html/1.0; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: iCord HD+
   os_family: GNU/Linux
   browser_family: Opera
@@ -2233,19 +2017,17 @@
   user_agent: Opera/9.80 (Linux 7335b0-smp; U; HbbTV/1.1.1 (; Humax; iCord MINI; 0.90.02; 1.0; ); ce-html/1.0; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: iCord MINI
   os_family: GNU/Linux
   browser_family: Opera
@@ -2253,19 +2035,17 @@
   user_agent: Opera/9.80 (Linux 7325b0; U; HbbTV/1.1.1 (; Humax; IRHD-5100S; 1.01.26; 1.0; ); ce-html/1.0; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: HX
+    brand: Humax
     model: IRHD-5100S
   os_family: GNU/Linux
   browser_family: Opera
@@ -2273,19 +2053,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; iconBIT Movie Ultra HD 4K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.67 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.67"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: I2
+    brand: IconBIT
     model: Movie Ultra HD 4K
   os_family: Android
   browser_family: Chrome
@@ -2293,19 +2071,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; XDS74K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: I2
+    brand: IconBIT
     model: XDS74K
   os_family: Android
   browser_family: Chrome
@@ -2313,19 +2089,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; XDS84K Build/LMY49F) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: I2
+    brand: IconBIT
     model: XDS84K
   os_family: Android
   browser_family: Chrome
@@ -2333,19 +2107,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; XDS94K Build/LMY47V) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: I2
+    brand: IconBIT
     model: XDS94K
   os_family: Android
   browser_family: Chrome
@@ -2353,19 +2125,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;IKEA LF1V358; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: IA
+    brand: Ikea
     model: LF1V358
   os_family: GNU/Linux
   browser_family: Opera
@@ -2373,19 +2143,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AFTJMST12) AppleWebKit/537.36 (KHTML, like Gecko) Silk/79.5.1 like Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "79.5.1"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: IS
+    brand: Insignia
     model: 4K (2018)
   os_family: Android
   browser_family: Chrome
@@ -2393,19 +2161,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AFTEAMR311 Build/NS6269; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: IS
+    brand: Insignia
     model: HD (2018)
   os_family: Android
   browser_family: Chrome
@@ -2413,19 +2179,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; Vantage Full HD Model;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; FXM-U2FsdGVkX19WaYSyGq70V2qt2C4bR92ULIOEtQrDKma1eRx3WQlWfuTO6eCHMYQm-END; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: IT
+    brand: Intek
     model: Vantage
   os_family: GNU/Linux
   browser_family: Opera
@@ -2433,19 +2197,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; VT-100 HD+;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: IT
+    brand: Intek
     model: VT-100
   os_family: GNU/Linux
   browser_family: Opera
@@ -2453,19 +2215,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (; INTEK; VT-100 HD+;;;) hdplusSmartTV/1.0 (NETRANGEMMH;) Bee/3.2 CE-HTML/1.0; FXM-U2FsdGVkX1+9IFast5+XgFhStntZ2aPC75KXhmr7DTyTjVYcbAaLpfmxnMmKiXRe-END; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: IT
+    brand: Intek
     model: VT-100
   os_family: GNU/Linux
   browser_family: Opera
@@ -2475,7 +2235,7 @@
   client: null
   device:
     type: tv
-    brand: IV
+    brand: Inverto
     model: IDL-6640N Volksbox Essential
   os_family: Unknown
   browser_family: Unknown
@@ -2485,7 +2245,7 @@
   client: null
   device:
     type: tv
-    brand: IV
+    brand: Inverto
     model: IDL-6651N Volksbox Web Edition
   os_family: Unknown
   browser_family: Unknown
@@ -2495,7 +2255,7 @@
   client: null
   device:
     type: tv
-    brand: IV
+    brand: Inverto
     model: IDL-6750N Volksbox II
   os_family: Unknown
   browser_family: Unknown
@@ -2505,7 +2265,7 @@
   client: null
   device:
     type: tv
-    brand: IV
+    brand: Inverto
     model: 'QUANTUM - IDL9000'
   os_family: Unknown
   browser_family: Unknown
@@ -2513,19 +2273,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; KATV-01 PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: K5
+    brand: KATV1
     model: KATV-01 Pro
   os_family: Android
   browser_family: Chrome
@@ -2533,19 +2291,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AFTB Build/JDQ39) AppleWebKit/537.22 (KHTML, like Gecko) Chrome/25.0.1364.173 Mobile Safari/537.22 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "25.0.1364.173"
     engine: WebKit
     engine_version: "537.22"
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV
   os_family: Android
   browser_family: Chrome
@@ -2553,19 +2309,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AFTN Build/NS6210; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.2883.91 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.2883.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV (Gen 3)
   os_family: Android
   browser_family: Chrome
@@ -2573,19 +2327,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; AFTA Build/NS6223) AppleWebKit/537.36 (KHTML, like Gecko) Silk/68.3.1 like Chrome/68.0.3440.85 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "68.3.1"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV Cube (Gen 1)
   os_family: Android
   browser_family: Chrome
@@ -2593,19 +2345,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; AFTR Build/PMAIN1; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/70.0.3538.110 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "70.0.3538.110"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV Cube (Gen 2)
   os_family: Android
   browser_family: Chrome
@@ -2613,19 +2363,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AFTM Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/34.0.0.0 Mobile Safari/537.36 cordova-amazon-fireos/3.4.0 AmazonWebAppPlatform/3.4.0;2.0
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "34.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV stick
   os_family: Android
   browser_family: Chrome
@@ -2633,19 +2381,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AFTT Build/LVY48F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/49.0.2623.10
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "49.0.2623.10"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV stick
   os_family: Android
   browser_family: Chrome
@@ -2653,19 +2399,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AFTS Build/LVY48F; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/55.0.28
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "55.0.28"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KN
+    brand: Amazon
     model: Fire TV stick
   os_family: Android
   browser_family: Chrome
@@ -2673,19 +2417,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 24FR50WU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.79 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.79"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 24FR50WU
   os_family: Android
   browser_family: Chrome
@@ -2693,19 +2435,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 24H600GR Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 24H600GR
   os_family: Android
   browser_family: Chrome
@@ -2713,19 +2453,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 24H600GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 24H600GU
   os_family: Android
   browser_family: Chrome
@@ -2733,19 +2471,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 24HK30B) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36 OPR/55.2.2719.50740
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "55.2.2719.50740"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 24HK30B
   os_family: Android
   browser_family: Opera
@@ -2753,19 +2489,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32FK30G Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.106 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "66.0.3359.106"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32FK30G
   os_family: Android
   browser_family: Chrome
@@ -2773,19 +2507,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32FK32G Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32FK32G
   os_family: Android
   browser_family: Chrome
@@ -2793,19 +2525,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32FK32G_-Ver01 Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/72.0.3626.121 Safari/537.36 OPR/51.3.2461.138727
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "51.3.2461.138727"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32FK32G v1
   os_family: Android
   browser_family: Opera
@@ -2813,19 +2543,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32FR50BU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32FR50BU
   os_family: Android
   browser_family: Chrome
@@ -2833,19 +2561,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32FR50WR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32FR50WR
   os_family: Android
   browser_family: Chrome
@@ -2853,19 +2579,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32HK30G_-Ver01 Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.123 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "64.0.3282.123"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32HK30G v1
   os_family: Android
   browser_family: Chrome
@@ -2873,19 +2597,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32HR50GR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32HR50GR
   os_family: Android
   browser_family: Chrome
@@ -2893,19 +2615,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32HR50GR_-Ver02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32HR50GR v2
   os_family: Android
   browser_family: Chrome
@@ -2913,19 +2633,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 32HR50GU_-Ver01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.111"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32HR50GU v1
   os_family: Android
   browser_family: Chrome
@@ -2933,19 +2651,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 32HR55GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 32HR55GU
   os_family: Android
   browser_family: Chrome
@@ -2953,19 +2669,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 40FK30G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40FK30G
   os_family: Android
   browser_family: Chrome
@@ -2973,19 +2687,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 40FK30G_-Ver02) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40FK30G v2
   os_family: Android
   browser_family: Chrome
@@ -2993,19 +2705,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 40FR50BR Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40FR50BR
   os_family: Android
   browser_family: Chrome
@@ -3013,19 +2723,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 40U600GR Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40U600GR
   os_family: Android
   browser_family: Chrome
@@ -3033,19 +2741,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 40U600GU) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.78 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "80.0.3987.78"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40U600GU
   os_family: Android
   browser_family: Chrome
@@ -3053,19 +2759,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 40UR50GR Build/NMF26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40UR50GR
   os_family: Android
   browser_family: Chrome
@@ -3073,19 +2777,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 40UR50GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 40UR50GU
   os_family: Android
   browser_family: Chrome
@@ -3093,19 +2795,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 43UK30G_-Ver01) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.92 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "77.0.3865.92"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 43UK30G v1
   os_family: Android
   browser_family: Chrome
@@ -3113,19 +2813,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 43UK30G_-Ver02 Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/50.0.2661.89 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "50.0.2661.89"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 43UK30G v2
   os_family: Android
   browser_family: Chrome
@@ -3133,19 +2831,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 43UK35G Build/M5C14J; uk-ua) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Mobile Safari/537.36 Puffin/7.8.2.40664AP
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "7.8.2.40664"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 43UK35G
   os_family: Android
   browser_family: Unknown
@@ -3153,19 +2849,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 43UP50GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 43UP50GU
   os_family: Android
   browser_family: Chrome
@@ -3173,19 +2867,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 49UP50GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 49UP50GU
   os_family: Android
   browser_family: Chrome
@@ -3193,19 +2885,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 50FK30G Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.0.2569.141117
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.0.2569.141117"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 50FK30G
   os_family: Android
   browser_family: Opera
@@ -3213,19 +2903,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 50U600GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 50U600GU
   os_family: Android
   browser_family: Chrome
@@ -3233,19 +2921,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 50UK35G Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 50UK35G
   os_family: Android
   browser_family: Chrome
@@ -3253,19 +2939,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; 55UC30G_-Ver02 Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.158 Safari/537.36 OPR/47.0.2249.129167
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "47.0.2249.129167"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 55UC30G v2
   os_family: Android
   browser_family: Opera
@@ -3273,19 +2957,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 55UP50GU Build/NMF26Q; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/52.0.2743.100 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "52.0.2743.100"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 55UP50GU
   os_family: Android
   browser_family: Chrome
@@ -3293,19 +2975,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; 55UR50GR) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "76.0.3809.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: KV
+    brand: Kivi
     model: 55UR50GR
   os_family: Android
   browser_family: Chrome
@@ -3313,19 +2993,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; AFTRS Build/LVY48F) AppleWebKit/537.36 (KHTML, like Gecko) Silk/65.2.1 like Chrome/65.0.3325.144 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Mobile Silk
-    short_name: MS
     version: "65.2.1"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: L0
+    brand: Element
     model: Element 4K (2017)
   os_family: Android
   browser_family: Chrome
@@ -3333,13 +3011,11 @@
   user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 49UH664V-ZC; WEBOS3.0 05.30.02; W3_M16;)
   os:
     name: webOS
-    short_name: WOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.122"
     engine: Blink
     engine_version: ""
@@ -3353,13 +3029,11 @@
   user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; 55UJ6307-ZA; WEBOS3.5 04.70.45; W3_K3LP;)
   os:
     name: webOS
-    short_name: WOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.122"
     engine: Blink
     engine_version: ""
@@ -3373,13 +3047,11 @@
   user_agent: Mozilla/5.0 (DirectFB; U; Linux 7630; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ HbbTV/1.1.1 ( ;LGE ;GLOBAL_PLAT3 ;BR.8.97.067.B ;1.0.0.1 ;)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: "531.2"
@@ -3393,13 +3065,11 @@
   user_agent: Mozilla/5.0 (Linux; NetCast; U) AppleWwbKit/537.31 (KHTML, like Gecko) Chrome/26.0.1410.33 Safari/537.31 SmartTV/5.0
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "26.0.1410.33"
     engine: WebKit
     engine_version: ""
@@ -3413,13 +3083,11 @@
   user_agent: Mozilla/5.0 (DirectFB; U; Linux mips; en) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ LG Browser/4.0.10(+SCREEN+TUNER; LGE; 42LE5500-SA; 04.02.02; 0x00000001;); LG NetCast.TV-2010
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: LG Browser
-    short_name: LG
     version: "4.0.10"
     engine: WebKit
     engine_version: "531.2"
@@ -3433,13 +3101,11 @@
   user_agent: Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ LG Browser/5.00.00(+mouse+3D+SCREEN+TUNER; LGE; 47LM9600-NA; 06.00.00; 0x00000001;); LG NetCast.TV-2012 0
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: LG Browser
-    short_name: LG
     version: "5.00.00"
     engine: WebKit
     engine_version: "534.26"
@@ -3453,13 +3119,11 @@
   user_agent: Mozilla/5.0 (DirectFB; Linux armv7l) AppleWebKit/534.26+ (KHTML, like Gecko) Version/5.0 Safari/534.26+ HbbTV/1.1.1 ( ;LGE ;NetCast 3.0 ;1.0 ;1.0M ;)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "5.0"
     engine: WebKit
     engine_version: "534.26"
@@ -3473,13 +3137,11 @@
   user_agent: Mozilla/5.0 (Unknown; Linux armv7l) AppleWebKit/537.1+ (KHTML, like Gecko) Safari/537.1+ HbbTV/1.1.1 ( ;LGE ;NetCast 4.0 ;03.10.81 ;1.0M ;)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: "537.1"
@@ -3493,13 +3155,11 @@
   user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) QtWebEngine/5.2.1 Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED55B6J-Z; WEBOS3.0 04.30.65; W3_K2L;)
   os:
     name: webOS
-    short_name: WOS
     version: ""
     platform: ""
   client:
     type: browser
     name: QtWebEngine
-    short_name: QW
     version: "5.2.1"
     engine: WebKit
     engine_version: "537.36"
@@ -3513,13 +3173,11 @@
   user_agent: Mozilla/5.0 (Web0S; Linux/SmartTV) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/38.0.2125.122 Safari/537.36 HbbTV/1.2.1 (+DRM; LGE; OLED65C7V-Z; WEBOS3.5 04.70.30; W3_M16P;)
   os:
     name: webOS
-    short_name: WOS
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "38.0.2125.122"
     engine: Blink
     engine_version: ""
@@ -3535,7 +3193,7 @@
   client: null
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL121
   os_family: Unknown
   browser_family: Unknown
@@ -3545,7 +3203,7 @@
   client: null
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL121
   os_family: Unknown
   browser_family: Unknown
@@ -3555,7 +3213,7 @@
   client: null
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL150
   os_family: Unknown
   browser_family: Unknown
@@ -3563,19 +3221,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (+PVR; Loewe; SL150; LOH/3.10;;) CE-HTML/1.0 Config(L:slv,CC:DEU); en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL150
   os_family: GNU/Linux
   browser_family: Opera
@@ -3585,7 +3241,7 @@
   client: null
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL220
   os_family: Unknown
   browser_family: Unknown
@@ -3593,19 +3249,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.2.1 (+PVR; Loewe; SL220; LOH/4.00;;) CE-HTML/1.0 Config(L:deu,CC:CHE) NETRANGEMMH; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: LO
+    brand: Loewe
     model: SL220
   os_family: GNU/Linux
   browser_family: Opera
@@ -3613,19 +3267,17 @@
   user_agent: Mozilla/5.0 (DirectFB; U; Linux armv6l; c) AppleWebKit/531.2+ (KHTML, like Gecko) Safari/531.2+ HbbTV/1.1.1 (;Metz;MMS;;;)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: "531.2"
   device:
     type: tv
-    brand: ME
+    brand: Metz
     model: ""
   os_family: GNU/Linux
   browser_family: Safari
@@ -3633,19 +3285,17 @@
   user_agent: HbbTV/1.1.1 (;MTK;MT5396;;;) ANTGalio/3.2.0.C341.06
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.2.0"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: MK
+    brand: MediaTek
     model: MT5396
   os_family: Real-time OS
   browser_family: Unknown
@@ -3653,19 +3303,17 @@
   user_agent: HbbTV/1.2.1 (;MTK;MT5396;;;) ANTGalio/3.3.0.26.02.devel
   os:
     name: MTK / Nucleus
-    short_name: MTK
     version: ""
     platform: ""
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.3.0.26.02"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: MK
+    brand: MediaTek
     model: MT5396
   os_family: Real-time OS
   browser_family: Unknown
@@ -3673,19 +3321,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; NX-32THS100 Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: N7
+    brand: National
     model: NX-32THS100
   os_family: Android
   browser_family: Chrome
@@ -3693,19 +3339,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NEXON X1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: N8
+    brand: NEXON
     model: X1
   os_family: Android
   browser_family: Chrome
@@ -3713,19 +3357,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; NEXON X9) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.162 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.162"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: N8
+    brand: NEXON
     model: X9
   os_family: Android
   browser_family: Chrome
@@ -3733,19 +3375,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 3.2; en-us; GTV100 Build/MASTER) AppleWebKit/534.13 (KHTML, like Gecko) Version/4.0 Safari/534.13
   os:
     name: Android
-    short_name: AND
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.13"
   device:
     type: tv
-    brand: NA
+    brand: Netgear
     model: NeoTV Prime
   os_family: Android
   browser_family: Android Browser
@@ -3753,19 +3393,17 @@
   user_agent: Dalvik/2.1.0 (Linux; U; Android 7.0; SHIELD Android TV Build/NRD90M)
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tv
-    brand: NV
+    brand: Nvidia
     model: SHIELD Android TV
   os_family: Android
   browser_family: Android Browser
@@ -3773,19 +3411,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; NG3128HD) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: NZ
+    brand: NG Optics
     model: NG3128HD
   os_family: Android
   browser_family: Chrome
@@ -3793,19 +3429,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; OPENBOX A3 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: OH
+    brand: Openbox
     model: A3
   os_family: Android
   browser_family: Android Browser
@@ -3813,19 +3447,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Openbox A4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OH
+    brand: Openbox
     model: A4
   os_family: Android
   browser_family: Chrome
@@ -3833,19 +3465,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Openbox A4 Lite) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OH
+    brand: Openbox
     model: A4 Lite
   os_family: Android
   browser_family: Chrome
@@ -3853,19 +3483,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; Openbox A4 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3987.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OH
+    brand: Openbox
     model: A4 Pro
   os_family: Android
   browser_family: Chrome
@@ -3873,19 +3501,17 @@
   user_agent: Opera/9.80 (Linux i686; U; fr) Presto/2.10.287 Version/12.00 ; SC/IHD92 STB
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: OR
+    brand: Orange
     model: Livebox Play
   os_family: GNU/Linux
   browser_family: Opera
@@ -3893,19 +3519,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; OzoneHD 4K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OZ
+    brand: OzoneHD
     model: 4K
   os_family: Android
   browser_family: Chrome
@@ -3913,19 +3537,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; OzoneHD 4K TV Build/MHC19J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OZ
+    brand: OzoneHD
     model: 4K TV
   os_family: Android
   browser_family: Chrome
@@ -3933,19 +3555,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; OzoneHD T2 WiFi) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: OZ
+    brand: OzoneHD
     model: T2 WiFi
   os_family: Android
   browser_family: Chrome
@@ -3953,19 +3573,17 @@
   user_agent: Opera/9.80 (Linux mn10300; U; HbbTV/1.1.1 (+PVR; Panasonic; DIGA M9031; 3.030; ; ); en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: ""
   os_family: GNU/Linux
   browser_family: Opera
@@ -3975,7 +3593,7 @@
   client: null
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: Smart TV
   os_family: Unknown
   browser_family: Unknown
@@ -3983,19 +3601,17 @@
   user_agent: Mozilla/5.0 (FreeBSD; U; Viera; fr-FR) AppleWebKit/535.1 (KHTML, like Gecko) Viera/1.5.2 Chrome/14.0.835.202 Safari/535.1
   os:
     name: FreeBSD
-    short_name: BSD
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "14.0.835.202"
     engine: WebKit
     engine_version: "535.1"
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: Smart TV
   os_family: Unix
   browser_family: Chrome
@@ -4003,19 +3619,17 @@
   user_agent: Mozilla/5.0 (X11; FreeBSD; U; Viera; de-DE) AppleWebKit/537.11 (KHTML, like Gecko) Viera/3.10.0 Chrome/23.0.1271.97 Safari/537.11
   os:
     name: FreeBSD
-    short_name: BSD
     version: ""
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "23.0.1271.97"
     engine: WebKit
     engine_version: "537.11"
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: Smart TV
   os_family: Unix
   browser_family: Chrome
@@ -4025,7 +3639,7 @@
   client: null
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: VIERA 2011
   os_family: Unknown
   browser_family: Unknown
@@ -4035,7 +3649,7 @@
   client: null
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: VIERA 2012
   os_family: Unknown
   browser_family: Unknown
@@ -4045,7 +3659,7 @@
   client: null
   device:
     type: tv
-    brand: PA
+    brand: Panasonic
     model: VIERA 2013
   os_family: Unknown
   browser_family: Unknown
@@ -4053,19 +3667,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;PEAQ LF1V350; en) Presto/2.8.115 Version/11.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.10"
     engine: Presto
     engine_version: "2.8.115"
   device:
     type: tv
-    brand: PE
+    brand: PEAQ
     model: LF1V350
   os_family: GNU/Linux
   browser_family: Opera
@@ -4073,19 +3685,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 28HFL5009D12; ; PHILIPSTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/004.001.163.001 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: 28HFL5009D12
   os_family: GNU/Linux
   browser_family: Opera
@@ -4093,19 +3703,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; 55PUS780912; ; PHILIPSTV;  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/014.002.026.129 (PhilipsTV, 3.1.1,)en) ) Presto/2.12.407 Version/12.50'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: 55PUS780912
   os_family: GNU/Linux
   browser_family: Opera
@@ -4113,19 +3721,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; 70PUH6774_96) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: 70PUH6774/96 4K UHD
   os_family: Android
   browser_family: Chrome
@@ -4133,19 +3739,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AND1E TV Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/29.0.1547.80 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "29.0.1547.80"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: Android TV
   os_family: Android
   browser_family: Chrome
@@ -4153,19 +3757,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.2.2; AND1E Build/JDQ39) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/37.0.2062.117 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "37.0.2062.117"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: Android TV
   os_family: Android
   browser_family: Chrome
@@ -4175,7 +3777,7 @@
   client: null
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: Blu-ray Player (BDP5600)
   os_family: Unknown
   browser_family: Unknown
@@ -4185,13 +3787,12 @@
   client:
     type: browser
     name: ANTGalio
-    short_name: AG
     version: "3.3.0.26.04"
     engine: ""
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: MT5580
   os_family: Unknown
   browser_family: Unknown
@@ -4199,19 +3800,17 @@
   user_agent: Opera/9.70 (Linux armv6l ; U; CE-HTML/1.0 NETTV/2.0.2; en) Presto/2.2.1
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.70"
     engine: Presto
     engine_version: "2.2.1"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4219,19 +3818,17 @@
   user_agent: Opera/9.80 (Linux armv6l ; U; CE-HTML/1.0 NETTV/3.0.1;; en) Presto/2.6.33 Version/10.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.60"
     engine: Presto
     engine_version: "2.6.33"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4239,19 +3836,17 @@
   user_agent: Opera/9.80 (Linux armv7l; U; CE-HTML/1.0 NETTV/3.3.0; PHILIPS-AVM-2012; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4259,19 +3854,17 @@
   user_agent: Opera/9.80 (Linux i686; U; HbbTV/1.1.1 (; Philips; ; ; ; ) CE-HTML/1.0 NETTV/4.0.1; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4279,19 +3872,17 @@
   user_agent: Opera/9.80(Linux armv7l; U; CE-HTML/1.0 NETTV/3.0.1; PHILIPS-AVM-2012; xx) Presto/2.10.250 Version/11.6
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.6"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4299,19 +3890,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l; HbbTV/1.2.1 (; Philips; ; ; PHILIPSTV; )  CE-HTML/1.0 NETTV/4.4.1 SmartTvA/3.0.0 Firmware/010.001.072.040 (PhilipsTV, 3.1.1,)en) Presto/2.12.407 Version/12.50'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: NetTV Series
   os_family: GNU/Linux
   browser_family: Opera
@@ -4319,19 +3908,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; QM161E Build/OPR5.170623.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/32.0.2128.0 OMI/4.8.0.142.Racer2.47
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.8.0.142"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: QM161E
   os_family: Android
   browser_family: Opera
@@ -4339,19 +3926,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; QM163E Build/OPR5.170623.014) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/32.0.2128.0 OMI/4.8.0.142.Racer2.51
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.8.0.142"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: QM163E
   os_family: Android
   browser_family: Opera
@@ -4359,19 +3944,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; QM164E Build/NZH54D) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/32.0.2128.0 OMI/4.8.0.142.Racer.70
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.8.0.142"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: QM164E
   os_family: Android
   browser_family: Opera
@@ -4379,19 +3962,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; TPM171E Build/OC) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/73.0.3683.90 Safari/537.36 OPR/52.4.2517.140781
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "52.4.2517.140781"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: TPM171E
   os_family: Android
   browser_family: Opera
@@ -4399,19 +3980,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 9.0; TPM191E Build/PTT1.181130.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.2623.112 Safari/537.36 OPR/32.0.2128.0 OMI/4.8.0.129.Sprinter7.124
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.8.0.129"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: PH
+    brand: Philips
     model: TPM191E
   os_family: GNU/Linux
   browser_family: Opera
@@ -4419,19 +3998,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; POV_TV-HDMI-KB-01 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: PV
+    brand: Point of View
     model: HDMI Smart TV Dongle
   os_family: Android
   browser_family: Android Browser
@@ -4439,19 +4016,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; nl-nl; POV_TV-HDMI-200BT Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: PV
+    brand: Point of View
     model: Mini PC HDMI Dongle
   os_family: Android
   browser_family: Android Browser
@@ -4459,19 +4034,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; R-TV BOX MINI+ AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box MINI+
   os_family: Android
   browser_family: Chrome
@@ -4479,19 +4052,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; R-TV BOXR10.03.d32 AppleWebKit/537.36 KHTML, like Gecko Chrome/73.0.3683.90 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "73.0.3683.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box R10
   os_family: Android
   browser_family: Chrome
@@ -4499,19 +4070,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; R-TV BOX S10 AppleWebKit/537.36 KHTML, like Gecko Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box S10
   os_family: Android
   browser_family: Chrome
@@ -4519,19 +4088,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; R-TV BOX X10 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box X10
   os_family: Android
   browser_family: Chrome
@@ -4539,19 +4106,17 @@
   user_agent: Mozilla/5.0 Linux; Android 8.1.0; R-TV BOX X10 PRO Build/OPM1.171019.011 AppleWebKit/537.36 KHTML, like Gecko Chrome/65.0.3325.109 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box X10 PRO
   os_family: Android
   browser_family: Chrome
@@ -4559,19 +4124,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; R-TV BOX X99.02.00.d32 Build/NHG47K; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/74.0.3729.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "74.0.3729.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R2
+    brand: R-TV
     model: Box X99
   os_family: Android
   browser_family: Chrome
@@ -4579,19 +4142,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; Rombica Infinity K8 Build/LMY48G) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/39.0.2171.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "39.0.2171.93"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Infinity K8
   os_family: Android
   browser_family: Chrome
@@ -4599,19 +4160,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Rombica Smart Box 4K V001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Smart Box 4K V001
   os_family: Android
   browser_family: Chrome
@@ -4619,19 +4178,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Rombica Smart Box Quad Build/SBQ-A0310) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/30.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "30.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Smart Box Quad
   os_family: Android
   browser_family: Chrome
@@ -4639,19 +4196,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; Rombica Smart Box Ultra HD v002) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Smart Box Ultra HD v002
   os_family: Android
   browser_family: Chrome
@@ -4659,19 +4214,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 7.1; Rombica Smart Box v005) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.2.90.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.2.90.01"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Smart Box v005
   os_family: Android
   browser_family: Unknown
@@ -4679,19 +4232,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; SSQ-A0500) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.143"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: R3
+    brand: Rombica
     model: Smart Stick 4K
   os_family: Android
   browser_family: Chrome
@@ -4699,19 +4250,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; tr-tr; MK808 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: RI
+    brand: Rikomagic
     model: MK808
   os_family: Android
   browser_family: Android Browser
@@ -4719,19 +4268,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; fr-fr; mk808b Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: RI
+    brand: Rikomagic
     model: MK808b
   os_family: Android
   browser_family: Android Browser
@@ -4741,7 +4288,7 @@
   client: null
   device:
     type: tv
-    brand: RK
+    brand: Roku
     model: Digital Video Player
   os_family: Unknown
   browser_family: Unknown
@@ -4749,19 +4296,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.2; TB-PO1 Build/NHG47L) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/56.0.2924.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "56.0.2924.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: S9
+    brand: Savio
     model: TB-PO1
   os_family: Android
   browser_family: Chrome
@@ -4771,7 +4316,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: ""
   os_family: Unknown
   browser_family: Unknown
@@ -4779,19 +4324,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; GT-B9150 Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Home Sync
   os_family: Android
   browser_family: Android Browser
@@ -4799,13 +4342,12 @@
   user_agent: Mozilla/5.0 (SmartHub; SMART-TV; U; Linux/SmartTV; Maple2012)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV
   os_family: GNU/Linux
   browser_family: Unknown
@@ -4813,19 +4355,17 @@
   user_agent: Mozilla/5.0 (SMART-TV; X11; Linux i686) AppleWebKit/535.20+ (KHTML, like Gecko) Version/5.0 Safari/535.20+
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: "5.0"
     engine: WebKit
     engine_version: "535.20"
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV
   os_family: GNU/Linux
   browser_family: Safari
@@ -4833,19 +4373,17 @@
   user_agent: Mozilla/5.0 (SMART-TV; Linux; Tizen 2.3) AppleWebkit/538.1 (KHTML, like Gecko) SamsungBrowser/1.0 TV Safari/538.1
   os:
     name: Tizen
-    short_name: TIZ
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "1.0"
     engine: WebKit
     engine_version: "538.1"
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV
   os_family: Other Mobile
   browser_family: Chrome
@@ -4855,7 +4393,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV 2011
   os_family: Unknown
   browser_family: Unknown
@@ -4865,7 +4403,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV 2012
   os_family: Unknown
   browser_family: Unknown
@@ -4875,7 +4413,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV 2013
   os_family: Unknown
   browser_family: Unknown
@@ -4885,7 +4423,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV 2014
   os_family: Unknown
   browser_family: Unknown
@@ -4895,13 +4433,12 @@
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: Smart TV 2017
   os_family: Unknown
   browser_family: Chrome
@@ -4911,7 +4448,7 @@
   client: null
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: SMT-E5015
   os_family: Unknown
   browser_family: Unknown
@@ -4919,19 +4456,17 @@
   user_agent: Mozilla/5.0 (Linux; olleh tv; U; xx; SMT-E5015) AppleWebKit/536.25 (KHTML, like Gecko) AltiBrowser/3.0.4 (olleh tv; Large Screen) Safari/536.25
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Safari
-    short_name: SF
     version: ""
     engine: WebKit
     engine_version: "536.25"
   device:
     type: tv
-    brand: SA
+    brand: Samsung
     model: SMT-E5015
   os_family: GNU/Linux
   browser_family: Safari
@@ -4941,7 +4476,7 @@
   client: null
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: Aquos Net Plus
   os_family: Unknown
   browser_family: Unknown
@@ -4951,13 +4486,12 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.1.5"
     engine: WebKit
     engine_version: "531.2"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: Aquos Net Plus
   os_family: Unknown
   browser_family: Unknown
@@ -4965,19 +4499,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; en) Presto/2.8.115 Version/11.10 AQUOS-AS/1.0 LC-40LE835X
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.10"
     engine: Presto
     engine_version: "2.8.115"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LC-40LE835X
   os_family: GNU/Linux
   browser_family: Opera
@@ -4987,13 +4519,12 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.0.5"
     engine: WebKit
     engine_version: "531.2"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LC-46LX840H
   os_family: Unknown
   browser_family: Unknown
@@ -5003,13 +4534,12 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.1.6"
     engine: WebKit
     engine_version: "531.2"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LC-60LX850H
   os_family: Unknown
   browser_family: Unknown
@@ -5019,13 +4549,12 @@
   client:
     type: browser
     name: Espial TV Browser
-    short_name: ES
     version: "6.1.12"
     engine: WebKit
     engine_version: "531.2"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LC-60UQ10E
   os_family: Unknown
   browser_family: Unknown
@@ -5033,19 +4562,17 @@
   user_agent: Opera/9.80 (Linux mips; U; NETRANGEMMH; Sharp; HbbTV/1.1.1; CE-HTML/1.0; LE542E; FT; LC:deu; CC:che;; en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LE542E
   os_family: GNU/Linux
   browser_family: Opera
@@ -5053,19 +4580,17 @@
   user_agent: Opera/9.80 (Linux sh4; HbbTV/1.2.1 (;Sharp;LE652;v0.1.43.5;;) CE-HTML/1.0 Config(L:deu,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LE652
   os_family: GNU/Linux
   browser_family: Opera
@@ -5073,19 +4598,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 ( ; Sharp; LE737; 690.1; 1.32;); en) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LE737
   os_family: GNU/Linux
   browser_family: Opera
@@ -5093,19 +4616,17 @@
   user_agent: Opera/9.80 (Linux sh4; HbbTV/1.2.1 (;Sharp;LE750;v0.100;;) CE-HTML/1.0 Config(L:eng,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LE750
   os_family: GNU/Linux
   browser_family: Opera
@@ -5113,19 +4634,17 @@
   user_agent: Opera/9.80 (Linux sh4; HbbTV/1.2.1 (;Sharp;LE752;v0.1.18.1;;) CE-HTML/1.0 Config(L:eng,CC:DEU) NETRANGEMMH) Presto/2.12.362 Version/12.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.10"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: LE752
   os_family: GNU/Linux
   browser_family: Opera
@@ -5133,19 +4652,17 @@
   user_agent: Opera/9.80 (Linux mips; U; ; xx) Presto/2.10.287 Version/12.00 HbbTV/1.1.1 (; CUS:SHARP; MB95; 2.1.9.o; 1.0;) CE-HTML/1.0 NETRANGEMMH iplayerV3
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: MB95
   os_family: GNU/Linux
   browser_family: Opera
@@ -5153,19 +4670,17 @@
   user_agent: Opera/9.80 (Linux mips; ) Presto/2.12.407 Version/12.51 MB90/3.3.8.e (SHARP, Si2156LG32, wired) HbbTV/1.1.1 (; CUS:SHARP; MB90; 3.3.8.e; 1.0;) CE-HTML/1.0 NETRANGEMMH iplayerV3
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.51"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: SH
+    brand: Sharp
     model: Si2156LG32
   os_family: GNU/Linux
   browser_family: Opera
@@ -5173,19 +4688,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; Skyworth 8K55 E680 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
   device:
     type: tv
-    brand: SK
+    brand: Skyworth
     model: 8K55 E680
   os_family: Android
   browser_family: Android Browser
@@ -5195,7 +4708,7 @@
   client: null
   device:
     type: tv
-    brand: SK
+    brand: Skyworth
     model: HC7620
   os_family: Unknown
   browser_family: Unknown
@@ -5203,19 +4716,17 @@
   user_agent: Opera/9.80 (Linux armv6l; Opera TV Store/5606) Presto/2.12.362 Version/12.11 Model/Sony-BDP9G_AXD SonyCEBrowser/1.0 (BDP9G_AXD; BDP2014/M20.R.0164; TWN)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.11"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: BDP9G AXD
   os_family: GNU/Linux
   browser_family: Opera
@@ -5223,19 +4734,17 @@
   user_agent: Opera/9.80 (Linux armv6l; Opera TV Store/5599; (SonyBDP/BDV13)) Presto/2.12.362 Version/12.11
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.11"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Blu-ray Player
   os_family: GNU/Linux
   browser_family: Opera
@@ -5243,19 +4752,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BRAVIA 2015 Build/NRD91N.S34; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/71.0.3578.99 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "71.0.3578.99"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 2015
   os_family: Android
   browser_family: Chrome
@@ -5263,19 +4770,17 @@
   user_agent: TV Bro/1.0 Mozilla/5.0 (Linux; Android 8.0.0; BRAVIA 2K GB ATV3 Build/OPR2.170623.027.S30; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/79.0.3945.93 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: TV Bro
-    short_name: TV
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 2K GB ATV3
   os_family: Android
   browser_family: Chrome
@@ -5283,19 +4788,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BRAVIA 4K 2015 Build/NRD91N.S34) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 4K 2015
   os_family: Android
   browser_family: Chrome
@@ -5303,19 +4806,17 @@
   user_agent: TV Bro/1.0 Mozilla/5.0 (Linux; Android 7.0; BRAVIA 4K GB Build/NRD91N.S139; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/77.0.3865.92 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: TV Bro
-    short_name: TV
     version: "1.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 4K GB
   os_family: Android
   browser_family: Chrome
@@ -5323,19 +4824,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; BRAVIA 4K GB ATV3) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 4K GB ATV3
   os_family: Android
   browser_family: Chrome
@@ -5343,19 +4842,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0.0; BRAVIA 4K UR2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: Bravia 4K UR2
   os_family: Android
   browser_family: Chrome
@@ -5363,19 +4860,17 @@
   user_agent: Opera/9.80 (Linux armv7l; Opera TV Store/6219) Presto/2.12.407 Version/12.50 Model/Sony-KD-55X8500B SonyCEBrowser/1.0 (KD-55X8500B; CTV2014/PKG2.263GAA; AUS)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.50"
     engine: Presto
     engine_version: "2.12.407"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KD-55X8500B
   os_family: GNU/Linux
   browser_family: Opera
@@ -5383,19 +4878,17 @@
   user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KD-55XD8577; v3.925; 2015;) sony.hbbtv.tv.2015HE
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.2.12.48"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KD-55XD8577
   os_family: GNU/Linux
   browser_family: Opera
@@ -5403,19 +4896,17 @@
   user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/42.0.2311.152 Safari/537.36 OPR/29.0.1803.0 OMI/4.5.23.37.ALSAN5.131 HbbTV/1.2.1 (; Sony; KD-65ZD9; v1.602671100; 2016;) sony.hbbtv.tv.2016HE
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.5.23.37"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KD-65ZD9
   os_family: GNU/Linux
   browser_family: Opera
@@ -5423,19 +4914,17 @@
   user_agent: Opera/9.80 (Linux mips; Opera TV Store/4510; U; en) Presto/2.10.250 Version/11.60 Model/Sony-KDL-32EX550 SonyCEBrowser/1.0 (KDL-32EX550; CTV/PKG2.120GAA; IND)
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL-32EX550
   os_family: GNU/Linux
   browser_family: Opera
@@ -5443,19 +4932,17 @@
   user_agent: Mozilla/5.0 (Linux armv7l) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/35.0.1916.153 Safari/537.36 OPR/22.0.1481.0 OMI/4.2.12.48.ALSAN3.122 HbbTV/1.2.1 (; Sony; KDL-65W859C; v3.925; 2015;) sony.hbbtv.tv.2015HE
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.2.12.48"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL-65W859
   os_family: GNU/Linux
   browser_family: Opera
@@ -5463,19 +4950,17 @@
   user_agent: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL32CX525; PKG4.008EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.00"
     engine: Presto
     engine_version: "2.7.61"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL32CX525
   os_family: GNU/Linux
   browser_family: Opera
@@ -5483,19 +4968,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l; U;  HbbTV/1.1.1 (; Sony; KDL40HX758; PKG1.212EUA; 2013;);; en) Presto/2.10.287 Version/12.00'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL40HX758
   os_family: GNU/Linux
   browser_family: Opera
@@ -5503,19 +4986,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l;  HbbTV/1.1.1 (; Sony; KDL42W805A; PKG3.105EUA; 2013;); ) Presto/2.12.362 Version/12.11'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.11"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL42W805
   os_family: GNU/Linux
   browser_family: Opera
@@ -5523,19 +5004,17 @@
   user_agent: Opera/9.80 (Linux armv7l; InettvBrowser/2.2 (00014A;SonyDTV115;0002;0100) KDL42W805A; CC/GBR) Presto/2.12.362 Version/12.11
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.11"
     engine: Presto
     engine_version: "2.12.362"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL42W805A
   os_family: GNU/Linux
   browser_family: Opera
@@ -5543,19 +5022,17 @@
   user_agent: 'Opera/9.80 (Linux armv7l; U;  HbbTV/1.1.1 (; Sony; KDL46EX650; PKG0.002EUA; 2013;);; en) Presto/2.10.287 Version/12.00'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL46EX650
   os_family: GNU/Linux
   browser_family: Opera
@@ -5563,19 +5040,17 @@
   user_agent: 'Opera/9.80 (Linux mips; U;  HbbTV/1.1.1 (; Sony; KDL55NX725; PKG4.012EUA; 2011;);; en) Presto/2.7.61 Version/11.00'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.00"
     engine: Presto
     engine_version: "2.7.61"
   device:
     type: tv
-    brand: SO
+    brand: Sony
     model: KDL55NX725
   os_family: GNU/Linux
   browser_family: Opera
@@ -5585,7 +5060,7 @@
   client: null
   device:
     type: tv
-    brand: SR
+    brand: Smart
     model: CX10
   os_family: Unknown
   browser_family: Unknown
@@ -5595,7 +5070,7 @@
   client: null
   device:
     type: tv
-    brand: SR
+    brand: Smart
     model: VX10
   os_family: Unknown
   browser_family: Unknown
@@ -5605,7 +5080,7 @@
   client: null
   device:
     type: tv
-    brand: SR
+    brand: Smart
     model: ZAPPIX HD+
   os_family: Unknown
   browser_family: Unknown
@@ -5613,19 +5088,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.4; fr-fr; STOREX LinkBox Build/20120103) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
   device:
     type: tv
-    brand: ST
+    brand: Storex
     model: LinkBox
   os_family: Android
   browser_family: Android Browser
@@ -5635,7 +5108,7 @@
   client: null
   device:
     type: tv
-    brand: SV
+    brand: Selevision
     model: EMC1000i
   os_family: Unknown
   browser_family: Unknown
@@ -5645,7 +5118,7 @@
   client: null
   device:
     type: tv
-    brand: SV
+    brand: Selevision
     model: EMC1000i
   os_family: Unknown
   browser_family: Unknown
@@ -5653,19 +5126,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K32DLX9HS Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: T0
+    brand: TD Systems
     model: K32DLX9HS
   os_family: Android
   browser_family: Chrome
@@ -5673,19 +5144,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; K40DLM8FS Build/NMF26Q) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/65.0.3325.109 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "65.0.3325.109"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: T0
+    brand: TD Systems
     model: K40DLM8FS
   os_family: Android
   browser_family: Chrome
@@ -5693,19 +5162,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; K40DLX9FS Build/NRD90M; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/51.0.2704.91 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "51.0.2704.91"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: T0
+    brand: TD Systems
     model: K40DLX9FS
   os_family: Android
   browser_family: Chrome
@@ -5713,19 +5180,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/TCL;SW-Version/V8-T56FSPS-LF1V032;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPS-LF1V032 TCL,32D1820,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TC
+    brand: TCL
     model: 32D1820
   os_family: GNU/Linux
   browser_family: Opera
@@ -5733,19 +5198,17 @@
   user_agent: Opera/9.80 (Linux mips; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;TCL LF1V042; en) Presto/2.10.287 Version/12.00
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: TC
+    brand: TCL
     model: LF1V042
   os_family: GNU/Linux
   browser_family: Opera
@@ -5753,19 +5216,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;TCL LF1V349; en) Presto/2.8.115 Version/11.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.10"
     engine: Presto
     engine_version: "2.8.115"
   device:
     type: tv
-    brand: TC
+    brand: TCL
     model: LF1V349
   os_family: GNU/Linux
   browser_family: Opera
@@ -5773,19 +5234,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Vestel; MB95; 1.0; 1.0; ); en) Presto/2.10.287 Version/12.00 HbbTV/1.1.1 (; CUS:TELEFUNKEN; MB95; 2.1.4; 1.0;) CE-HTML/1.0 NETRANGEMMH iplayerV3
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: MB95
   os_family: GNU/Linux
   browser_family: Opera
@@ -5793,19 +5252,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TF-LED32S39T2S Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED32S39T2S
   os_family: Android
   browser_family: Chrome
@@ -5813,19 +5270,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TF-LED32S52T2S Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED32S52T2S
   os_family: Android
   browser_family: Chrome
@@ -5833,19 +5288,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TF-LED32S58T2S_-Ver01 Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED32S58T2S
   os_family: Android
   browser_family: Chrome
@@ -5853,19 +5306,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TF-LED32S59T2S Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED32S59T2S
   os_family: Android
   browser_family: Chrome
@@ -5873,19 +5324,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; TF-LED32S70T2S Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED32S70T2S
   os_family: Android
   browser_family: Chrome
@@ -5893,19 +5342,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0; TF-LED65S75T2SU Build/MRA58K; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: TL
+    brand: Telefunken
     model: TF-LED65S75T2SU
   os_family: Android
   browser_family: Chrome
@@ -5913,19 +5360,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;THOMSON LF1V017; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: LF1V017
   os_family: GNU/Linux
   browser_family: Opera
@@ -5933,19 +5378,17 @@
   user_agent: Opera/9.80 (Linux armv6l; U; NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;THOM LF1V375; en) Presto/2.10.250 Version/11.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.60"
     engine: Presto
     engine_version: "2.10.250"
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: LF1V375
   os_family: GNU/Linux
   browser_family: Opera
@@ -5953,19 +5396,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V039;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V039 THOMSON,T28D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T28D18SFS-01B 28.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -5973,19 +5414,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V048;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V048 THOMSON,T32D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T32D18SFS-01B 32.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -5993,19 +5432,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V092;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V092 THOMSON,T32RTM5040,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T32RTM5040 32.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6013,19 +5450,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V039;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V039 THOMSON,T40D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T40D18SFS-01B 40.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6033,19 +5468,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V039;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V039 THOMSON,T43D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T43D18SFS-01B 43.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6053,19 +5486,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V069;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V069 THOMSON,T43FSL5031,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T43FSL5031 43.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6073,19 +5504,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V039;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V039 THOMSON,T49D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T49D18SFS-01B 49.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6093,19 +5522,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V092;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V092 THOMSON,T55D18DFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T55D18DFS-01B 55.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6113,19 +5540,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V039;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V039 THOMSON,T55D18SFS-01B,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: T55D18SFS-01B 55.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6133,19 +5558,17 @@
   user_agent: Opera/9.80 X11;Linux armv7i;NETRANGEMMH;HbbTV/1.1.1;CE-HTML/1.0;Vendor/THOMSON;SW-Version/V8-T56FSPK-LF1V096;Cnt/GBR;Lan/eng;U;en AppleWebKit/534.24 KHTML, like Gecko Safari/534.24, Digital-TV/V8-T56FSPK-LF1V096 THOMSON,TB28D19DHS-01,wireless
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "9.80"
     engine: Presto
     engine_version: ""
   device:
     type: tv
-    brand: TN
+    brand: Thomson
     model: TB28D19DHS-01 28.0"
   os_family: GNU/Linux
   browser_family: Opera
@@ -6155,13 +5578,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.1"
     engine: NetFront
     engine_version: "4.1"
   device:
     type: tv
-    brand: TS
+    brand: Toshiba
     model: ""
   os_family: Unknown
   browser_family: NetFront
@@ -6169,19 +5591,17 @@
   user_agent: Opera/9.80 (Linux armv7l ; U; HbbTV/1.1.1 (; TOSHIBA; 55WL863; 19.5.61.15; 3; ) ; ToshibaTP/1.3.0 (+VIDEO_X_MS_ASF+VIDEO_MP4+AUDIO_MPEG+AUDIO_MP4+DRM+3D) ; de) Presto/2.6.33 Version/10.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.60"
     engine: Presto
     engine_version: "2.6.33"
   device:
     type: tv
-    brand: TS
+    brand: Toshiba
     model: 55WL863
   os_family: GNU/Linux
   browser_family: Opera
@@ -6189,19 +5609,17 @@
   user_agent: Opera/9.80 (Linux armv7l ; U; HbbTV/1.1.1 (; TOSHIBA; 55ZL1; 19.7.61.14; 3; ) ; ToshibaTP/1.3.0 (+VIDEO_MP4+AUDIO_MPEG+AUDIO_MP4) ; de) Presto/2.6.33 Version/10.60
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "10.60"
     engine: Presto
     engine_version: "2.6.33"
   device:
     type: tv
-    brand: TS
+    brand: Toshiba
     model: 55ZL1
   os_family: GNU/Linux
   browser_family: Opera
@@ -6211,7 +5629,7 @@
   client: null
   device:
     type: tv
-    brand: TT
+    brand: TechnoTrend
     model: S-855
   os_family: Unknown
   browser_family: Unknown
@@ -6219,19 +5637,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat DigiCorder ISIO C; de) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: TX
+    brand: TechniSat
     model: DigiCorder ISIO C
   os_family: GNU/Linux
   browser_family: Opera
@@ -6239,19 +5655,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat DigiCorder ISIO S; de) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: TX
+    brand: TechniSat
     model: DigiCorder ISIO S
   os_family: GNU/Linux
   browser_family: Opera
@@ -6259,19 +5673,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO C; de) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: TX
+    brand: TechniSat
     model: Digit ISIO C
   os_family: GNU/Linux
   browser_family: Opera
@@ -6279,19 +5691,17 @@
   user_agent: Opera/9.80 (Linux sh4; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat Digit ISIO S; de) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: TX
+    brand: TechniSat
     model: Digit ISIO S
   os_family: GNU/Linux
   browser_family: Opera
@@ -6299,19 +5709,17 @@
   user_agent: Opera/9.80 (Linux i686; U; HbbTV/1.1.1 (;;;;;); CE-HTML; TechniSat MultyVision ISIO; de) Presto/2.9.167 Version/11.50
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x86
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.50"
     engine: Presto
     engine_version: "2.9.167"
   device:
     type: tv
-    brand: TX
+    brand: TechniSat
     model: MultyVision ISIO
   os_family: GNU/Linux
   browser_family: Opera
@@ -6319,19 +5727,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9; UGOOS-AM6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3962.2 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "80.0.3962.2"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: UG
+    brand: Ugoos
     model: AM6
   os_family: Android
   browser_family: Chrome
@@ -6339,19 +5745,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; VMP-011-81) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: V7
+    brand: Vinga
     model: "011"
   os_family: Android
   browser_family: Chrome
@@ -6359,19 +5763,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; VMP-021-82) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.136 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "79.0.3945.136"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: V7
+    brand: Vinga
     model: "021"
   os_family: Android
   browser_family: Chrome
@@ -6379,19 +5781,17 @@
   user_agent: Mozilla/5.0 (Linux; arm; Android 6.0.1; VMP-041-162) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.143 YaBrowser/19.7.2.90.01 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ARM
   client:
     type: browser
     name: Yandex Browser
-    short_name: YA
     version: "19.7.2.90.01"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: V7
+    brand: Vinga
     model: "041"
   os_family: Android
   browser_family: Unknown
@@ -6399,19 +5799,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; VESTA32LD86) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: V8
+    brand: Vesta
     model: SmartT V2.0 32LD86S
   os_family: Android
   browser_family: Chrome
@@ -6421,13 +5819,12 @@
   client:
     type: browser
     name: NetFront
-    short_name: NF
     version: "4.1"
     engine: NetFront
     engine_version: "4.1"
   device:
     type: tv
-    brand: VT
+    brand: Vestel
     model: MB70
   os_family: Unknown
   browser_family: NetFront
@@ -6435,19 +5832,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Vestel; MB95; 1.0; 1.0; ); en) Presto/2.10.287 Version/12.00
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: VT
+    brand: Vestel
     model: MB95
   os_family: GNU/Linux
   browser_family: Opera
@@ -6455,19 +5850,17 @@
   user_agent: Opera/9.80 (Linux armv7l; U; HbbTV/1.1.1 (;tv2n;videoweb;1.0.0;1.0;); en) Presto/2.8.115 Version/11.10
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ARM
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "11.10"
     engine: Presto
     engine_version: "2.8.115"
   device:
     type: tv
-    brand: VW
+    brand: Videoweb
     model: tv2n
   os_family: GNU/Linux
   browser_family: Opera
@@ -6475,19 +5868,17 @@
   user_agent: Opera/9.80 (Linux mips; U; HbbTV/1.1.1 (; Opera Software; videowebtv; ; ; ); en) Presto/2.10.287 Version/12.00
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "12.00"
     engine: Presto
     engine_version: "2.10.287"
   device:
     type: tv
-    brand: VW
+    brand: Videoweb
     model: VideoWeb TV
   os_family: GNU/Linux
   browser_family: Opera
@@ -6495,19 +5886,17 @@
   user_agent: Mozilla/5.0 (Linux; GoogleTV 3.2; VAP430 Build/MASTER) AppleWebKit/534.24 (KHTML, like Gecko) Chrome/11.0.696.77 Safari/534.24
   os:
     name: Google TV
-    short_name: GTV
     version: "3.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "11.0.696.77"
     engine: WebKit
     engine_version: "534.24"
   device:
     type: tv
-    brand: VZ
+    brand: Vizio
     model: VAP430
   os_family: Google TV
   browser_family: Chrome
@@ -6515,19 +5904,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-LED32M04S Build/M5C14J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: X2
+    brand: Soundmax
     model: SM-LED32M04S
   os_family: Android
   browser_family: Chrome
@@ -6535,19 +5922,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; SM-LED32M11S Build/M5C14J; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/48.0.2542.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "48.0.2542.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: X2
+    brand: Soundmax
     model: SM-LED32M11S
   os_family: Android
   browser_family: Chrome
@@ -6555,19 +5940,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.4; SM-LED40M04S) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.62 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.4"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.62"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: X2
+    brand: Soundmax
     model: SM-LED40M04S
   os_family: Android
   browser_family: Chrome
@@ -6575,19 +5958,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; NEXBOX-A1 Build/NEXBOX-A1; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/44.0.2403.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: A1
   os_family: Android
   browser_family: Chrome
@@ -6595,19 +5976,17 @@
   user_agent: Mozilla/5.0 Linux; Android 6.0.1; NEXBOX-A5 Build/NEXBOX-A5-RTL8723BS; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/44.0.2403.119 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "44.0.2403.119"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: A5
   os_family: Android
   browser_family: Chrome
@@ -6615,19 +5994,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; NEXBOX-A95X AppleWebKit/537.36 KHTML, like Gecko Chrome/74.0.3729.157 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "74.0.3729.157"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: A95X
   os_family: Android
   browser_family: Chrome
@@ -6635,19 +6012,17 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.2; NEXBOX-A95X Build/NEXBOX-A95X; wv AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/72.0.3626.105 Safari/537.36 YandexSearch/8.11/apad YandexSearchBrowser/8.11
   os:
     name: Android
-    short_name: AND
     version: "7.1.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "72.0.3626.105"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: A95X
   os_family: Android
   browser_family: Chrome
@@ -6655,19 +6030,17 @@
   user_agent: Mozilla/5.0 Linux; Android 4.4.2; MXQ-NEXBOX Build/MXQ.NEXBOX.SSV6051P AppleWebKit/537.36 KHTML, like Gecko Chrome/67.0.3396.87 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "67.0.3396.87"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: MXQ
   os_family: Android
   browser_family: Chrome
@@ -6675,19 +6048,17 @@
   user_agent: Mozilla/5.0 Linux; Android 5.1.1; MXQ-Pro-NEXBOX Build/MXQ-Pro-NEXBOX AppleWebKit/537.36 KHTML, like Gecko Version/4.0 Chrome/39.0.0.0 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "39.0.0.0"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XB
+    brand: NEXBOX
     model: MXQ Pro
   os_family: Android
   browser_family: Chrome
@@ -6695,19 +6066,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; XGODY_X96 Build/MHC19J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/60.0.3112.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "60.0.3112.116"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XG
+    brand: Xgody
     model: X96
   os_family: Android
   browser_family: Chrome
@@ -6715,19 +6084,17 @@
   user_agent: Dalvik/1.6.0 (Linux; U; Android 4.4.2; MiBOX1S Build/KOT49H)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: Mi Box 1S
   os_family: Android
   browser_family: Android Browser
@@ -6735,19 +6102,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; MiBOX2 Build/KOT49H; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/62.0.3202.97 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "62.0.3202.97"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: Mi Box 2
   os_family: Android
   browser_family: Chrome
@@ -6755,19 +6120,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 6.0.1; MIBOX3 Build/MHC19J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.59.E9103576.114
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.9.0.59"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: Mi Box 3
   os_family: GNU/Linux
   browser_family: Opera
@@ -6775,19 +6138,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1; MiBOX3_PRO) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.90 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "78.0.3904.90"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: Mi Box 3 Pro
   os_family: Android
   browser_family: Chrome
@@ -6795,19 +6156,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 8.1; MIBOX4 Build/OPM1.171019.011) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.59.E9103576.114
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.9.0.59"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: Mi Box 4
   os_family: GNU/Linux
   browser_family: Opera
@@ -6815,19 +6174,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; MiTV4-ANSM0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.93 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "79.0.3945.93"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4A
   os_family: Android
   browser_family: Chrome
@@ -6835,19 +6192,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; zh-cn; MiTV4A Build/MHC19J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.132 MQQBrowser/8.4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: QQ Browser
-    short_name: QQ
     version: "8.4"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4A
   os_family: Android
   browser_family: Unknown
@@ -6855,19 +6210,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 8.1.0; MiTV-AXSO0 Build/OPM1.171019.011; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/61.0.3163.98 Safari/537.36 OPR/31.0.2254.122029
   os:
     name: Android
-    short_name: AND
     version: "8.1.0"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "31.0.2254.122029"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4A
   os_family: Android
   browser_family: Opera
@@ -6875,19 +6228,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 6.0.1; MiTV4C Build/MHC19J) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.59.E9103576.114
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.9.0.59"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4C
   os_family: GNU/Linux
   browser_family: Opera
@@ -6895,19 +6246,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 9.0; MiTV-MSSP1 Build/PTT1.181019.001) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/57.0.2987.132 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "9.0"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "57.0.2987.132"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4S
   os_family: Android
   browser_family: Chrome
@@ -6915,19 +6264,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 6.0; MiTV4S Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.59.E9103576.114
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.9.0.59"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4S
   os_family: GNU/Linux
   browser_family: Opera
@@ -6935,19 +6282,17 @@
   user_agent: Mozilla/5.0 (Linux; Andr0id 6.0; MiTV4X Build/MRA58K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Safari/537.36 OPR/40.0.2207.0 OMI/4.9.0.59.E9103576.114
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Devices
-    short_name: OH
     version: "4.9.0.59"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XI
+    brand: Xiaomi
     model: MiTV 4X
   os_family: GNU/Linux
   browser_family: Opera
@@ -6955,19 +6300,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; HST 260) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.101 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "75.0.3770.101"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: XR
+    brand: Xoro
     model: HST 260
   os_family: Android
   browser_family: Chrome
@@ -6975,19 +6318,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.0; ZIDOO_H6 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.108"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: H6 Pro
   os_family: Android
   browser_family: Chrome
@@ -6995,19 +6336,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 4.4.2; ZIDOO_X1 Build/KOT49H) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.157 Safari/537.36 OPR/53.0.2569.141117
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
     type: browser
     name: Opera
-    short_name: OP
     version: "53.0.2569.141117"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: X1
   os_family: Android
   browser_family: Opera
@@ -7015,19 +6354,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ZIDOO_X5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/77.0.3865.116 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "77.0.3865.116"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: X5
   os_family: Android
   browser_family: Chrome
@@ -7035,19 +6372,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 5.1.1; ZIDOO_X6 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.89 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "5.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "76.0.3809.89"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: X6 Pro
   os_family: Android
   browser_family: Chrome
@@ -7055,19 +6390,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 6.0.1; ZIDOO_X8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: X8
   os_family: Android
   browser_family: Chrome
@@ -7075,19 +6408,17 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 6.0.1; en-US; ZIDOO_X9S Build/MOB30J) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/57.0.2987.108 UCBrowser/12.13.0.1207 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "6.0.1"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "12.13.0.1207"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: X9S
   os_family: Android
   browser_family: Unknown
@@ -7095,19 +6426,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 7.1.1; ZIDOO_Z10) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.96 Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "78.0.3904.96"
     engine: Blink
     engine_version: ""
   device:
     type: tv
-    brand: ZI
+    brand: Zidoo
     model: Z10
   os_family: Android
   browser_family: Chrome

--- a/Tests/fixtures/unknown.yml
+++ b/Tests/fixtures/unknown.yml
@@ -15,7 +15,6 @@
   client:
     type: browser
     name: Amaya
-    short_name: AM
     version: "9.51"
     engine: ""
     engine_version: ""
@@ -44,7 +43,6 @@
   client:
     type: browser
     name: Chrome Webview
-    short_name: CV
     version: "80.0.3987.117"
     engine: Blink
     engine_version: ""
@@ -60,7 +58,6 @@
   client:
     type: browser
     name: Dillo
-    short_name: DI
     version: "0.8.5"
     engine: Dillo
     engine_version: "0.8.5"
@@ -102,7 +99,6 @@
   client:
     type: browser
     name: HotJava
-    short_name: HJ
     version: "1.1.2"
     engine: ""
     engine_version: ""
@@ -118,7 +114,6 @@
   client:
     type: browser
     name: Lynx
-    short_name: LX
     version: "2.8.8"
     engine: Text-based
     engine_version: ""
@@ -134,7 +129,6 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.2"
     engine: ""
     engine_version: ""
@@ -150,7 +144,6 @@
   client:
     type: browser
     name: Openwave Mobile Browser
-    short_name: OV
     version: "6.2.3.8"
     engine: ""
     engine_version: ""
@@ -166,7 +159,6 @@
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "5.0.22371"
     engine: Presto
     engine_version: "2.8.119"
@@ -195,7 +187,6 @@
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: "8.4.0.150"
     engine: ""
     engine_version: ""
@@ -209,13 +200,11 @@
   user_agent: Mozilla/5.0 (Android; Linux armv7l; rv:10.0) Gecko/20120118 Firefox/10.0 Fennec/10.0
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ARM
   client:
     type: browser
     name: Fennec
-    short_name: FE
     version: "10.0"
     engine: Gecko
     engine_version: "10.0"
@@ -229,13 +218,11 @@
   user_agent: Opera/9.80 (Android; Opera Mini/7.5.33361/34.861; U; en) Presto/2.8.119 Version/11.10
   os:
     name: Android
-    short_name: AND
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mini
-    short_name: OI
     version: "7.5.33361"
     engine: Presto
     engine_version: "2.8.119"
@@ -249,13 +236,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3; en-us; MID Build/GRH55) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -269,13 +254,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; e1109_v73_gq1003_rtp Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -289,13 +272,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; en-us; SP100 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -309,13 +290,11 @@
   user_agent: 'Mozilla/5.0 (Linux; U; Android 2.3.6; in-id; A7* Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -329,13 +308,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; mk-mk; move 2 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -349,13 +326,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; BF9200 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -369,13 +344,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; k6 Build/GRJ90) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -389,13 +362,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; MT917 Build/6.5.1_GC-146-DNRTD-9) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -409,13 +380,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; TV808 Build/GINGERBREAD) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.6"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -429,13 +398,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-au; T-Hub2 Build/TVA301TELBG3) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -449,13 +416,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; A19 Build/REL_2.3.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -469,13 +434,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; nine i7400 Build/REL_2.3.12) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -489,13 +452,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Precedent Build/AreaRom Test) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -509,13 +470,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fa-ir; X8 Build/GingerDX; GingerDX) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -529,13 +488,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; fr-fr; AZ210B Build/AZ210B_GB_01.06I) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -549,13 +506,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; ja-jp; IS12S Build/6.0.D.0.272) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -569,13 +524,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; 8180 Build/GWK74) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -589,13 +542,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; Blade Build/GRJ22; mumayi.com_hyurpg_love_01) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -609,13 +560,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; zh-cn; S800 Build/REL_2.3.7) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "2.3.7"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -629,13 +578,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; bg-bg; EPAD Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -649,13 +596,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; el-gr; R9 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -669,13 +614,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; 97FC Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -689,13 +632,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; AT107F Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -709,13 +650,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Build/S5110-01-V2.1-20120801) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -729,13 +668,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; F-01D Build/V08R31A) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -749,13 +686,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; Full AOSP on Rk29sdk Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -769,13 +704,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; ICS Build/ICS.f08refem31.20120808) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -789,13 +722,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; MID Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -809,13 +740,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; en-us; T10A Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -829,13 +758,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; Build/ICS.f06ref848L.20120530) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -849,13 +776,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; es-es; Proton Lite Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -869,13 +794,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MIDR477 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -889,13 +812,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; fr-fr; MIDR47B Build/eng.glwx.20121127.134615) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -909,13 +830,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; id-id; SpeedUp S3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -929,13 +848,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; id-id; Z5 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -949,13 +866,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; it-it; e1809c_v75_gq1008_9p017 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -969,13 +884,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ro-ro; GV7777 Build/GV7777) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -989,13 +902,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; ru-ru; T-800 Build/ICS.g04w138188ref.20121030) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1009,13 +920,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; Broncho M7 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1029,13 +938,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; T736 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1049,13 +956,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; tr-tr; Vega Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1069,13 +974,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; 3GNET U8 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1089,13 +992,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; I_7520 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1109,13 +1010,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-cn; T6 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1129,13 +1028,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-tw; M701C Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1149,13 +1046,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.3; zh-tw; Playboy_PB-S3 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.3"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1169,13 +1064,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; A704J Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1189,13 +1082,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; KB901 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1209,13 +1100,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ar-eg; TP-107A Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1229,13 +1118,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-au; A13-MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1249,13 +1136,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1269,13 +1154,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-ca; X10 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1289,13 +1172,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-eg; A13 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1309,13 +1190,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-eg; TWD_MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1329,13 +1208,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; A088 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1349,13 +1226,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; Softwinerf900 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1369,13 +1244,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-gb; X906 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1389,13 +1262,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; 201M Build/7.7.1Q-164_SMJ-143) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1409,13 +1280,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; ANDROID T3i Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1429,13 +1298,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; e1809c_v75_jbl_253 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1449,13 +1316,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; e1908_v77_mt6628_hjy1a6x_9p017 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1469,13 +1334,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Expad Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1489,13 +1352,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Gadmei ICS Build/E8HD-T364-1280x768) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1509,13 +1370,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; IdolPad 7+ Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1529,13 +1388,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; IS12M Build/6.7.5-50_MR1-11) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1549,13 +1406,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; J-Q8D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1569,13 +1424,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; M006-Q Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1589,13 +1442,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; N10 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1609,13 +1460,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; N10 Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1629,13 +1478,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; PC721 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1649,13 +1496,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Spark Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1669,13 +1514,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; SX9701W Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1689,13 +1532,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; TAB900 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1709,13 +1550,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; TVPAD Slim K3409 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1729,13 +1568,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; UM-A13 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1749,13 +1586,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; V700D Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1769,13 +1604,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; X401 Build/IML74K) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1789,13 +1622,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; MANHATTAN Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1809,13 +1640,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; MW0710 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1829,13 +1658,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; Planet II v2 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1849,13 +1676,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; Proton Lite Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1869,13 +1694,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; SoftwinerEvb Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1889,13 +1712,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; TAB-1030 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1909,13 +1730,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; tablet Fnac 10 3G Build/1.1.11-1015 20130125-16:17) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1929,13 +1748,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-us; f7 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1949,13 +1766,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; 1FC Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1969,13 +1784,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; E330 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -1989,13 +1802,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fr-fr; MHU001D Build/MHU001D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2009,13 +1820,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; it-it; I9220 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2029,13 +1838,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; CAL21 Build/A1000091) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2049,13 +1856,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; IS12M Build/6.7.5-50_MR1-11) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2069,13 +1874,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; N70 DUAL CORE Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2089,13 +1892,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ja-jp; SHT21 Build/SC170) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2109,13 +1910,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ms-my; MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2129,13 +1928,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; nl-nl; CRESTA.CTP888 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2149,13 +1946,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pl-pl; A13-MID Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2169,13 +1964,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-br; T02A Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2189,13 +1982,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; pt-pt; DEM752NC Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2209,13 +2000,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ro-ro; M1001 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2229,13 +2018,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ro-ro; M1005 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2249,13 +2036,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; Advance TV Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2269,13 +2054,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; DNS Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2289,13 +2072,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; ru-ru; M83w Build/M83w-eng 4.0.4 IMM76D test-keys_OTA:MID_2.1.1.1_20120905.203550) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2309,13 +2090,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; th-th; TP710 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2329,13 +2108,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; tr-tr; AMPE Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2349,13 +2126,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; tr-tr; TP73G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2369,13 +2144,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; vi-vn; VL-110 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2389,13 +2162,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; 4S Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -2409,13 +2180,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; LA-I Build/IMM76I) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2429,13 +2198,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-cn; N710 Build/IMM76L) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2449,13 +2216,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; DOUBLE IV Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2469,13 +2234,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; ELIYA S1 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2489,13 +2252,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; GPLUS N809 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2509,13 +2270,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; zh-tw; PC-828 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2529,13 +2288,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; NABI2-NV7A Build/IMM76L)Maxthon AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.4"
     platform: ""
   client:
     type: browser
     name: Maxthon
-    short_name: MX
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2549,13 +2306,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.9; ru-ru; X710d Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.0.9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2569,13 +2324,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1; zh-tw; 9300 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2589,13 +2342,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.0; zh-cn; Coolgen E70 G Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2609,13 +2360,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-gb; X817 Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2629,13 +2378,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; e1908_v77_jbl1_9p017_6628 Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2649,13 +2396,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; I9220 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2669,13 +2414,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; es-es; I699 Build/GRK39F) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -2689,13 +2432,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; hu-hu; MonsterPad Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2709,13 +2450,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; ja-jp; M704S Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2729,13 +2468,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; pl-pl; Pro 10 dual core Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2749,13 +2486,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; Build/JRO03C) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2769,13 +2504,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; ifive MX Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2789,13 +2522,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-cn; N12GJ-QZ Build/JRO03H) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2809,13 +2540,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; zh-tw; HD3 Build/IMM76D) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2829,13 +2558,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.2.2; ru-ru; Alcor Zest Q813IS Build/JDQ39) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Safari/534.30
   os:
     name: Android
-    short_name: AND
     version: "4.2.2"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2849,7 +2576,6 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.4.2; zh-cn; X5 R1 Build/KOT49H) AppleWebKit/534.24 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.24 T5/2.0 baiduboxapp/6.7 (Baidu; P1 4.4.2)
   os:
     name: Android
-    short_name: AND
     version: "4.4.2"
     platform: ""
   client:
@@ -2866,19 +2592,17 @@
   user_agent: 'Dalvik/2.1.0 (Linux## U## Android 7.1.1## Chromebook 14 (CB3-431) Build/R63-10032.86.0)'
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: ""
   device:
     type: desktop
-    brand: AC
+    brand: Acer
     model: Chromebook 14
   os_family: Android
   browser_family: Android Browser
@@ -2886,7 +2610,6 @@
   user_agent: bPod
   os:
     name: BlackBerry OS
-    short_name: BLB
     version: ""
     platform: ""
   client:
@@ -2903,13 +2626,11 @@
   user_agent: 'BREW-Applet/0x20068888 (BREW/3.1.5.20; DeviceId: 90086; Lang: zhcn) ucweb-squid'
   os:
     name: Brew
-    short_name: BMP
     version: "3.1.5.20"
     platform: ""
   client:
     type: browser
     name: UC Browser
-    short_name: UC
     version: ""
     engine: ""
     engine_version: ""
@@ -2923,13 +2644,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.1.1; en-us; Incredible 2 Build/JRO03H; CyanogenMod-PARANOIDANDROID) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: ""
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -2943,13 +2662,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; LS670 Build/GWK74; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -2963,13 +2680,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.7; tr-tr; Mokee Os Build/FRG83; CyanogenMod-7.2.0) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "7.2.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -2983,13 +2698,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; en-us; Blade Build/IMM76D; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3003,13 +2716,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; es-es; Skate Build/IML74K; CyanogenMod-9) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3023,13 +2734,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 4.0.4; fa-ir; Liberty Build/IMM76L; CyanogenMod-9.0.0) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30
   os:
     name: CyanogenMod
-    short_name: CYN
     version: "9.0.0"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "534.30"
@@ -3043,13 +2752,11 @@
   user_agent: 'Mozilla/5.0 (X11; U; Linux x86_64; fa-ir) AppleWebKit/534.35 (KHTML, like Gecko)  Chrome/11.0.696.65 Safari/534.35 Puffin/2.10977AP'
   os:
     name: GNU/Linux
-    short_name: LIN
     version: ""
     platform: x64
   client:
     type: browser
     name: Puffin
-    short_name: PU
     version: "2.10977"
     engine: WebKit
     engine_version: "534.35"
@@ -3063,13 +2770,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Android 2.3.6; zh-cn; SPHS on Hsdroid Build/MocorDroid2.3.5) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1
   os:
     name: MocorDroid
-    short_name: MCD
     version: "2.3.5"
     platform: ""
   client:
     type: browser
     name: Android Browser
-    short_name: AN
     version: ""
     engine: WebKit
     engine_version: "533.1"
@@ -3083,13 +2788,11 @@
   user_agent: 'Mozilla/1.10 [en] (Compatible; RISC OS 3.70; Oregano 1.10)'
   os:
     name: RISC OS
-    short_name: ROS
     version: "3.70"
     platform: ""
   client:
     type: browser
     name: Oregano
-    short_name: OR
     version: "1.10"
     engine: ""
     engine_version: ""
@@ -3103,7 +2806,6 @@
   user_agent: 'Mozilla/4.01 (Compatible; Acorn Browse 1.25 [23-Oct-97] AW  97; RISC OS 4.39) Acorn-HTTP/0.84'
   os:
     name: RISC OS
-    short_name: ROS
     version: "4.39"
     platform: ""
   client: null
@@ -3117,13 +2819,11 @@
   user_agent: Mozilla/3.04 (compatible; NCBrowser/2.35; ANTFresco/2.17; RISC OS-NC 5.13 Laz1UK1309)
   os:
     name: RISC OS
-    short_name: ROS
     version: "5.13"
     platform: ""
   client:
     type: browser
     name: ANT Fresco
-    short_name: AF
     version: "2.17"
     engine: ""
     engine_version: ""
@@ -3137,13 +2837,11 @@
   user_agent: Mozilla/5.0 (Linux; U; Tizen/1.0 like Android; en-us; AppleWebKit/534.46 (KHTML, like Gecko) Tizen Browser/1.0 Mobile
   os:
     name: Tizen
-    short_name: TIZ
     version: "1.0"
     platform: ""
   client:
     type: browser
     name: Tizen Browser
-    short_name: TZ
     version: "1.0"
     engine: WebKit
     engine_version: "534.46"
@@ -3157,13 +2855,11 @@
   user_agent: Mozilla/4.0 (compatible; MSIE 4.01; Windows NT Windows CE)
   os:
     name: Windows CE
-    short_name: WCE
     version: ""
     platform: ""
   client:
     type: browser
     name: Internet Explorer
-    short_name: IE
     version: "4.01"
     engine: Trident
     engine_version: ""
@@ -3177,13 +2873,11 @@
   user_agent: Opera/9.80 (Windows Mobile; WCE; Opera Mobi/WMD-50433; U; en) Presto/2.4.13 Version/10.00
   os:
     name: Windows Mobile
-    short_name: WMO
     version: ""
     platform: ""
   client:
     type: browser
     name: Opera Mobile
-    short_name: OM
     version: "10.00"
     engine: Presto
     engine_version: "2.4.13"
@@ -3197,13 +2891,11 @@
   user_agent: Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0; XBLWP7; ZuneWP7)
   os:
     name: Windows Phone
-    short_name: WPH
     version: ""
     platform: ""
   client:
     type: browser
     name: IE Mobile
-    short_name: IM
     version: "9.0"
     engine: Trident
     engine_version: "5.0"
@@ -3217,7 +2909,6 @@
   user_agent: SubStream/0.7 CFNetwork/485.12.30 Darwin/10.4.0
   os:
     name: iOS
-    short_name: IOS
     version: "4.2"
     platform: ""
   client:
@@ -3226,7 +2917,7 @@
     version: "0.7"
   device:
     type: ""
-    brand: AP
+    brand: Apple
     model: ""
   os_family: iOS
   browser_family: Unknown

--- a/Tests/fixtures/wearable.yml
+++ b/Tests/fixtures/wearable.yml
@@ -3,19 +3,17 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.0; LEO-BX9 Build/OWDD.180926.001.A1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/53.0.2785.143 Cr4 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "8.0"
     platform: ""
   client:
     type: browser
     name: Chrome
-    short_name: CH
     version: "53.0.2785.143"
     engine: Blink
     engine_version: ""
   device:
     type: wearable
-    brand: HU
+    brand: Huawei
     model: Smart Watch 2
   os_family: Android
   browser_family: Chrome
@@ -23,13 +21,11 @@
   user_agent: Mozilla/5.0 Linux; Android 7.1.1; LG Watch Urbane Build/NWD1.180306.004 AppleWebKit/537.36 KHTML, like Gecko Chrome/19.77.34.5 Mobile Safari/537.36
   os:
     name: Android
-    short_name: AND
     version: "7.1.1"
     platform: ""
   client:
     type: browser
     name: Chrome Mobile
-    short_name: CM
     version: "19.77.34.5"
     engine: WebKit
     engine_version: "537.36"
@@ -43,19 +39,17 @@
   user_agent: Mozilla/5.0 (Linux; Tizen 4.0; SAMSUNG SM-R820) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/2.0 Chrome/56.0.2924.0 Mobile Safari/537.36
   os:
     name: Tizen
-    short_name: TIZ
     version: "4.0"
     platform: ""
   client:
     type: browser
     name: Samsung Browser
-    short_name: SB
     version: "2.0"
     engine: WebKit
     engine_version: "537.36"
   device:
     type: wearable
-    brand: SA
+    brand: Samsung
     model: GALAXY Watch Active 2
   os_family: Other Mobile
   browser_family: Chrome

--- a/misc/fileTest.php
+++ b/misc/fileTest.php
@@ -25,9 +25,7 @@
  * `php file-test.php /tmp/source-useragent.txt "not" "useragent" > /tmp/useragent-not-detected.txt`
  */
 use DeviceDetector\DeviceDetector;
-use DeviceDetector\Parser\Client\Browser;
 use DeviceDetector\Parser\Device\AbstractDeviceParser;
-use DeviceDetector\Parser\OperatingSystem;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -107,14 +105,10 @@ while (!feof($fn)) {
     $deviceDetector->setUserAgent($userAgent);
     $deviceDetector->parse();
 
-    if ($deviceDetector->isBot()) {
-        $result = [
-            'user_agent' => $deviceDetector->getUserAgent(),
-            'bot'        => $deviceDetector->getBot(),
-        ];
-    } else {
-        $result = DeviceDetector::getInfoFromUserAgent($userAgent);
-    }
+    $result = $deviceDetector->isBot() ? [
+        'user_agent' => $deviceDetector->getUserAgent(),
+        'bot'        => $deviceDetector->getBot(),
+    ] : DeviceDetector::getInfoFromUserAgent($userAgent);
 
     if (!isset($result['device']['model'])) {
         continue;

--- a/misc/fileTest.php
+++ b/misc/fileTest.php
@@ -113,20 +113,7 @@ while (!feof($fn)) {
             'bot'        => $deviceDetector->getBot(),
         ];
     } else {
-        $osFamily      = OperatingSystem::getOsFamily($deviceDetector->getOs('short_name'));
-        $browserFamily = Browser::getBrowserFamily($deviceDetector->getClient('short_name'));
-        $result        = [
-            'user_agent'     => $deviceDetector->getUserAgent(),
-            'os'             => $deviceDetector->getOs(),
-            'client'         => $deviceDetector->getClient(),
-            'device'         => [
-                'type'  => $deviceDetector->getDeviceName(),
-                'brand' => $deviceDetector->getBrand(),
-                'model' => $deviceDetector->getModel(),
-            ],
-            'os_family'      => false !== $osFamily ? $osFamily : 'Unknown',
-            'browser_family' => false !== $browserFamily ? $browserFamily : 'Unknown',
-        ];
+        $result = DeviceDetector::getInfoFromUserAgent($userAgent);
     }
 
     if (!isset($result['device']['model'])) {

--- a/misc/rewriteTestFixtureFiles.php
+++ b/misc/rewriteTestFixtureFiles.php
@@ -19,14 +19,6 @@ foreach ($fixtureFiles as $file) {
     foreach ($fileFixtures as $i => $fixture) {
         $keys = array_flip(array_keys($fixture));
 
-        if (isset($fixture['client']['short_name']) && true === $fixture['client']['short_name']) {
-            $fixture['client']['short_name'] = 'ON';
-        }
-
-        if (isset($fixture['client']['short_name']) && false === $fixture['client']['short_name']) {
-            $fixture['client']['short_name'] = 'NO';
-        }
-
         if ($overwrite) {
             $fixture = \DeviceDetector\DeviceDetector::getInfoFromUserAgent($fixture['user_agent']);
         }

--- a/misc/sortTestFixtureFiles.php
+++ b/misc/sortTestFixtureFiles.php
@@ -17,14 +17,6 @@ foreach ($fixtureFiles as $file) {
     $fileFixtures = Spyc::YAMLLoad(file_get_contents($file));
 
     foreach ($fileFixtures as $fixture) {
-        if (isset($fixture['client']['short_name']) && true === $fixture['client']['short_name']) {
-            $fixture['client']['short_name'] = 'ON';
-        }
-
-        if (isset($fixture['client']['short_name']) && false === $fixture['client']['short_name']) {
-            $fixture['client']['short_name'] = 'NO';
-        }
-
         if ($overwrite) {
             $fixture = \DeviceDetector\DeviceDetector::getInfoFromUserAgent($fixture['user_agent']);
         }


### PR DESCRIPTION
In order to remove the short codes completely in maybe the next major release, we should start deprecating them first.
This PR will already remove the short_name usage from all tests. Additionally they won't be returned by `getInfoFromUserAgent` any longer.