### PR TITLE
Use self version as replace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,6 @@
         "exclude": ["/autoload.php"]
     },
     "replace": {
-        "piwik/device-detector":"*"
+        "piwik/device-detector":"self.version"
     }
 }


### PR DESCRIPTION
As [matomo/device-detector](https://packagist.org/packages/matomo/device-detector):`3.1.3` matches [piwik/devic-detector](https://packagist.org/packages/piwik/device-detector):`3.1.3` version.
A matamo/device-detector:`4` can not replace a piwik/devic-detector:`1` version a `self.version` should be used to replace correctly.