### PR TITLE
always put a newline at the end of the README.md

### DIFF
--- a/misc/updateReadme.php
+++ b/misc/updateReadme.php
@@ -69,7 +69,7 @@ The lists below are auto generated and updated from time to time. Some of them m
 
 ### List of detected bots:
 
-' . implode(', ', $bots);
+' . implode(', ', $bots) . "\n";
 
 $file = __DIR__ . '/../README.md';
 


### PR DESCRIPTION
On unix files are traditionally a list of lines that all end with a newline. So every editor of mine adds a newline at the end of it when saving.

This should avoid ugliy diffs like in #6401