### PR TITLE
Update version action-yamllint to 3.0.1

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -12,4 +12,4 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: YAML Lint
-        uses: ibiqlik/action-yamllint@v3.0.0
+        uses: ibiqlik/action-yamllint@v3.0.1


### PR DESCRIPTION
The new version has a more detailed error output, and also tells you which file the error is in.
previously, this could be achieved using the parameter
```yml
        uses: ibiqlik/action-yamllint@v3.0.0
        with:
          format: parsable
```