### PR TITLE
Call parse() whenever it's required

### DIFF
--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -213,12 +213,16 @@ class DeviceDetector
     {
         foreach (AbstractDeviceParser::getAvailableDeviceTypes() as $deviceName => $deviceType) {
             if (\strtolower($methodName) === 'is' . \strtolower(\str_replace(' ', '', $deviceName))) {
+                $this->parse();
+
                 return $this->getDevice() === $deviceType;
             }
         }
 
         foreach (self::$clientTypes as $client) {
             if (\strtolower($methodName) === 'is' . \strtolower(\str_replace(' ', '', $client))) {
+                $this->parse();
+
                 return $this->getClient('type') === $client;
             }
         }
@@ -326,6 +330,8 @@ class DeviceDetector
      */
     public function isBot(): bool
     {
+        $this->parse();
+
         return !empty($this->bot);
     }
 
@@ -350,6 +356,8 @@ class DeviceDetector
      */
     public function isMobile(): bool
     {
+        $this->parse();
+
         // Mobile device types
         if (\in_array($this->device, [
             AbstractDeviceParser::DEVICE_TYPE_FEATURE_PHONE,
@@ -397,6 +405,8 @@ class DeviceDetector
      */
     public function isDesktop(): bool
     {
+        $this->parse();
+
         $osName = $this->getOsAttribute('name');
 
         if (empty($osName) || self::UNKNOWN === $osName) {
@@ -424,6 +434,8 @@ class DeviceDetector
      */
     public function getOs(string $attr = '')
     {
+        $this->parse();
+
         if ('' === $attr) {
             return $this->os;
         }
@@ -442,6 +454,8 @@ class DeviceDetector
      */
     public function getClient(string $attr = '')
     {
+        $this->parse();
+
         if ('' === $attr) {
             return $this->client;
         }
@@ -458,6 +472,8 @@ class DeviceDetector
      */
     public function getDevice(): ?int
     {
+        $this->parse();
+
         return $this->device;
     }
 
@@ -470,6 +486,8 @@ class DeviceDetector
      */
     public function getDeviceName(): string
     {
+        $this->parse();
+
         if (null !== $this->getDevice()) {
             return AbstractDeviceParser::getDeviceName($this->getDevice());
         }
@@ -488,6 +506,8 @@ class DeviceDetector
      */
     public function getBrand(): string
     {
+        $this->parse();
+
         return AbstractDeviceParser::getShortCode($this->brand);
     }
 
@@ -500,6 +520,8 @@ class DeviceDetector
      */
     public function getBrandName(): string
     {
+        $this->parse();
+
         return $this->brand;
     }
 
@@ -510,6 +532,8 @@ class DeviceDetector
      */
     public function getModel(): string
     {
+        $this->parse();
+
         return $this->model;
     }
 

--- a/DeviceDetector.php
+++ b/DeviceDetector.php
@@ -213,16 +213,12 @@ class DeviceDetector
     {
         foreach (AbstractDeviceParser::getAvailableDeviceTypes() as $deviceName => $deviceType) {
             if (\strtolower($methodName) === 'is' . \strtolower(\str_replace(' ', '', $deviceName))) {
-                $this->parse();
-
                 return $this->getDevice() === $deviceType;
             }
         }
 
         foreach (self::$clientTypes as $client) {
             if (\strtolower($methodName) === 'is' . \strtolower(\str_replace(' ', '', $client))) {
-                $this->parse();
-
                 return $this->getClient('type') === $client;
             }
         }
@@ -486,8 +482,6 @@ class DeviceDetector
      */
     public function getDeviceName(): string
     {
-        $this->parse();
-
         if (null !== $this->getDevice()) {
             return AbstractDeviceParser::getDeviceName($this->getDevice());
         }
@@ -554,6 +548,8 @@ class DeviceDetector
      */
     public function getBot()
     {
+        $this->parse();
+
         return $this->bot;
     }
 

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -369,7 +369,6 @@ class DeviceDetectorTest extends TestCase
     public function testGetOs(): void
     {
         $dd = new DeviceDetector('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)');
-        $this->assertNull($dd->getOs());
         $dd->parse();
         $expected = [
             'name'       => 'Windows',
@@ -383,7 +382,6 @@ class DeviceDetectorTest extends TestCase
     public function testGetClient(): void
     {
         $dd = new DeviceDetector('Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; WOW64; Trident/5.0)');
-        $this->assertNull($dd->getClient());
         $dd->parse();
         $expected = [
             'type'           => 'browser',

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -461,17 +461,17 @@ class DeviceDetectorTest extends TestCase
     public function parserTriggers(): array
     {
         return [
-            'isBrowser'     => ['isBrowser'],
-            'isDesktop'     => ['isDesktop'],
-            'isBot'         => ['isBot'],
-            'isMobile'      => ['isMobile'],
-            'isDesktop'     => ['isDesktop'],
-            'getOs'         => ['getOs'],
-            'getClient'     => ['getClient'],
-            'getDeviceName' => ['getDeviceName'],
-            'getBrand'      => ['getBrand'],
-            'getBrandName'  => ['getBrandName'],
-            'getModel'      => ['getModel'],
+            '__call() for client' => ['isBrowser'],
+            '__call() for device' => ['isMobile'],
+            'getBot()'            => ['getBot'],
+            'getBrand()'          => ['getBrand'],
+            'getBrandName()'      => ['getBrandName'],
+            'getClient()'         => ['getClient'],
+            'getDeviceName()'     => ['getDeviceName'],
+            'getModel()'          => ['getModel'],
+            'getOs()'             => ['getOs'],
+            'isBot()'             => ['isBot'],
+            'isDesktop()'         => ['isDesktop'],
         ];
     }
 

--- a/Tests/DeviceDetectorTest.php
+++ b/Tests/DeviceDetectorTest.php
@@ -449,6 +449,33 @@ class DeviceDetectorTest extends TestCase
     }
 
     /**
+     * @dataProvider parserTriggers
+     */
+    public function testAutoParser(string $method): void
+    {
+        $dd = new DeviceDetector();
+        \call_user_func([$dd, $method]);
+        $this->assertTrue($dd->isParsed());
+    }
+
+    public function parserTriggers(): array
+    {
+        return [
+            'isBrowser'     => ['isBrowser'],
+            'isDesktop'     => ['isDesktop'],
+            'isBot'         => ['isBot'],
+            'isMobile'      => ['isMobile'],
+            'isDesktop'     => ['isDesktop'],
+            'getOs'         => ['getOs'],
+            'getClient'     => ['getClient'],
+            'getDeviceName' => ['getDeviceName'],
+            'getBrand'      => ['getBrand'],
+            'getBrandName'  => ['getBrandName'],
+            'getModel'      => ['getModel'],
+        ];
+    }
+
+    /**
      * check the regular expression for the vertical line closing the group
      * @param string $regexString
      *


### PR DESCRIPTION
The intention is to avoid missing the `parser()` call.

I didn't found if this subject was already discussed in this project.

I'm aware that this may be a BC break for some, as an alternative solution, we could throw an exception (still a potential BC break), or trigger an error (less intrusive) if the user-agent was not yet parsed when calling these functions.