### PR TITLE
Don't use numeric keys as it breaks using Symfony YAML

### DIFF
--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -1310,7 +1310,7 @@
   engine:
     default: 'WebKit'
     versions:
-      5.2: 'Blink'
+      '5.2': 'Blink'
 - regex: '(?:Maxthon(?:%20Browser)?|MxBrowser(?:-inhouse|-iPhone)?)[ /](\d+[\.\d]+)'
   name: 'Maxthon'
   version: '$1'


### PR DESCRIPTION
@sanchezzzhak  Using numeric keys isn't supported by Symfony YAML. We should try to avoid them if possible.
The YAML linter doesn't support something like that, as it's something Symfony special I guess.
Maybe we could add a new test that uses Symfony YAML instead or extend the YAML parser maybe to avoid such problems in the future