### PR TITLE
fix invalid yaml

### DIFF
--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -12745,7 +12745,7 @@ Quechua:
 Ramos:
   regex: 'Ramos ?([^/;]+) Build|MOS1(?:[);/ ]|$)'
   device: 'tablet'
-  models: '$1'
+  models:
     - regex: '(MOS1)(?:[);/ ]|$)'
       model: '$1'
     - regex: 'Ramos ?([^/;]+) Build'


### PR DESCRIPTION
fixed a typo introduced in https://github.com/matomo-org/device-detector/pull/6428

I'm not sure why the tests didn't fail as at least for me the Symfony yaml parser was not able to parse the file.