### PR TITLE
Keeping quotes structure

### DIFF
--- a/regexes/bots.yml
+++ b/regexes/bots.yml
@@ -108,13 +108,13 @@
     name: 'Apple Inc'
     url: 'https://www.apple.com'
 
-- regex: "AppSignalBot"
-  name: "AppSignalBot"
-  category: "Site Monitor"
-  url: "https://docs.appsignal.com/uptime-monitoring/"
+- regex: 'AppSignalBot'
+  name: 'AppSignalBot'
+  category: 'Site Monitor'
+  url: 'https://docs.appsignal.com/uptime-monitoring/'
   producer:
-    name: "AppSignal"
-    url: "https://appsignal.com/"
+    name: 'AppSignal'
+    url: 'https://appsignal.com/'
 
 - regex: 'Arachni'
   name: 'Arachni'


### PR DESCRIPTION
Changed from double quote to single quote. Saw it when getting all lines containing category to see max char length. Nothing fancy.