### PR TITLE
remove redundant character classes from regexes

### DIFF
--- a/regexes/client/libraries.yml
+++ b/regexes/client/libraries.yml
@@ -55,7 +55,7 @@
   name: 'aiohttp'
   version: '$1'
 
-- regex: 'Google-HTTP-Java-Client(?:/(\d+[\.\d\w-]+))?'
+- regex: 'Google-HTTP-Java-Client(?:/(\d+[\.\w-]+))?'
   name: 'Google HTTP Java Client'
   version: '$1'
 

--- a/regexes/client/mediaplayers.yml
+++ b/regexes/client/mediaplayers.yml
@@ -105,7 +105,7 @@
   name: 'mpv'
   version: '$1'
 
-- regex: 'foobar2000(?:/([\d\w_\.]+))?'
+- regex: 'foobar2000(?:/([\w\.]+))?'
   name: 'foobar2000'
   version: '$1'
 
@@ -113,7 +113,7 @@
   name: 'HTC Streaming Player'
   version: ''
 
-- regex: 'MediaGo(?:/([\d\w_\.]+))?'
+- regex: 'MediaGo(?:/([\w\.]+))?'
   name: 'Sony Media Go'
   version: '$1'
 

--- a/regexes/device/mobiles.yml
+++ b/regexes/device/mobiles.yml
@@ -2065,7 +2065,7 @@ Alcatel:
       model: 'U50'
     - regex: '5033XR'
       model: '1 (2021)'
-    - regex: '5033[ADXJEFGMOTXYQS]'
+    - regex: '5033[ADJEFGMOTXYQS]'
       model: '1'
     - regex: '5009[AD]'
       model: '1C'
@@ -11301,7 +11301,7 @@ LG:
       model: 'Q92'
     - regex: 'LM-Q927L'
       model: 'Q9 One'
-    - regex: '(?:LG-)?(?:RS987|H90[01]|H96[02128]|VS990|F600[LK]|K428)'
+    - regex: '(?:LG-)?(?:RS987|H90[01]|H96[0218]|VS990|F600[LK]|K428)'
       model: 'V10'
     - regex: 'LG-(?:X240|M200)'
       model: 'K8 (2017)'
@@ -13107,7 +13107,7 @@ Nobby:
 
 # nec or nec lavie (www.nec-lavie.jp)
 NEC:
-  regex: 'NEC[ _\-]|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N|(?:PC-T[SE]\d{3}[\w\d]{2,3}|N-06C|N-02E|LAVIE Tab E (?:10|8)FHD[12]|7SD1|8HD1)(?:[);/ ]|$)'
+  regex: 'NEC[ _\-]|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N|(?:PC-T[SE]\d{3}[\w]{2,3}|N-06C|N-02E|LAVIE Tab E (?:10|8)FHD[12]|7SD1|8HD1)(?:[);/ ]|$)'
   device: 'smartphone'
   models:
     - regex: 'N-06C(?:[);/ ]|$)'


### PR DESCRIPTION
This is a follow up of https://github.com/matomo-org/device-detector/issues/6990 and https://github.com/matomo-org/device-detector/pull/6991

I am currently updating the https://github.com/podigee/device_detector fork to make use of the latest regexes.

Thanks for putting in the effort to detect regexes with minor flaws using the CI task.

I am creating this PR to solve the last issues I can see popping up in the ruby version:

```
warning: character class has duplicated range, caused by:
  foobar2000(?:/([\d\w_\.]+))?
warning: character class has duplicated range, caused by:
  MediaGo(?:/([\d\w_\.]+))?
warning: character class has duplicated range, caused by:
  Google-HTTP-Java-Client(?:/(\d+[\.\d\w-]+))?
warning: character class has duplicated range, caused by:
  5033[ADXJEFGMOTXYQS]
warning: character class has duplicated range, caused by:
  (?:LG-)?(?:RS987|H90[01]|H96[02128]|VS990|F600[LK]|K428)
warning: character class has duplicated range, caused by:
  NEC[ _\-]|KGT/2\.0|portalmmm/1\.0 (?:DB|N)|(?:portalmmm|o2imode)/2.0[ ,]N|(?:PC-T[SE]\d{3}[\w\d]{2,3}|N-06C|N-02E|LAVIE Tab E (?:10|8)FHD[12]|7SD1|8HD1)(?:[);/ ]|$)
```

This is mostly caused by the combination of `\w` together with `\d` or `_`. In two cases something like `[012012]` is causing a warning, too.


### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
