### PR TITLE
Fixes detection for Aloha browser

### DIFF
--- a/Parser/Client/Browser.php
+++ b/Parser/Client/Browser.php
@@ -409,11 +409,11 @@ class Browser extends AbstractClientParser
      */
     protected static $mobileOnlyBrowsers = [
         '36', 'OC', 'PU', 'SK', 'MF', 'OI', 'OM', 'DD', 'DB',
-        'ST', 'BL', 'IV', 'FM', 'C1', 'AL', 'SA', 'SB', 'FR',
+        'ST', 'BL', 'IV', 'FM', 'C1', 'C4', 'SA', 'SB', 'FR',
         'WP', 'HA', 'NX', 'HU', 'VV', 'RE', 'CB', 'MZ', 'UM',
         'FK', 'FX', 'WI', 'MN', 'M1', 'AH', 'SU', 'EU', 'EZ',
         'UT', 'DT', 'S0', 'QU', 'YN', 'JB', 'GH', 'PI', 'SG',
-        'KD', 'PE', 'UH', 'S7', 'CW', 'OZ', 'GI', 'VE', 'C4',
+        'KD', 'PE', 'UH', 'S7', 'CW', 'OZ', 'GI', 'VE',
     ];
 
     /**

--- a/Tests/Parser/Client/fixtures/browser.yml
+++ b/Tests/Parser/Client/fixtures/browser.yml
@@ -2093,8 +2093,8 @@
     type: browser
     name: Aloha Browser Lite
     version: "1.4.0.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
 - 
   user_agent: Mozilla/5.0 (Windows NT 6.1) AppleWebKit/536.11 (KHTML, like Gecko) Chrome/20.0.1132.11 TaoBrowser/3.1 Safari/536.11
   client:

--- a/Tests/fixtures/desktop.yml
+++ b/Tests/fixtures/desktop.yml
@@ -6876,3 +6876,21 @@
     model: Mac Mini (2018)
   os_family: Mac
   browser_family: Unknown
+-
+  user_agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/85.0.4183.83 AlohaBrowser/0.1.0 Safari/537.36
+  os:
+    name: Windows
+    version: "10"
+    platform: x64
+  client:
+    type: browser
+    name: Aloha Browser
+    version: "0.1.0"
+    engine: Blink
+    engine_version: ""
+  device:
+    type: desktop
+    brand: ""
+    model: ""
+  os_family: Windows
+  browser_family: Unknown

--- a/Tests/fixtures/smartphone-11.yml
+++ b/Tests/fixtures/smartphone-11.yml
@@ -6511,8 +6511,8 @@
     type: browser
     name: Aloha Browser
     version: "2.8.0.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Casper

--- a/Tests/fixtures/smartphone-12.yml
+++ b/Tests/fixtures/smartphone-12.yml
@@ -297,8 +297,8 @@
     type: browser
     name: Aloha Browser
     version: "2.7.0.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Ryte

--- a/Tests/fixtures/smartphone-17.yml
+++ b/Tests/fixtures/smartphone-17.yml
@@ -3632,15 +3632,14 @@
   user_agent: Mozilla/5.0 (Linux; Android 8.1.0; ARTEL U3_4G Build/NMF26F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/76.0.3809.111 Mobile Safari/537.36 AlohaBrowser/2.17.3
   os:
     name: Android
-
     version: 8.1.0
     platform: ""
   client:
     type: browser
     name: Aloha Browser
     version: 2.17.3
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Artel

--- a/Tests/fixtures/smartphone-18.yml
+++ b/Tests/fixtures/smartphone-18.yml
@@ -4561,8 +4561,8 @@
     type: browser
     name: Aloha Browser
     version: 2.20.3
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Oukitel

--- a/Tests/fixtures/smartphone-4.yml
+++ b/Tests/fixtures/smartphone-4.yml
@@ -4021,8 +4021,8 @@
     type: browser
     name: Aloha Browser
     version: "1.3.3.0"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Fly

--- a/Tests/fixtures/smartphone-5.yml
+++ b/Tests/fixtures/smartphone-5.yml
@@ -711,8 +711,8 @@
     type: browser
     name: Aloha Browser
     version: "2.14.1"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Hoffmann
@@ -909,8 +909,8 @@
     type: browser
     name: Aloha Browser
     version: "2.4.0.3"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Highscreen

--- a/Tests/fixtures/smartphone.yml
+++ b/Tests/fixtures/smartphone.yml
@@ -2691,8 +2691,8 @@
     type: browser
     name: Aloha Browser
     version: "2.9.0.2"
-    engine: WebKit
-    engine_version: "537.36"
+    engine: Blink
+    engine_version: ""
   device:
     type: smartphone
     brand: Nomu

--- a/regexes/client/browsers.yml
+++ b/regexes/client/browsers.yml
@@ -503,6 +503,8 @@
 - regex: 'AlohaLite(?:/(\d+[\.\d]+))?'
   name: 'Aloha Browser Lite'
   version: '$1'
+  engine:
+    default: 'Blink'
 
 # Tao Browser (https://browser.taobao.com/)
 - regex: 'TaoBrowser(?:/(\d+[\.\d]+))?'
@@ -790,6 +792,11 @@
     default: 'Gecko'
 
 #AlohaBrowser
+- regex: 'Chrome/.+ AlohaBrowser(?:/(\d+[\.\d]+))?'
+  name: 'Aloha Browser'
+  version: '$1'
+  engine:
+    default: 'Blink'
 - regex: 'AlohaBrowser(?:/(\d+[\.\d]+))?'
   name: 'Aloha Browser'
   version: '$1'


### PR DESCRIPTION
We're working on desktop version of Aloha Browser, therefore Aloha should be removed from `mobileOnlyBrowsers` list.
