### PR TITLE
Adds Postman requester as "library"

### DIFF
--- a/Tests/Parser/Client/fixtures/library.yml
+++ b/Tests/Parser/Client/fixtures/library.yml
@@ -197,3 +197,9 @@
     type: library
     name: ReactorNetty
     version: "0.9.10"
+- 
+  user_agent: PostmanRuntime/7.9.1
+  client:
+    type: library
+    name: Postman Desktop
+    version: "7.9.1"

--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -111,3 +111,8 @@
   name: 'ReactorNetty'
   version: $1
   url: 'https://github.com/reactor/reactor-netty'
+
+- regex: 'PostmanRuntime(?:/(\d+[\.\d]+))?'
+  name: 'Postman Desktop'
+  version: $1
+  url: 'https://github.com/postmanlabs/postman-runtime'


### PR DESCRIPTION
As Postman requester has its own UA when used in desktop app (unlike the browser extensions), I suggest to add it as a "library".
See #5953